### PR TITLE
feat: add plugin SDK and passive header sample plugin

### DIFF
--- a/plugins/samples/passive-header-scan/main.go
+++ b/plugins/samples/passive-header-scan/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/RowanDark/Glyph/sdk/plugin-sdk"
+)
+
+func main() {
+	var (
+		serverAddr = flag.String("server", "127.0.0.1:50051", "glyphd gRPC address")
+		authToken  = flag.String("token", "supersecrettoken", "authentication token")
+	)
+	flag.Parse()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	cfg := pluginsdk.Config{
+		PluginName: "passive-header-scan",
+		Host:       *serverAddr,
+		AuthToken:  *authToken,
+		Capabilities: []pluginsdk.Capability{
+			pluginsdk.CapabilityHTTPPassive,
+			pluginsdk.CapabilityEmitFindings,
+		},
+		Logger: logger,
+	}
+
+	hooks := pluginsdk.Hooks{
+		OnStart: func(ctx *pluginsdk.Context) error {
+			ctx.Logger().Info("plugin started", "addr", *serverAddr)
+			return nil
+		},
+		OnHTTPPassive: func(ctx *pluginsdk.Context, event pluginsdk.HTTPPassiveEvent) error {
+			headers := event.Response.Headers
+			missing := []string{}
+			checks := map[string]string{
+				"Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+				"X-Content-Type-Options":    "nosniff",
+				"X-Frame-Options":           "DENY",
+				"Content-Security-Policy":   "default-src 'none'",
+			}
+			for header, recommended := range checks {
+				if headers.Get(header) == "" {
+					missing = append(missing, header)
+					if err := ctx.EmitFinding(pluginsdk.Finding{
+						Type:     "missing-security-header",
+						Message:  fmt.Sprintf("response missing %s header", header),
+						Severity: pluginsdk.SeverityMedium,
+						Metadata: map[string]string{
+							"header":         header,
+							"recommendation": recommended,
+						},
+					}); err != nil {
+						return err
+					}
+				}
+			}
+
+			if len(missing) == 0 {
+				ctx.Logger().Debug("all monitored headers present")
+			} else {
+				ctx.Logger().Info("detected insecure response", "missing", strings.Join(missing, ", "))
+			}
+			return nil
+		},
+	}
+
+	if err := pluginsdk.Serve(ctx, cfg, hooks); err != nil {
+		logger.Error("plugin terminated", "error", err)
+		os.Exit(1)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+}

--- a/plugins/samples/passive-header-scan/main_test.go
+++ b/plugins/samples/passive-header-scan/main_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/bus"
+	"github.com/RowanDark/Glyph/internal/findings"
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
+	"google.golang.org/grpc"
+)
+
+func TestSampleEmitsFinding(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	findingsBus := findings.NewBus()
+	server := bus.NewServer("test-token", findingsBus)
+	grpcServer := grpc.NewServer()
+	pb.RegisterPluginBusServer(grpcServer, server)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = lis.Close()
+	})
+
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Logf("grpc server error: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		grpcServer.GracefulStop()
+	})
+
+	go server.StartEventGenerator(ctx)
+
+	findingsCh := findingsBus.Subscribe(ctx)
+
+	cmdCtx, cmdCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cmdCancel()
+
+	var stdout, stderr bytes.Buffer
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	binDir := t.TempDir()
+	binaryPath := filepath.Join(binDir, "passive-header-scan")
+	buildCmd := exec.CommandContext(cmdCtx, "go", "build", "-o", binaryPath, ".")
+	buildCmd.Dir = wd
+	var buildOutput bytes.Buffer
+	buildCmd.Stdout = &buildOutput
+	buildCmd.Stderr = &buildOutput
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("build plugin: %v\noutput: %s", err, buildOutput.String())
+	}
+
+	cmd := exec.CommandContext(cmdCtx, binaryPath, "--server", lis.Addr().String(), "--token", "test-token")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start plugin: %v", err)
+	}
+
+	var finding findings.Finding
+	select {
+	case finding = <-findingsCh:
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for finding\nstdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	}
+
+	if finding.ID != "missing-security-header" {
+		t.Fatalf("unexpected finding id: %s", finding.ID)
+	}
+	if !strings.HasPrefix(finding.Plugin, "passive-header-scan-") {
+		t.Fatalf("unexpected plugin id: %s", finding.Plugin)
+	}
+
+	if cmd.Process != nil {
+		_ = cmd.Process.Signal(os.Interrupt)
+	}
+
+	if err := cmd.Wait(); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "signal: killed") && !strings.Contains(err.Error(), "signal: interrupt") {
+		t.Fatalf("plugin exit: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+}

--- a/plugins/samples/passive-header-scan/manifest.json
+++ b/plugins/samples/passive-header-scan/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "passive-header-scan",
   "version": "0.1.0",
-  "entry": "plugin.js",
-  "capabilities": ["CAP_HTTP_PASSIVE"],
+  "entry": "passive-header-scan",
+  "capabilities": ["CAP_HTTP_PASSIVE", "CAP_EMIT_FINDINGS"],
   "config": {
     "includeResponseHeaders": true
   }

--- a/sdk/plugin-sdk/sdk.go
+++ b/sdk/plugin-sdk/sdk.go
@@ -1,0 +1,348 @@
+package pluginsdk
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Capability represents a permission that must be granted to the plugin by the host
+// before certain operations are allowed.
+type Capability string
+
+const (
+	// CapabilityEmitFindings allows the plugin to report findings to the host.
+	CapabilityEmitFindings Capability = "CAP_EMIT_FINDINGS"
+	// CapabilityHTTPPassive allows the plugin to receive passive HTTP events.
+	CapabilityHTTPPassive Capability = "CAP_HTTP_PASSIVE"
+)
+
+// Subscription identifies the type of host events a plugin is interested in.
+type Subscription string
+
+const (
+	// SubscriptionFlowResponse subscribes to HTTP response flow events from the host.
+	SubscriptionFlowResponse Subscription = "FLOW_RESPONSE"
+)
+
+// Severity describes how serious a finding is considered by the plugin.
+type Severity pb.Severity
+
+const (
+	SeverityInfo     Severity = Severity(pb.Severity_INFO)
+	SeverityLow      Severity = Severity(pb.Severity_LOW)
+	SeverityMedium   Severity = Severity(pb.Severity_MEDIUM)
+	SeverityHigh     Severity = Severity(pb.Severity_HIGH)
+	SeverityCritical Severity = Severity(pb.Severity_CRITICAL)
+)
+
+// Finding captures the structured data that will be sent back to the host when the
+// plugin observes an issue.
+type Finding struct {
+	Type     string
+	Message  string
+	Severity Severity
+	Metadata map[string]string
+}
+
+// Hooks contains the callbacks provided by a plugin implementation.
+type Hooks struct {
+	OnStart       OnStartHook
+	OnHTTPPassive HTTPPassiveHook
+}
+
+// OnStartHook is invoked once after the plugin successfully connects to the host.
+type OnStartHook func(ctx *Context) error
+
+// HTTPPassiveHook handles passive HTTP response events streamed from the host.
+type HTTPPassiveHook func(ctx *Context, event HTTPPassiveEvent) error
+
+// Config encapsulates the runtime configuration for a plugin instance.
+type Config struct {
+	// PluginName is the name reported to the host. It should match the manifest.
+	PluginName string
+	// Host is the host:port combination to dial the Glyph core.
+	Host string
+	// AuthToken is the shared secret required by the host.
+	AuthToken string
+	// Capabilities is the set of capabilities granted by the manifest.
+	Capabilities []Capability
+	// Subscriptions lists the host events the plugin wants to receive.
+	Subscriptions []Subscription
+	// Logger allows callers to customise logging output. A sensible default is used otherwise.
+	Logger *slog.Logger
+}
+
+// HTTPResponse summarises an HTTP response derived from a passive flow event.
+type HTTPResponse struct {
+	StatusLine string
+	Headers    http.Header
+	Body       []byte
+}
+
+// HTTPPassiveEvent wraps a passive HTTP response observed by the plugin.
+type HTTPPassiveEvent struct {
+	Raw      []byte
+	Response *HTTPResponse
+}
+
+// Context provides helpers for hooks to interact with the host safely.
+type Context struct {
+	runtime      *runtimeState
+	logger       *slog.Logger
+	capabilities map[Capability]struct{}
+	pluginName   string
+}
+
+// Logger returns the logger bound to the plugin context.
+func (c *Context) Logger() *slog.Logger {
+	return c.logger
+}
+
+// EmitFinding reports a finding to the host if the plugin has the required capability.
+func (c *Context) EmitFinding(f Finding) error {
+	if _, ok := c.capabilities[CapabilityEmitFindings]; !ok {
+		return fmt.Errorf("missing capability %s", CapabilityEmitFindings)
+	}
+	if strings.TrimSpace(f.Type) == "" {
+		return errors.New("finding type must not be empty")
+	}
+	if strings.TrimSpace(f.Message) == "" {
+		return errors.New("finding message must not be empty")
+	}
+
+	pbFinding := &pb.Finding{
+		Type:     f.Type,
+		Message:  f.Message,
+		Severity: pb.Severity(f.Severity),
+	}
+	if len(f.Metadata) > 0 {
+		pbFinding.Metadata = make(map[string]string, len(f.Metadata))
+		for k, v := range f.Metadata {
+			pbFinding.Metadata[k] = v
+		}
+	}
+
+	return c.runtime.sendFinding(pbFinding)
+}
+
+// runtimeState bundles mutable state shared across hooks and the event loop.
+type runtimeState struct {
+	stream pb.PluginBus_EventStreamClient
+	sendMu sync.Mutex
+}
+
+func (r *runtimeState) sendFinding(f *pb.Finding) error {
+	r.sendMu.Lock()
+	defer r.sendMu.Unlock()
+	if r.stream == nil {
+		return errors.New("event stream not initialised")
+	}
+	return r.stream.Send(&pb.PluginEvent{Event: &pb.PluginEvent_Finding{Finding: f}})
+}
+
+// Serve launches the plugin runtime and blocks until the context is cancelled or an error occurs.
+func Serve(parent context.Context, cfg Config, hooks Hooks) error {
+	if cfg.PluginName == "" {
+		return errors.New("plugin name is required")
+	}
+	if cfg.Host == "" {
+		return errors.New("host address is required")
+	}
+	if cfg.AuthToken == "" {
+		return errors.New("auth token is required")
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+	}
+
+	caps := dedupeCapabilities(cfg.Capabilities)
+	subs := dedupeSubscriptions(cfg.Subscriptions)
+
+	if hooks.OnHTTPPassive != nil {
+		if _, ok := caps[CapabilityHTTPPassive]; !ok {
+			return fmt.Errorf("hook OnHTTPPassive requires capability %s", CapabilityHTTPPassive)
+		}
+		if _, present := subs[SubscriptionFlowResponse]; !present {
+			subs[SubscriptionFlowResponse] = struct{}{}
+		}
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, cfg.Host, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		return fmt.Errorf("dial host: %w", err)
+	}
+	defer conn.Close()
+
+	client := pb.NewPluginBusClient(conn)
+	stream, err := client.EventStream(ctx)
+	if err != nil {
+		return fmt.Errorf("open event stream: %w", err)
+	}
+	defer stream.CloseSend()
+
+	hello := &pb.PluginHello{
+		AuthToken:     cfg.AuthToken,
+		PluginName:    cfg.PluginName,
+		Pid:           int32(os.Getpid()),
+		Subscriptions: mapSubscriptions(subs),
+		Capabilities:  mapCapabilities(caps),
+	}
+	if err := stream.Send(&pb.PluginEvent{Event: &pb.PluginEvent_Hello{Hello: hello}}); err != nil {
+		return fmt.Errorf("send hello: %w", err)
+	}
+
+	runtime := &runtimeState{stream: stream}
+	pluginCtx := &Context{
+		runtime:      runtime,
+		logger:       logger.With("plugin", cfg.PluginName),
+		capabilities: caps,
+		pluginName:   cfg.PluginName,
+	}
+
+	if hooks.OnStart != nil {
+		if err := hooks.OnStart(pluginCtx); err != nil {
+			return fmt.Errorf("onStart: %w", err)
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		hostEvent, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "context canceled") {
+				return nil
+			}
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("receive host event: %w", err)
+		}
+
+		flowEvent := hostEvent.GetFlowEvent()
+		if flowEvent == nil {
+			continue
+		}
+
+		if flowEvent.GetType().String() != string(SubscriptionFlowResponse) {
+			continue
+		}
+
+		if hooks.OnHTTPPassive == nil {
+			continue
+		}
+
+		httpResp, err := parseHTTPResponse(flowEvent.GetData())
+		if err != nil {
+			pluginCtx.Logger().Warn("failed to parse HTTP response", "error", err)
+			continue
+		}
+
+		event := HTTPPassiveEvent{Raw: flowEvent.GetData(), Response: httpResp}
+		if err := hooks.OnHTTPPassive(pluginCtx, event); err != nil {
+			return fmt.Errorf("onHTTPPassive: %w", err)
+		}
+	}
+}
+
+// Run is a convenience helper that handles system interrupts and blocks until Serve returns.
+func Run(cfg Config, hooks Hooks) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return Serve(ctx, cfg, hooks)
+}
+
+func dedupeCapabilities(caps []Capability) map[Capability]struct{} {
+	out := make(map[Capability]struct{}, len(caps))
+	for _, c := range caps {
+		if c != "" {
+			out[c] = struct{}{}
+		}
+	}
+	return out
+}
+
+func dedupeSubscriptions(subs []Subscription) map[Subscription]struct{} {
+	out := make(map[Subscription]struct{}, len(subs))
+	for _, s := range subs {
+		if s != "" {
+			out[s] = struct{}{}
+		}
+	}
+	return out
+}
+
+func mapCapabilities(caps map[Capability]struct{}) []string {
+	if len(caps) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(caps))
+	for c := range caps {
+		out = append(out, string(c))
+	}
+	return out
+}
+
+func mapSubscriptions(subs map[Subscription]struct{}) []string {
+	if len(subs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(subs))
+	for s := range subs {
+		out = append(out, string(s))
+	}
+	return out
+}
+
+func parseHTTPResponse(raw []byte) (*HTTPResponse, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("empty payload")
+	}
+	sections := bytes.SplitN(raw, []byte("\n\n"), 2)
+	headerBlob := string(sections[0])
+	lines := strings.Split(headerBlob, "\n")
+	if len(lines) == 0 {
+		return nil, errors.New("missing status line")
+	}
+	statusLine := strings.TrimSpace(lines[0])
+	headers := http.Header{}
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(trimmed, ":")
+		if !ok {
+			continue
+		}
+		headers.Add(strings.TrimSpace(key), strings.TrimSpace(value))
+	}
+	body := []byte{}
+	if len(sections) == 2 {
+		body = sections[1]
+	}
+	return &HTTPResponse{StatusLine: statusLine, Headers: headers, Body: body}, nil
+}


### PR DESCRIPTION
## Summary
- implement a Go plugin SDK with typed hooks, capability enforcement, and helper utilities for passive HTTP events
- add a passive-header-scan sample plugin that reports missing security headers using the SDK
- add a subprocess test that builds and runs the sample to ensure at least one finding is emitted

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68caadb28a28832ab9b73cf3f355c25a