### PR TITLE
Add findings pipeline and reporting tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ __pycache__/
 /vendor/
 /node_modules/
 
+# Generated reports
+/out/
+
 # IDE files
 .idea/
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ validate-manifests:
 	@go run ./cmd/glyphctl --manifest-validate plugins/samples/passive-header-scan/manifest.json
 	@! go run ./cmd/glyphctl --manifest-validate plugins/samples/invalid/manifest.json >/dev/null 2>&1 || (echo "invalid sample should fail" && exit 1)
 
+.PHONY: report-sample
+report-sample:
+	@mkdir -p out
+	@cp examples/findings-sample.jsonl out/findings.jsonl
+	@go run ./cmd/glyphctl report --input out/findings.jsonl --out out/report.md
+	@echo "Report written to out/report.md"
+
 .PHONY: verify
 verify: build
 	@golangci-lint run ./...

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 )
 
@@ -12,7 +13,20 @@ func main() {
 	if *manifestValidate != "" {
 		os.Exit(runManifestValidate())
 	}
-	// No subcommand/flags provided: show usage and exit non-zero.
-	flag.Usage()
-	os.Exit(2)
+
+	args := flag.Args()
+	if len(args) == 0 {
+		// No subcommand/flags provided: show usage and exit non-zero.
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "report":
+		os.Exit(runReport(args[1:]))
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
+		flag.Usage()
+		os.Exit(2)
+	}
 }

--- a/cmd/glyphctl/report.go
+++ b/cmd/glyphctl/report.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/RowanDark/Glyph/internal/reporter"
+)
+
+func runReport(args []string) int {
+	fs := flag.NewFlagSet("report", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	input := fs.String("input", reporter.DefaultFindingsPath, "path to findings JSONL input")
+	output := fs.String("out", reporter.DefaultReportPath, "path to write the markdown report")
+	top := fs.Int("top", reporter.DefaultTopTargets, "number of top targets to include")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *input == "" || *output == "" {
+		fmt.Fprintln(os.Stderr, "--input and --out must be provided")
+		return 2
+	}
+
+	if err := reporter.RenderReport(*input, *output, *top); err != nil {
+		fmt.Fprintf(os.Stderr, "generate report: %v\n", err)
+		return 1
+	}
+
+	return 0
+}

--- a/cmd/glyphctl/report_test.go
+++ b/cmd/glyphctl/report_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+	"github.com/RowanDark/Glyph/internal/reporter"
+)
+
+func TestRunReportSuccess(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	dir := t.TempDir()
+	input := filepath.Join(dir, "findings.jsonl")
+	output := filepath.Join(dir, "report.md")
+
+	writer := reporter.NewJSONL(input)
+	sample := findings.Finding{ID: "a", Plugin: "p", Target: "https://example.com", Evidence: "issue", Severity: "low", TS: time.Unix(1710000000, 0).UTC()}
+	if err := writer.Write(sample); err != nil {
+		t.Fatalf("write finding: %v", err)
+	}
+
+	if code := runReport([]string{"--input", input, "--out", output, "--top", "3"}); code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(data), "Findings Report") {
+		t.Fatalf("report missing header: %s", data)
+	}
+}
+
+func TestRunReportMissingArgs(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	if code := runReport([]string{"--input", "", "--out", ""}); code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+}

--- a/examples/findings-sample.jsonl
+++ b/examples/findings-sample.jsonl
@@ -1,0 +1,5 @@
+{"ID":"missing-security-header","Plugin":"passive-header-scan-42","Target":"https://example.com","Evidence":"Missing X-Frame-Options header","Severity":"med","TS":"2024-01-02T03:04:05Z"}
+{"ID":"outdated-cipher","Plugin":"tls-scan-7","Target":"https://example.com","Evidence":"Server allows TLS 1.0","Severity":"high","TS":"2024-01-02T04:00:00Z"}
+{"ID":"exposed-admin","Plugin":"crawler-1","Target":"https://example.com/admin","Evidence":"Admin console accessible without auth","Severity":"crit","TS":"2024-01-02T05:06:07Z"}
+{"ID":"missing-https","Plugin":"passive-header-scan-42","Target":"http://example.org","Evidence":"Site not using HTTPS","Severity":"low","TS":"2024-01-02T06:00:00Z"}
+{"ID":"server-banner","Plugin":"passive-header-scan-42","Target":"https://example.com","Evidence":"Server banner reveals version","Severity":"info","TS":"2024-01-02T07:00:00Z"}

--- a/internal/findings/bus.go
+++ b/internal/findings/bus.go
@@ -1,0 +1,56 @@
+package findings
+
+import (
+	"context"
+	"sync"
+)
+
+// Bus provides an in-process pub/sub system for findings. Multiple subscribers
+// can listen for emitted findings concurrently.
+type Bus struct {
+	mu   sync.RWMutex
+	subs map[int]chan Finding
+	next int
+}
+
+// NewBus returns a new, empty findings bus.
+func NewBus() *Bus {
+	return &Bus{
+		subs: make(map[int]chan Finding),
+	}
+}
+
+// Subscribe registers a new subscriber that will receive emitted findings. The
+// returned channel is closed when the provided context is cancelled.
+func (b *Bus) Subscribe(ctx context.Context) <-chan Finding {
+	ch := make(chan Finding, 16)
+
+	b.mu.Lock()
+	id := b.next
+	b.next++
+	b.subs[id] = ch
+	b.mu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		b.mu.Lock()
+		if sub, ok := b.subs[id]; ok {
+			delete(b.subs, id)
+			close(sub)
+		}
+		b.mu.Unlock()
+	}()
+
+	return ch
+}
+
+// Emit publishes a finding to all registered subscribers. If no subscribers are
+// present the call is a no-op.
+func (b *Bus) Emit(f Finding) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for _, ch := range b.subs {
+		ch <- f
+	}
+}

--- a/internal/findings/bus_test.go
+++ b/internal/findings/bus_test.go
@@ -1,0 +1,54 @@
+package findings
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestBusEmitDeliversToSubscribers(t *testing.T) {
+	bus := NewBus()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := bus.Subscribe(ctx)
+	finding := Finding{ID: "1", Plugin: "p", Severity: "info"}
+
+	done := make(chan struct{})
+	go func() {
+		bus.Emit(finding)
+		close(done)
+	}()
+
+	select {
+	case got := <-ch:
+		if got.ID != finding.ID || got.Plugin != finding.Plugin {
+			t.Fatalf("unexpected finding: %+v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for finding")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("emit did not return")
+	}
+}
+
+func TestBusSubscribeCancelClosesChannel(t *testing.T) {
+	bus := NewBus()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch := bus.Subscribe(ctx)
+	cancel()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected channel to be closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for channel close")
+	}
+}

--- a/internal/findings/types.go
+++ b/internal/findings/types.go
@@ -1,0 +1,13 @@
+package findings
+
+import "time"
+
+// Finding represents a single issue reported by a plugin.
+type Finding struct {
+	ID       string
+	Plugin   string
+	Target   string
+	Evidence string
+	Severity string    // info|low|med|high|crit
+	TS       time.Time // timestamp of when the finding was recorded
+}

--- a/internal/reporter/jsonl.go
+++ b/internal/reporter/jsonl.go
@@ -1,0 +1,81 @@
+package reporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+// JSONL handles persisting findings to a JSON Lines file.
+type JSONL struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewJSONL creates a reporter that writes findings to the provided path.
+func NewJSONL(path string) *JSONL {
+	return &JSONL{path: path}
+}
+
+// Write appends the given finding to the JSONL file.
+func (r *JSONL) Write(f findings.Finding) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o755); err != nil {
+		return fmt.Errorf("create findings directory: %w", err)
+	}
+
+	file, err := os.OpenFile(r.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open findings file: %w", err)
+	}
+	defer file.Close()
+
+	enc := json.NewEncoder(file)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(f); err != nil {
+		return fmt.Errorf("encode finding: %w", err)
+	}
+	return nil
+}
+
+// ReadAll loads every finding stored in the JSONL file.
+func (r *JSONL) ReadAll() ([]findings.Finding, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	file, err := os.Open(r.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open findings file: %w", err)
+	}
+	defer file.Close()
+
+	dec := json.NewDecoder(file)
+	var out []findings.Finding
+	for {
+		var f findings.Finding
+		if err := dec.Decode(&f); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode finding: %w", err)
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// ReadJSONL reads findings from an arbitrary JSONL file path without creating a reporter.
+func ReadJSONL(path string) ([]findings.Finding, error) {
+	r := NewJSONL(path)
+	return r.ReadAll()
+}

--- a/internal/reporter/jsonl_test.go
+++ b/internal/reporter/jsonl_test.go
@@ -1,0 +1,52 @@
+package reporter
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+func TestJSONLWriteAndRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "findings.jsonl")
+	reporter := NewJSONL(path)
+
+	f1 := findings.Finding{ID: "a", Plugin: "plugin-a", Target: "https://a", Evidence: "issue", Severity: "low", TS: time.Unix(1710000000, 0).UTC()}
+	f2 := findings.Finding{ID: "b", Plugin: "plugin-b", Target: "https://b", Evidence: "issue", Severity: "high", TS: time.Unix(1710003600, 0).UTC()}
+
+	if err := reporter.Write(f1); err != nil {
+		t.Fatalf("write f1: %v", err)
+	}
+	if err := reporter.Write(f2); err != nil {
+		t.Fatalf("write f2: %v", err)
+	}
+
+	findings, err := reporter.ReadAll()
+	if err != nil {
+		t.Fatalf("read all: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+
+	if findings[0].ID != f1.ID || !findings[0].TS.Equal(f1.TS) {
+		t.Fatalf("unexpected first finding: %+v", findings[0])
+	}
+	if findings[1].ID != f2.ID || !findings[1].TS.Equal(f2.TS) {
+		t.Fatalf("unexpected second finding: %+v", findings[1])
+	}
+}
+
+func TestReadJSONLMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing.jsonl")
+	findings, err := ReadJSONL(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected empty slice, got %d findings", len(findings))
+	}
+}

--- a/internal/reporter/md.go
+++ b/internal/reporter/md.go
@@ -1,0 +1,143 @@
+package reporter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+const (
+	// DefaultFindingsPath is where glyphd persists findings for other tools to consume.
+	DefaultFindingsPath = "/out/findings.jsonl"
+	// DefaultReportPath is the default markdown summary written for CAP_REPORT consumers.
+	DefaultReportPath = "/out/report.md"
+	// DefaultTopTargets controls how many targets appear in summary tables.
+	DefaultTopTargets = 5
+)
+
+var severityOrder = []struct {
+	key   string
+	label string
+}{
+	{key: "crit", label: "Critical"},
+	{key: "high", label: "High"},
+	{key: "med", label: "Medium"},
+	{key: "low", label: "Low"},
+	{key: "info", label: "Informational"},
+}
+
+// RenderReport loads findings from inputPath and writes a markdown summary to outputPath.
+func RenderReport(inputPath, outputPath string, topN int) error {
+	findings, err := ReadJSONL(inputPath)
+	if err != nil {
+		return err
+	}
+
+	if topN <= 0 {
+		topN = DefaultTopTargets
+	}
+
+	content := RenderMarkdown(findings, topN)
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("create report directory: %w", err)
+	}
+	if err := os.WriteFile(outputPath, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+// RenderMarkdown converts a slice of findings into a markdown report.
+func RenderMarkdown(list []findings.Finding, topN int) string {
+	counts := map[string]int{
+		"crit": 0,
+		"high": 0,
+		"med":  0,
+		"low":  0,
+		"info": 0,
+	}
+	targets := map[string]int{}
+
+	for _, f := range list {
+		sev := normalizeSeverity(f.Severity)
+		counts[sev]++
+
+		target := strings.TrimSpace(f.Target)
+		if target == "" {
+			target = "(not specified)"
+		}
+		targets[target]++
+	}
+
+	type targetCount struct {
+		Target string
+		Count  int
+	}
+
+	ranked := make([]targetCount, 0, len(targets))
+	for target, count := range targets {
+		if count == 0 {
+			continue
+		}
+		ranked = append(ranked, targetCount{Target: target, Count: count})
+	}
+
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].Count == ranked[j].Count {
+			return ranked[i].Target < ranked[j].Target
+		}
+		return ranked[i].Count > ranked[j].Count
+	})
+
+	limit := len(ranked)
+	if topN > 0 && topN < limit {
+		limit = topN
+	}
+
+	var b strings.Builder
+	b.WriteString("# Findings Report\n\n")
+	fmt.Fprintf(&b, "Total findings: %d\n\n", len(list))
+
+	b.WriteString("## Severity Breakdown\n\n")
+	b.WriteString("| Severity | Count |\n")
+	b.WriteString("| --- | ---: |\n")
+	for _, entry := range severityOrder {
+		fmt.Fprintf(&b, "| %s | %d |\n", entry.label, counts[entry.key])
+	}
+	b.WriteString("\n")
+
+	b.WriteString("## Top Targets\n\n")
+	if limit == 0 {
+		b.WriteString("No targets reported.\n")
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "Showing top %d targets by finding volume.\n\n", limit)
+	for i := 0; i < limit; i++ {
+		entry := ranked[i]
+		fmt.Fprintf(&b, "%d. **%s** — %d findings\n", i+1, entry.Target, entry.Count)
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func normalizeSeverity(input string) string {
+	switch strings.ToLower(strings.TrimSpace(input)) {
+	case "critical", "crit":
+		return "crit"
+	case "high":
+		return "high"
+	case "medium", "med":
+		return "med"
+	case "low":
+		return "low"
+	case "info", "informational":
+		return "info"
+	default:
+		return "info"
+	}
+}

--- a/internal/reporter/md_test.go
+++ b/internal/reporter/md_test.go
@@ -1,0 +1,56 @@
+package reporter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+func TestRenderMarkdown(t *testing.T) {
+	findings := []findings.Finding{
+		{ID: "1", Target: "https://a", Severity: "high"},
+		{ID: "2", Target: "https://a", Severity: "med"},
+		{ID: "3", Target: "https://b", Severity: "low"},
+	}
+	md := RenderMarkdown(findings, 5)
+	if !strings.Contains(md, "Total findings: 3") {
+		t.Fatalf("missing total count: %s", md)
+	}
+	if !strings.Contains(md, "| High | 1 |") {
+		t.Fatalf("missing high count: %s", md)
+	}
+	if !strings.Contains(md, "1. **https://a** — 2 findings") {
+		t.Fatalf("missing top target: %s", md)
+	}
+}
+
+func TestRenderReportWritesFile(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "findings.jsonl")
+	output := filepath.Join(dir, "report.md")
+
+	writer := NewJSONL(input)
+	sample := findings.Finding{ID: "x", Plugin: "p", Target: "", Evidence: "", Severity: "crit", TS: time.Unix(1710000000, 0).UTC()}
+	if err := writer.Write(sample); err != nil {
+		t.Fatalf("write finding: %v", err)
+	}
+
+	if err := RenderReport(input, output, 3); err != nil {
+		t.Fatalf("render report: %v", err)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(data), "Critical") {
+		t.Fatalf("report missing severity: %s", data)
+	}
+	if !strings.Contains(string(data), "(not specified)") {
+		t.Fatalf("report missing placeholder target: %s", data)
+	}
+}


### PR DESCRIPTION
## Summary
- add an in-process findings bus and types to share plugin findings
- persist findings to a JSONL log, render markdown summaries, and expose a glyphctl report command
- provide a sample findings dataset and make target to exercise the reporting workflow

## Testing
- go test ./...
- make report-sample

------
https://chatgpt.com/codex/tasks/task_e_68c9aaf3b3ec832aac39e6cbefedb325