### PR TITLE
Add manifest schema validation and CLI tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
       - name: Build
         run: go build ./...
+      - name: Validate plugin manifests
+        run: make validate-manifests
       - name: Test
         run: go test ./... -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
-          args: ./...
+          args: --out-format=github-actions ./...

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ test:
 lint:
 	go vet ./...
 
+.PHONY: validate-manifests
+validate-manifests:
+	@echo "Validating sample manifests..."
+	@go run ./cmd/glyphctl --manifest-validate plugins/samples/passive-header-scan/manifest.json
+	@! go run ./cmd/glyphctl --manifest-validate plugins/samples/invalid/manifest.json >/dev/null 2>&1 || (echo "invalid sample should fail" && exit 1)
+
 .PHONY: run
 run:
 	go run ./cmd/glyphd --addr $(GLYPH_ADDR) --token $(GLYPH_AUTH_TOKEN)

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,21 @@ test:
 lint:
 	go vet ./...
 
+.PHONY: build
+build:
+	go build ./...
+
 .PHONY: validate-manifests
 validate-manifests:
 	@echo "Validating sample manifests..."
 	@go run ./cmd/glyphctl --manifest-validate plugins/samples/passive-header-scan/manifest.json
 	@! go run ./cmd/glyphctl --manifest-validate plugins/samples/invalid/manifest.json >/dev/null 2>&1 || (echo "invalid sample should fail" && exit 1)
+
+.PHONY: verify
+verify: build
+	@golangci-lint run ./...
+	@go test ./... -v
+	@$(MAKE) validate-manifests
 
 .PHONY: run
 run:

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -3,42 +3,19 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io"
 	"os"
-
-	"github.com/RowanDark/Glyph/internal/plugins"
 )
 
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
-}
+	flag.Parse()
 
-func run(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("glyphctl", flag.ContinueOnError)
-	fs.SetOutput(stderr)
-
-	manifestPath := fs.String("manifest", "", "Path to a plugin manifest to validate")
-
-	if err := fs.Parse(args); err != nil {
-		return 2
-	}
-
-	if *manifestPath == "" {
-		if _, err := fmt.Fprintln(stderr, "--manifest flag is required"); err != nil {
-			return 2
+	if code := runManifestValidate(); code != 0 || *manifestValidate != "" {
+		if *manifestValidate != "" {
+			os.Exit(code)
 		}
-		return 2
 	}
 
-	if err := plugins.ValidateManifest(*manifestPath); err != nil {
-		if _, writeErr := fmt.Fprintf(stderr, "invalid manifest: %v\n", err); writeErr != nil {
-			return 1
-		}
-		return 1
-	}
-
-	if _, err := fmt.Fprintf(stdout, "manifest %s is valid\n", *manifestPath); err != nil {
-		return 1
-	}
-	return 0
+	fmt.Fprintln(os.Stderr, "no command specified")
+	flag.Usage()
+	os.Exit(2)
 }

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -2,20 +2,17 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 )
 
 func main() {
+	// Parse global flags (including --manifest-validate) once.
 	flag.Parse()
-
-	if code := runManifestValidate(); code != 0 || *manifestValidate != "" {
-		if *manifestValidate != "" {
-			os.Exit(code)
-		}
+	// Fast path: if the validator flag is present, run it and exit with its code.
+	if *manifestValidate != "" {
+		os.Exit(runManifestValidate())
 	}
-
-	fmt.Fprintln(os.Stderr, "no command specified")
+	// No subcommand/flags provided: show usage and exit non-zero.
 	flag.Usage()
 	os.Exit(2)
 }

--- a/cmd/glyphctl/main_test.go
+++ b/cmd/glyphctl/main_test.go
@@ -3,23 +3,62 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-func TestRunInvalidManifestReturnsNonZero(t *testing.T) {
-	dir := t.TempDir()
-	manifestPath := filepath.Join(dir, "manifest.json")
-	if err := os.WriteFile(manifestPath, []byte(`{"name":"demo","version":"1.0.0","entry":"/bin/demo"}`), 0o644); err != nil {
-		t.Fatalf("failed to write manifest: %v", err)
+func silenceOutput(t *testing.T) func() {
+	t.Helper()
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open dev null: %v", err)
 	}
+	stdout := os.Stdout
+	stderr := os.Stderr
+	os.Stdout = devNull
+	os.Stderr = devNull
+	return func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+		if err := devNull.Close(); err != nil {
+			t.Fatalf("close dev null: %v", err)
+		}
+	}
+}
 
-	var stdout, stderr strings.Builder
-	code := run([]string{"--manifest", manifestPath}, &stdout, &stderr)
-	if code == 0 {
+func TestRunManifestValidateValid(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	path := filepath.Join("..", "..", "plugins", "samples", "passive-header-scan", "manifest.json")
+	*manifestValidate = path
+	t.Cleanup(func() { *manifestValidate = "" })
+
+	if code := runManifestValidate(); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestRunManifestValidateInvalid(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	path := filepath.Join("..", "..", "plugins", "samples", "invalid", "manifest.json")
+	*manifestValidate = path
+	t.Cleanup(func() { *manifestValidate = "" })
+
+	if code := runManifestValidate(); code == 0 {
 		t.Fatalf("expected non-zero exit code, got %d", code)
 	}
-	if !strings.Contains(stderr.String(), "capability") {
-		t.Fatalf("expected error mentioning capabilities, got %q", stderr.String())
+}
+
+func TestRunManifestValidateMissingFile(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	*manifestValidate = filepath.Join(t.TempDir(), "missing.json")
+	t.Cleanup(func() { *manifestValidate = "" })
+
+	if code := runManifestValidate(); code != 2 {
+		t.Fatalf("expected exit code 2 for read errors, got %d", code)
 	}
 }

--- a/cmd/glyphctl/manifest_validate.go
+++ b/cmd/glyphctl/manifest_validate.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/RowanDark/Glyph/internal/plugins"
+)
+
+var manifestValidate = flag.String("manifest-validate", "", "Validate a plugin manifest JSON file and exit")
+
+// runManifestValidate integrates into main() without breaking other commands.
+// main() should call flag.Parse() and then exit(runManifestValidate()) if the
+// flag is set.
+func runManifestValidate() int {
+	if *manifestValidate == "" {
+		return 0
+	}
+
+	data, err := os.ReadFile(*manifestValidate)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read error: %v\n", err)
+		return 2
+	}
+
+	var strict plugins.Manifest
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&strict); err != nil {
+		fmt.Fprintf(os.Stderr, "json decode error (unknown field or type): %v\n", err)
+		return 1
+	}
+	if err := strict.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid manifest: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintln(os.Stdout, "ok")
+	return 0
+}

--- a/internal/plugins/manifest_test.go
+++ b/internal/plugins/manifest_test.go
@@ -1,19 +1,67 @@
-package plugins
+package plugins_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/RowanDark/Glyph/internal/plugins"
 )
 
-func TestLoadManifestRequiresCapabilities(t *testing.T) {
-	dir := t.TempDir()
-	manifestPath := filepath.Join(dir, "manifest.json")
-	if err := os.WriteFile(manifestPath, []byte(`{"name":"demo","version":"1.0.0","entry":"/bin/demo"}`), 0o644); err != nil {
-		t.Fatalf("failed to write manifest: %v", err)
+func TestAcceptsValidManifest(t *testing.T) {
+	path := filepath.Join("..", "..", "plugins", "samples", "passive-header-scan", "manifest.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
 	}
+	var m plugins.Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
 
-	if _, err := LoadManifest(manifestPath); err == nil {
+func TestRejectsInvalidManifest(t *testing.T) {
+	path := filepath.Join("..", "..", "plugins", "samples", "invalid", "manifest.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var m plugins.Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if err := m.Validate(); err == nil {
+		t.Fatalf("expected validation error for invalid manifest")
+	}
+}
+
+func TestValidateRequiresCapabilities(t *testing.T) {
+	m := plugins.Manifest{
+		Name:    "demo",
+		Version: "1.0.0",
+		Entry:   "plugin.js",
+	}
+	if err := m.Validate(); err == nil {
 		t.Fatalf("expected error when capabilities are missing")
+	}
+}
+
+func TestLoadManifestRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.json")
+	if err := os.WriteFile(path, []byte(`{"name":"demo","version":"1.0.0","entry":"plugin.js","capabilities":["CAP_HTTP_PASSIVE"],"unexpected":true}`), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	err := plugins.ValidateManifest(path)
+	if err == nil {
+		t.Fatalf("expected validation error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "decode manifest") {
+		t.Fatalf("expected decode error, got: %v", err)
 	}
 }

--- a/plugins/manifest.schema.json
+++ b/plugins/manifest.schema.json
@@ -1,19 +1,30 @@
-// /plugins/manifest.schema.json
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Glyph Plugin Manifest",
   "type": "object",
-  "required": ["name","version","entry","capabilities"],
+  "required": ["name", "version", "entry", "capabilities"],
+  "additionalProperties": false,
   "properties": {
-    "name": {"type":"string"},
-    "version": {"type":"string"},
-    "entry": {"type":"string"},
+    "name": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "entry": { "type": "string", "minLength": 1 },
     "capabilities": {
-      "type":"array",
-      "items":{"type":"string","enum":[
-        "CAP_EMIT_FINDINGS","CAP_HTTP_ACTIVE","CAP_HTTP_PASSIVE",
-        "CAP_WS","CAP_SPIDER","CAP_REPORT","CAP_STORAGE"
-      ]}
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "CAP_EMIT_FINDINGS",
+          "CAP_HTTP_ACTIVE",
+          "CAP_HTTP_PASSIVE",
+          "CAP_WS",
+          "CAP_SPIDER",
+          "CAP_REPORT",
+          "CAP_STORAGE"
+        ]
+      }
     },
-    "config": {"type":"object","additionalProperties": true}
-  },
-  "additionalProperties": false
+    "config": { "type": "object", "additionalProperties": true }
+  }
 }

--- a/plugins/samples/invalid/manifest.json
+++ b/plugins/samples/invalid/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "bad-plugin",
+  "version": "0.0.1",
+  "entry": "bad.js",
+  "capabilities": ["CAP_HTTP_PASSIVE", "CAP_HTTP_PASSIVE", "CAP_MAGIC"]
+}

--- a/plugins/samples/passive-header-scan/manifest.json
+++ b/plugins/samples/passive-header-scan/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "passive-header-scan",
+  "version": "0.1.0",
+  "entry": "plugin.js",
+  "capabilities": ["CAP_HTTP_PASSIVE"],
+  "config": {
+    "includeResponseHeaders": true
+  }
+}


### PR DESCRIPTION
## Summary
- add an authoritative JSON Schema for plugin manifests and provide valid/invalid samples
- implement `glyphctl --manifest-validate` for strict manifest checking with updated server-side validation and tests
- wire manifest validation into the Makefile helper and CI workflow

## Testing
- go test ./...
- make validate-manifests

------
https://chatgpt.com/codex/tasks/task_e_68c95868d548832a9ceab1c7539910f9