### PR TITLE
Implement findings schema, sandbox gates, and CLI tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,14 @@
+repository:
+  default_branch: main
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - CI / build-test (ubuntu-latest)
+          - CI / build-test (macos-latest)
+          - CI / lint
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      restrictions: null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,14 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
+permissions:
+  contents: read
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,15 +28,20 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
+
       - name: Build
         run: go build ./...
+
       - name: Validate plugin manifests
         run: make validate-manifests
-      - name: Test
-        run: go test ./... -v
+
+      - name: Test (race)
+        run: go test -race ./...
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,19 @@
+name: CodeQL
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -24,6 +24,20 @@ func main() {
 	switch args[0] {
 	case "report":
 		os.Exit(runReport(args[1:]))
+	case "plugin":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "plugin subcommand required")
+			os.Exit(2)
+		}
+		switch args[1] {
+		case "run":
+			os.Exit(runPluginRun(args[2:]))
+		default:
+			fmt.Fprintf(os.Stderr, "unknown plugin subcommand: %s\n", args[1])
+			os.Exit(2)
+		}
+	case "version":
+		os.Exit(runVersion(args[1:]))
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
 		flag.Usage()

--- a/cmd/glyphctl/main_test.go
+++ b/cmd/glyphctl/main_test.go
@@ -62,3 +62,12 @@ func TestRunManifestValidateMissingFile(t *testing.T) {
 		t.Fatalf("expected exit code 2 for read errors, got %d", code)
 	}
 }
+
+func TestRunVersion(t *testing.T) {
+	restore := silenceOutput(t)
+	defer restore()
+
+	if code := runVersion(nil); code != 0 {
+		t.Fatalf("expected version command to exit 0, got %d", code)
+	}
+}

--- a/cmd/glyphctl/plugin_run.go
+++ b/cmd/glyphctl/plugin_run.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/plugins"
+	"github.com/RowanDark/Glyph/internal/plugins/integrity"
+	"github.com/RowanDark/Glyph/internal/plugins/runner"
+)
+
+func runPluginRun(args []string) int {
+	fs := flag.NewFlagSet("plugin run", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	sample := fs.String("sample", "", "sample plugin to execute")
+	server := fs.String("server", "127.0.0.1:50051", "glyphd gRPC address")
+	token := fs.String("token", "supersecrettoken", "glyphd authentication token")
+	duration := fs.Duration("duration", 5*time.Second, "maximum runtime before termination")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *sample == "" {
+		fmt.Fprintln(os.Stderr, "--sample is required")
+		return 2
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "determine working directory: %v\n", err)
+		return 1
+	}
+
+	manifestPath := filepath.Join(root, "plugins", "samples", *sample, "manifest.json")
+	manifest, err := plugins.LoadManifest(manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load manifest: %v\n", err)
+		return 1
+	}
+
+	allowlist, err := integrity.LoadAllowlist(filepath.Join(root, "plugins", "ALLOWLIST"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load allowlist: %v\n", err)
+		return 1
+	}
+
+	artifactPath := manifest.Artifact
+	if !filepath.IsAbs(artifactPath) {
+		artifactPath = filepath.Join(root, artifactPath)
+	}
+	if err := allowlist.Verify(artifactPath); err != nil {
+		fmt.Fprintf(os.Stderr, "artifact verification failed: %v\n", err)
+		return 1
+	}
+
+	pluginDir := filepath.Dir(manifestPath)
+	binaryDir, err := os.MkdirTemp("", "glyph-plugin-build-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create build dir: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(binaryDir)
+	binaryPath := filepath.Join(binaryDir, manifest.Entry)
+
+	build := exec.Command("go", "build", "-o", binaryPath, ".")
+	build.Dir = pluginDir
+	var buildOutput bytes.Buffer
+	build.Stdout = &buildOutput
+	build.Stderr = &buildOutput
+	if err := build.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "build plugin: %v\n%s\n", err, buildOutput.String())
+		return 1
+	}
+
+	ctx := context.Background()
+	limits := runner.Limits{
+		CPUSeconds: 60,
+		WallTime:   *duration,
+	}
+	if limits.WallTime <= 0 {
+		limits.WallTime = 5 * time.Second
+	}
+	config := runner.Config{
+		Binary: binaryPath,
+		Args:   []string{"--server", *server, "--token", *token},
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Limits: limits,
+	}
+
+	if err := runner.Run(ctx, config); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Fprintln(os.Stderr, "plugin reached the configured runtime limit")
+			return 0
+		}
+		fmt.Fprintf(os.Stderr, "run plugin: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/glyphctl/report_test.go
+++ b/cmd/glyphctl/report_test.go
@@ -20,7 +20,16 @@ func TestRunReportSuccess(t *testing.T) {
 	output := filepath.Join(dir, "report.md")
 
 	writer := reporter.NewJSONL(input)
-	sample := findings.Finding{ID: "a", Plugin: "p", Target: "https://example.com", Evidence: "issue", Severity: "low", TS: time.Unix(1710000000, 0).UTC()}
+	sample := findings.Finding{
+		ID:         "a",
+		Plugin:     "p",
+		Type:       "t",
+		Message:    "m",
+		Target:     "https://example.com",
+		Evidence:   "issue",
+		Severity:   findings.SeverityLow,
+		DetectedAt: time.Unix(1710000000, 0).UTC(),
+	}
 	if err := writer.Write(sample); err != nil {
 		t.Fatalf("write finding: %v", err)
 	}

--- a/cmd/glyphctl/version.go
+++ b/cmd/glyphctl/version.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+var version = "dev"
+
+func runVersion(args []string) int {
+	fs := flag.NewFlagSet("version", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(os.Stderr, "version takes no arguments")
+		return 2
+	}
+	fmt.Println(version)
+	return 0
+}

--- a/examples/findings-sample.jsonl
+++ b/examples/findings-sample.jsonl
@@ -1,5 +1,5 @@
-{"ID":"missing-security-header","Plugin":"passive-header-scan-42","Target":"https://example.com","Evidence":"Missing X-Frame-Options header","Severity":"med","TS":"2024-01-02T03:04:05Z"}
-{"ID":"outdated-cipher","Plugin":"tls-scan-7","Target":"https://example.com","Evidence":"Server allows TLS 1.0","Severity":"high","TS":"2024-01-02T04:00:00Z"}
-{"ID":"exposed-admin","Plugin":"crawler-1","Target":"https://example.com/admin","Evidence":"Admin console accessible without auth","Severity":"crit","TS":"2024-01-02T05:06:07Z"}
-{"ID":"missing-https","Plugin":"passive-header-scan-42","Target":"http://example.org","Evidence":"Site not using HTTPS","Severity":"low","TS":"2024-01-02T06:00:00Z"}
-{"ID":"server-banner","Plugin":"passive-header-scan-42","Target":"https://example.com","Evidence":"Server banner reveals version","Severity":"info","TS":"2024-01-02T07:00:00Z"}
+{"id":"missing-security-header","plugin":"passive-header-scan-42","type":"missing-security-header","message":"response missing Strict-Transport-Security header","target":"https://example.com","evidence":"Missing Strict-Transport-Security header","severity":"MEDIUM","detected_at":"2024-01-02T03:04:05Z"}
+{"id":"outdated-cipher","plugin":"tls-scan-7","type":"weak-tls","message":"Server allows TLS 1.0","target":"https://example.com","evidence":"Server allows TLS 1.0","severity":"HIGH","detected_at":"2024-01-02T04:00:00Z"}
+{"id":"exposed-admin","plugin":"crawler-1","type":"exposed-admin","message":"Admin console accessible without auth","target":"https://example.com/admin","evidence":"Admin console accessible without auth","severity":"CRITICAL","detected_at":"2024-01-02T05:06:07Z"}
+{"id":"missing-https","plugin":"passive-header-scan-42","type":"unencrypted-http","message":"Site not using HTTPS","target":"http://example.org","evidence":"Site not using HTTPS","severity":"LOW","detected_at":"2024-01-02T06:00:00Z"}
+{"id":"server-banner","plugin":"passive-header-scan-42","type":"verbose-banner","message":"Server banner reveals version","target":"https://example.com","evidence":"Server banner reveals version","severity":"INFO","detected_at":"2024-01-02T07:00:00Z"}

--- a/internal/bus/server_test.go
+++ b/internal/bus/server_test.go
@@ -182,8 +182,11 @@ func TestPublishFindingEmitsToBus(t *testing.T) {
 		if finding.Evidence != "Header X-Test missing" {
 			t.Fatalf("unexpected evidence: %s", finding.Evidence)
 		}
-		if finding.Severity != "high" {
+		if finding.Severity != findings.SeverityHigh {
 			t.Fatalf("unexpected severity: %s", finding.Severity)
+		}
+		if finding.DetectedAt.IsZero() {
+			t.Fatal("expected detected_at to be populated")
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for finding from bus")

--- a/internal/findings/convert.go
+++ b/internal/findings/convert.go
@@ -1,0 +1,103 @@
+package findings
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
+)
+
+const (
+	metadataID         = "id"
+	metadataTarget     = "target"
+	metadataEvidence   = "evidence"
+	metadataDetectedAt = "detected_at"
+)
+
+// FromProto converts a protobuf Finding emitted by a plugin into the internal
+// representation persisted by glyphd.
+func FromProto(pluginID string, incoming *pb.Finding) (Finding, error) {
+	return fromProtoWithClock(pluginID, incoming, time.Now)
+}
+
+func fromProtoWithClock(pluginID string, incoming *pb.Finding, clock func() time.Time) (Finding, error) {
+	if incoming == nil {
+		return Finding{}, errors.New("incoming finding is nil")
+	}
+	if pluginID = strings.TrimSpace(pluginID); pluginID == "" {
+		return Finding{}, errors.New("plugin id is required")
+	}
+
+	metadata := incoming.GetMetadata()
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+
+	id := strings.TrimSpace(metadata[metadataID])
+	if id == "" {
+		id = uuid.NewString()
+	}
+
+	detectedAt := clock().UTC()
+	if ts := strings.TrimSpace(metadata[metadataDetectedAt]); ts != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, ts)
+		if err != nil {
+			return Finding{}, fmt.Errorf("invalid detected_at timestamp: %w", err)
+		}
+		detectedAt = parsed.UTC()
+	}
+
+	cleanMeta := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		if k == metadataID || k == metadataTarget || k == metadataEvidence || k == metadataDetectedAt {
+			continue
+		}
+		cleanMeta[k] = v
+	}
+	if len(cleanMeta) == 0 {
+		cleanMeta = nil
+	}
+
+	f := Finding{
+		ID:         id,
+		Plugin:     pluginID,
+		Type:       strings.TrimSpace(incoming.GetType()),
+		Message:    strings.TrimSpace(incoming.GetMessage()),
+		Target:     strings.TrimSpace(metadata[metadataTarget]),
+		Evidence:   metadata[metadataEvidence],
+		Severity:   severityFromProto(incoming.GetSeverity()),
+		DetectedAt: detectedAt,
+		Metadata:   cleanMeta,
+	}
+
+	if f.Evidence == "" {
+		f.Evidence = f.Message
+	}
+
+	if err := f.Validate(); err != nil {
+		return Finding{}, err
+	}
+
+	return f, nil
+}
+
+func severityFromProto(sev pb.Severity) Severity {
+	switch sev {
+	case pb.Severity_CRITICAL:
+		return SeverityCritical
+	case pb.Severity_HIGH:
+		return SeverityHigh
+	case pb.Severity_MEDIUM:
+		return SeverityMedium
+	case pb.Severity_LOW:
+		return SeverityLow
+	case pb.Severity_INFO:
+		return SeverityInfo
+	default:
+		return SeverityInfo
+	}
+}

--- a/internal/findings/convert_test.go
+++ b/internal/findings/convert_test.go
@@ -1,0 +1,53 @@
+package findings
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
+)
+
+func TestFromProtoPopulatesDefaults(t *testing.T) {
+	clock := func() time.Time { return time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) }
+	meta := map[string]string{
+		"target":      "https://example.com",
+		"evidence":    "e",
+		"detected_at": "2024-01-02T03:04:05Z",
+	}
+	incoming := &pb.Finding{
+		Type:     "missing",
+		Message:  "msg",
+		Severity: pb.Severity_HIGH,
+		Metadata: meta,
+	}
+
+	finding, err := fromProtoWithClock("plugin-1", incoming, clock)
+	if err != nil {
+		t.Fatalf("fromProto: %v", err)
+	}
+	if finding.ID == "" {
+		t.Fatal("expected id to be populated")
+	}
+	if finding.Plugin != "plugin-1" {
+		t.Fatalf("unexpected plugin: %s", finding.Plugin)
+	}
+	if finding.Target != "https://example.com" {
+		t.Fatalf("unexpected target: %s", finding.Target)
+	}
+	if finding.Evidence != "e" {
+		t.Fatalf("unexpected evidence: %s", finding.Evidence)
+	}
+	if finding.Severity != SeverityHigh {
+		t.Fatalf("unexpected severity: %s", finding.Severity)
+	}
+	if !finding.DetectedAt.Equal(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)) {
+		t.Fatalf("unexpected detected_at: %s", finding.DetectedAt)
+	}
+}
+
+func TestFromProtoRejectsBadTimestamp(t *testing.T) {
+	incoming := &pb.Finding{Metadata: map[string]string{"detected_at": "not-a-timestamp"}}
+	if _, err := FromProto("p", incoming); err == nil {
+		t.Fatal("expected error for bad timestamp")
+	}
+}

--- a/internal/findings/types.go
+++ b/internal/findings/types.go
@@ -1,13 +1,115 @@
 package findings
 
-import "time"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Severity captures the allowed severity values for findings persisted by the
+// host. The values are intentionally normalised to uppercase so JSON encoding
+// is stable and easy to validate.
+type Severity string
+
+const (
+	SeverityInfo     Severity = "INFO"
+	SeverityLow      Severity = "LOW"
+	SeverityMedium   Severity = "MEDIUM"
+	SeverityHigh     Severity = "HIGH"
+	SeverityCritical Severity = "CRITICAL"
+)
+
+var severitySet = map[Severity]struct{}{
+	SeverityInfo:     {},
+	SeverityLow:      {},
+	SeverityMedium:   {},
+	SeverityHigh:     {},
+	SeverityCritical: {},
+}
+
+// MarshalJSON ensures severities are always emitted as quoted strings.
+func (s Severity) MarshalJSON() ([]byte, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(s))
+}
+
+// UnmarshalJSON performs strict validation so we catch typos during testing and
+// when loading persisted findings.
+func (s *Severity) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	parsed := Severity(strings.ToUpper(strings.TrimSpace(raw)))
+	if err := parsed.validate(); err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
+
+func (s Severity) validate() error {
+	if _, ok := severitySet[s]; !ok {
+		return fmt.Errorf("invalid severity: %q", s)
+	}
+	return nil
+}
 
 // Finding represents a single issue reported by a plugin.
 type Finding struct {
-	ID       string
-	Plugin   string
-	Target   string
-	Evidence string
-	Severity string    // info|low|med|high|crit
-	TS       time.Time // timestamp of when the finding was recorded
+	ID         string            `json:"id"`
+	Plugin     string            `json:"plugin"`
+	Type       string            `json:"type"`
+	Message    string            `json:"message"`
+	Target     string            `json:"target,omitempty"`
+	Evidence   string            `json:"evidence,omitempty"`
+	Severity   Severity          `json:"severity"`
+	DetectedAt time.Time         `json:"detected_at"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+// Validate performs sanity checks ensuring the struct complies with the
+// contract codified in specs/finding.schema.json.
+func (f Finding) Validate() error {
+	if strings.TrimSpace(f.ID) == "" {
+		return errors.New("finding id is required")
+	}
+	if strings.TrimSpace(f.Plugin) == "" {
+		return errors.New("plugin is required")
+	}
+	if strings.TrimSpace(f.Type) == "" {
+		return errors.New("type is required")
+	}
+	if strings.TrimSpace(f.Message) == "" {
+		return errors.New("message is required")
+	}
+	if err := f.Severity.validate(); err != nil {
+		return err
+	}
+	if f.DetectedAt.IsZero() {
+		return errors.New("detected_at is required")
+	}
+	return nil
+}
+
+// Clone returns a deep copy of the finding to avoid accidental mutation when
+// broadcasting to subscribers.
+func (f Finding) Clone() Finding {
+	copy := f
+	if len(f.Metadata) > 0 {
+		copy.Metadata = make(map[string]string, len(f.Metadata))
+		for k, v := range f.Metadata {
+			copy.Metadata[k] = v
+		}
+	}
+	return copy
+}
+
+// Timestamp returns the detection timestamp in UTC to simplify reporting code.
+func (f Finding) Timestamp() time.Time {
+	return f.DetectedAt.UTC()
 }

--- a/internal/netgate/gate.go
+++ b/internal/netgate/gate.go
@@ -1,0 +1,96 @@
+package netgate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	capHTTPActive  = "CAP_HTTP_ACTIVE"
+	capHTTPPassive = "CAP_HTTP_PASSIVE"
+)
+
+// Dialer defines the subset of net.Dialer we require. net.Dialer itself
+// satisfies this interface.
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Gate ensures all outbound network operations performed on behalf of plugins
+// respect the declared capabilities.
+type Gate struct {
+	dialer Dialer
+	mu     sync.RWMutex
+	perms  map[string]map[string]struct{}
+}
+
+// New creates a gate wrapping the provided dialer. If dialer is nil a sane
+// default is used.
+func New(dialer Dialer) *Gate {
+	if dialer == nil {
+		dialer = &net.Dialer{Timeout: 5 * time.Second}
+	}
+	return &Gate{dialer: dialer, perms: make(map[string]map[string]struct{})}
+}
+
+// Register stores the capabilities granted to the plugin. Passing an empty
+// slice clears any prior grant.
+func (g *Gate) Register(pluginID string, capabilities []string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if pluginID == "" {
+		return
+	}
+
+	capSet := make(map[string]struct{}, len(capabilities))
+	for _, cap := range capabilities {
+		cap = strings.TrimSpace(cap)
+		if cap == "" {
+			continue
+		}
+		capSet[cap] = struct{}{}
+	}
+	g.perms[pluginID] = capSet
+}
+
+// Unregister removes any stored capabilities for the plugin.
+func (g *Gate) Unregister(pluginID string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.perms, pluginID)
+}
+
+// DialContext enforces the requested capability before delegating to the
+// underlying dialer.
+func (g *Gate) DialContext(ctx context.Context, pluginID, capability, network, address string) (net.Conn, error) {
+	if err := g.check(pluginID, capability); err != nil {
+		return nil, err
+	}
+	return g.dialer.DialContext(ctx, network, address)
+}
+
+func (g *Gate) check(pluginID, capability string) error {
+	switch capability {
+	case capHTTPActive, capHTTPPassive:
+	default:
+		return fmt.Errorf("unsupported capability check: %s", capability)
+	}
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	perms, ok := g.perms[pluginID]
+	if !ok {
+		return errors.New("plugin not registered with gate")
+	}
+	if _, ok := perms[capability]; !ok {
+		return fmt.Errorf("plugin %s missing capability %s", pluginID, capability)
+	}
+	return nil
+}

--- a/internal/netgate/gate_test.go
+++ b/internal/netgate/gate_test.go
@@ -1,0 +1,47 @@
+package netgate
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestGateDeniesMissingCapability(t *testing.T) {
+	gate := New(nil)
+	gate.Register("plugin", nil)
+
+	if _, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "127.0.0.1:1"); err == nil {
+		t.Fatal("expected dial to be denied without capability")
+	}
+}
+
+func TestGateAllowsWithCapability(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	gate := New(&net.Dialer{Timeout: time.Second})
+	gate.Register("plugin", []string{capHTTPActive})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			conn.Close()
+		}
+		close(done)
+	}()
+
+	conn, err := gate.DialContext(ctx, "plugin", capHTTPActive, "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	conn.Close()
+	<-done
+}

--- a/internal/plugins/integrity/allowlist.go
+++ b/internal/plugins/integrity/allowlist.go
@@ -1,0 +1,99 @@
+package integrity
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Allowlist captures the trusted hashes recorded for plugin artifacts.
+type Allowlist struct {
+	baseDir string
+	entries map[string]string
+}
+
+// LoadAllowlist parses the allowlist file. Paths are interpreted relative to
+// the directory containing the allowlist itself.
+func LoadAllowlist(path string) (*Allowlist, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open allowlist: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	entries := make(map[string]string)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("invalid allowlist entry on line %d", lineNo)
+		}
+		hash := strings.ToLower(fields[0])
+		if len(hash) != 64 {
+			return nil, fmt.Errorf("invalid hash on line %d", lineNo)
+		}
+		pathField := filepath.ToSlash(filepath.Clean(fields[1]))
+		entries[pathField] = hash
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read allowlist: %w", err)
+	}
+
+	return &Allowlist{baseDir: filepath.Dir(path), entries: entries}, nil
+}
+
+// Verify ensures the artifact's hash matches the allowlist.
+func (a *Allowlist) Verify(artifactPath string) error {
+	if a == nil {
+		return errors.New("allowlist not initialised")
+	}
+	abs, err := filepath.Abs(artifactPath)
+	if err != nil {
+		return fmt.Errorf("abs artifact path: %w", err)
+	}
+	rel, err := filepath.Rel(a.baseDir, abs)
+	if err != nil {
+		return fmt.Errorf("relativise artifact: %w", err)
+	}
+	key := filepath.ToSlash(rel)
+
+	expected, ok := a.entries[key]
+	if !ok {
+		return fmt.Errorf("artifact %s not present in allowlist", key)
+	}
+
+	actual, err := hashFile(abs)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("artifact %s hash mismatch", key)
+	}
+	return nil
+}
+
+func hashFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open artifact: %w", err)
+	}
+	defer file.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return "", fmt.Errorf("hash artifact: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/plugins/integrity/allowlist_test.go
+++ b/internal/plugins/integrity/allowlist_test.go
@@ -1,0 +1,42 @@
+package integrity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAllowlistVerify(t *testing.T) {
+	dir := t.TempDir()
+	artifact := filepath.Join(dir, "sample.txt")
+	if err := os.WriteFile(artifact, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	hash, err := hashFile(artifact)
+	if err != nil {
+		t.Fatalf("hash artifact: %v", err)
+	}
+
+	allowlistPath := filepath.Join(dir, "ALLOWLIST")
+	content := hash + " sample.txt\n"
+	if err := os.WriteFile(allowlistPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write allowlist: %v", err)
+	}
+
+	allowlist, err := LoadAllowlist(allowlistPath)
+	if err != nil {
+		t.Fatalf("load allowlist: %v", err)
+	}
+
+	if err := allowlist.Verify(artifact); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if err := os.WriteFile(artifact, []byte("tampered"), 0o644); err != nil {
+		t.Fatalf("tamper artifact: %v", err)
+	}
+	if err := allowlist.Verify(artifact); err == nil {
+		t.Fatal("expected verification failure after tampering")
+	}
+}

--- a/internal/plugins/manifest.go
+++ b/internal/plugins/manifest.go
@@ -13,6 +13,7 @@ type Manifest struct {
 	Name         string         `json:"name"`
 	Version      string         `json:"version"`
 	Entry        string         `json:"entry"`
+	Artifact     string         `json:"artifact"`
 	Capabilities []string       `json:"capabilities"`
 	Config       map[string]any `json:"config,omitempty"`
 }
@@ -28,8 +29,8 @@ var allowedCaps = map[string]struct{}{
 }
 
 func (m *Manifest) Validate() error {
-	if m.Name == "" || m.Version == "" || m.Entry == "" {
-		return errors.New("name, version, and entry are required")
+	if m.Name == "" || m.Version == "" || m.Entry == "" || m.Artifact == "" {
+		return errors.New("name, version, entry, and artifact are required")
 	}
 	if len(m.Capabilities) == 0 {
 		return errors.New("at least one capability is required")

--- a/internal/plugins/manifest_test.go
+++ b/internal/plugins/manifest_test.go
@@ -14,6 +14,7 @@ func validManifest() plugins.Manifest {
 		Name:         "demo",
 		Version:      "1.0.0",
 		Entry:        "plugin.js",
+		Artifact:     "plugin.js",
 		Capabilities: []string{"CAP_HTTP_PASSIVE"},
 	}
 }
@@ -84,7 +85,7 @@ func TestValidateRequiresMetadata(t *testing.T) {
 func TestLoadManifestRejectsUnknownField(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "manifest.json")
-	if err := os.WriteFile(path, []byte(`{"name":"demo","version":"1.0.0","entry":"plugin.js","capabilities":["CAP_HTTP_PASSIVE"],"unexpected":true}`), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(`{"name":"demo","version":"1.0.0","entry":"plugin.js","artifact":"plugin.js","capabilities":["CAP_HTTP_PASSIVE"],"unexpected":true}`), 0o644); err != nil {
 		t.Fatalf("write manifest: %v", err)
 	}
 	err := plugins.ValidateManifest(path)

--- a/internal/plugins/runner/runner.go
+++ b/internal/plugins/runner/runner.go
@@ -1,0 +1,167 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Limits configures the sandbox applied to plugin subprocesses.
+type Limits struct {
+	CPUSeconds  uint64
+	MemoryBytes uint64
+	WallTime    time.Duration
+}
+
+// Config describes a plugin invocation.
+type Config struct {
+	Binary string
+	Args   []string
+	Env    map[string]string
+	Stdout io.Writer
+	Stderr io.Writer
+	Limits Limits
+}
+
+// Run executes the plugin binary with the provided configuration. The caller
+// should supply a cancellable context to terminate the plugin early.
+func Run(ctx context.Context, cfg Config) error {
+	if cfg.Binary == "" {
+		return errors.New("binary path is required")
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	wallCtx := ctx
+	var cancel context.CancelFunc
+	if cfg.Limits.WallTime > 0 {
+		wallCtx, cancel = context.WithTimeout(ctx, cfg.Limits.WallTime)
+		defer cancel()
+	}
+
+	tmpDir, err := os.MkdirTemp("", "glyph-plugin-")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cmd := exec.CommandContext(wallCtx, cfg.Binary, cfg.Args...)
+	cmd.Dir = tmpDir
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if cfg.Stdout != nil {
+		cmd.Stdout = cfg.Stdout
+	}
+	if cfg.Stderr != nil {
+		cmd.Stderr = cfg.Stderr
+	}
+
+	cmd.Env = buildEnv(tmpDir, cfg.Env)
+
+	if err := startWithLimits(cmd, cfg.Limits); err != nil {
+		return err
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-result:
+		return err
+	case <-wallCtx.Done():
+		killProcessGroup(cmd)
+		<-result
+		return wallCtx.Err()
+	}
+}
+
+func buildEnv(workDir string, overrides map[string]string) []string {
+	base := map[string]string{
+		"PATH":   os.Getenv("PATH"),
+		"HOME":   workDir,
+		"TMPDIR": workDir,
+	}
+	for k, v := range overrides {
+		base[k] = v
+	}
+	env := make([]string, 0, len(base))
+	for k, v := range base {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env
+}
+
+var limitMu sync.Mutex
+
+func startWithLimits(cmd *exec.Cmd, lim Limits) error {
+	limitMu.Lock()
+	defer limitMu.Unlock()
+
+	var (
+		cpuOrig syscall.Rlimit
+		memOrig syscall.Rlimit
+		cpuSet  bool
+		memSet  bool
+	)
+
+	if lim.CPUSeconds > 0 {
+		if err := syscall.Getrlimit(syscall.RLIMIT_CPU, &cpuOrig); err != nil {
+			return fmt.Errorf("get cpu limit: %w", err)
+		}
+		newLimit := syscall.Rlimit{Cur: lim.CPUSeconds, Max: lim.CPUSeconds}
+		if err := syscall.Setrlimit(syscall.RLIMIT_CPU, &newLimit); err != nil {
+			return fmt.Errorf("set cpu limit: %w", err)
+		}
+		cpuSet = true
+	}
+
+	if lim.MemoryBytes > 0 {
+		if err := syscall.Getrlimit(syscall.RLIMIT_AS, &memOrig); err != nil {
+			return fmt.Errorf("get memory limit: %w", err)
+		}
+		newLimit := syscall.Rlimit{Cur: lim.MemoryBytes, Max: lim.MemoryBytes}
+		if err := syscall.Setrlimit(syscall.RLIMIT_AS, &newLimit); err != nil {
+			return fmt.Errorf("set memory limit: %w", err)
+		}
+		memSet = true
+	}
+
+	startErr := cmd.Start()
+
+	if cpuSet {
+		_ = syscall.Setrlimit(syscall.RLIMIT_CPU, &cpuOrig)
+	}
+	if memSet {
+		_ = syscall.Setrlimit(syscall.RLIMIT_AS, &memOrig)
+	}
+
+	return startErr
+}
+
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	if runtime.GOOS == "windows" {
+		_ = cmd.Process.Kill()
+		return
+	}
+	// Negative PID targets the process group.
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+}

--- a/internal/plugins/runner/runner_test.go
+++ b/internal/plugins/runner/runner_test.go
@@ -1,0 +1,31 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunTimeoutKillsProcess(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "main.go")
+	program := "package main\nimport \"time\"\nfunc main(){for {time.Sleep(time.Second)}}"
+	if err := os.WriteFile(source, []byte(program), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	binary := filepath.Join(dir, "sleepy")
+	build := exec.Command("go", "build", "-o", binary, source)
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build binary: %v\noutput: %s", err, out)
+	}
+
+	err := Run(ctx, Config{Binary: binary, Limits: Limits{WallTime: 200 * time.Millisecond}})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}

--- a/internal/reporter/jsonl_test.go
+++ b/internal/reporter/jsonl_test.go
@@ -1,6 +1,8 @@
 package reporter
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,8 +15,27 @@ func TestJSONLWriteAndRead(t *testing.T) {
 	path := filepath.Join(dir, "findings.jsonl")
 	reporter := NewJSONL(path)
 
-	f1 := findings.Finding{ID: "a", Plugin: "plugin-a", Target: "https://a", Evidence: "issue", Severity: "low", TS: time.Unix(1710000000, 0).UTC()}
-	f2 := findings.Finding{ID: "b", Plugin: "plugin-b", Target: "https://b", Evidence: "issue", Severity: "high", TS: time.Unix(1710003600, 0).UTC()}
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	f1 := findings.Finding{
+		ID:         "a",
+		Plugin:     "plugin-a",
+		Type:       "missing-header",
+		Message:    "Missing X-Test",
+		Target:     "https://a",
+		Evidence:   "issue",
+		Severity:   findings.SeverityLow,
+		DetectedAt: base,
+	}
+	f2 := findings.Finding{
+		ID:         "b",
+		Plugin:     "plugin-b",
+		Type:       "missing-header",
+		Message:    "Missing X-Other",
+		Target:     "https://b",
+		Evidence:   "issue",
+		Severity:   findings.SeverityHigh,
+		DetectedAt: base.Add(1 * time.Hour),
+	}
 
 	if err := reporter.Write(f1); err != nil {
 		t.Fatalf("write f1: %v", err)
@@ -23,19 +44,61 @@ func TestJSONLWriteAndRead(t *testing.T) {
 		t.Fatalf("write f2: %v", err)
 	}
 
-	findings, err := reporter.ReadAll()
+	list, err := reporter.ReadAll()
 	if err != nil {
 		t.Fatalf("read all: %v", err)
 	}
-	if len(findings) != 2 {
-		t.Fatalf("expected 2 findings, got %d", len(findings))
+	if len(list) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(list))
+	}
+	if list[0].ID != f1.ID || !list[0].DetectedAt.Equal(f1.DetectedAt) {
+		t.Fatalf("unexpected first finding: %+v", list[0])
+	}
+	if list[1].ID != f2.ID || !list[1].DetectedAt.Equal(f2.DetectedAt) {
+		t.Fatalf("unexpected second finding: %+v", list[1])
+	}
+}
+
+func TestJSONLRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "findings.jsonl")
+	content := `{"id":"a","plugin":"p","type":"x","message":"m","severity":"LOW","detected_at":"2024-01-01T00:00:00Z","unexpected":true}`
+	if err := os.WriteFile(path, []byte(content+"\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
 	}
 
-	if findings[0].ID != f1.ID || !findings[0].TS.Equal(f1.TS) {
-		t.Fatalf("unexpected first finding: %+v", findings[0])
+	reporter := NewJSONL(path)
+	if _, err := reporter.ReadAll(); err == nil {
+		t.Fatal("expected error for unknown field, got nil")
 	}
-	if findings[1].ID != f2.ID || !findings[1].TS.Equal(f2.TS) {
-		t.Fatalf("unexpected second finding: %+v", findings[1])
+}
+
+func TestJSONLRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "findings.jsonl")
+	reporter := NewJSONL(path, WithMaxBytes(150))
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		f := findings.Finding{
+			ID:         fmt.Sprintf("id-%d", i),
+			Plugin:     "plugin",
+			Type:       "t",
+			Message:    "m",
+			Severity:   findings.SeverityInfo,
+			DetectedAt: base.Add(time.Duration(i) * time.Minute),
+		}
+		if err := reporter.Write(f); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "findings.jsonl.*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("expected rotated files to exist")
 	}
 }
 

--- a/internal/reporter/md.go
+++ b/internal/reporter/md.go
@@ -20,14 +20,14 @@ const (
 )
 
 var severityOrder = []struct {
-	key   string
+	key   findings.Severity
 	label string
 }{
-	{key: "crit", label: "Critical"},
-	{key: "high", label: "High"},
-	{key: "med", label: "Medium"},
-	{key: "low", label: "Low"},
-	{key: "info", label: "Informational"},
+	{key: findings.SeverityCritical, label: "Critical"},
+	{key: findings.SeverityHigh, label: "High"},
+	{key: findings.SeverityMedium, label: "Medium"},
+	{key: findings.SeverityLow, label: "Low"},
+	{key: findings.SeverityInfo, label: "Informational"},
 }
 
 // RenderReport loads findings from inputPath and writes a markdown summary to outputPath.
@@ -53,17 +53,17 @@ func RenderReport(inputPath, outputPath string, topN int) error {
 
 // RenderMarkdown converts a slice of findings into a markdown report.
 func RenderMarkdown(list []findings.Finding, topN int) string {
-	counts := map[string]int{
-		"crit": 0,
-		"high": 0,
-		"med":  0,
-		"low":  0,
-		"info": 0,
+	counts := map[findings.Severity]int{
+		findings.SeverityCritical: 0,
+		findings.SeverityHigh:     0,
+		findings.SeverityMedium:   0,
+		findings.SeverityLow:      0,
+		findings.SeverityInfo:     0,
 	}
 	targets := map[string]int{}
 
 	for _, f := range list {
-		sev := normalizeSeverity(f.Severity)
+		sev := canonicalSeverity(f.Severity)
 		counts[sev]++
 
 		target := strings.TrimSpace(f.Target)
@@ -125,19 +125,19 @@ func RenderMarkdown(list []findings.Finding, topN int) string {
 	return b.String()
 }
 
-func normalizeSeverity(input string) string {
-	switch strings.ToLower(strings.TrimSpace(input)) {
-	case "critical", "crit":
-		return "crit"
-	case "high":
-		return "high"
-	case "medium", "med":
-		return "med"
-	case "low":
-		return "low"
-	case "info", "informational":
-		return "info"
+func canonicalSeverity(input findings.Severity) findings.Severity {
+	switch strings.ToUpper(strings.TrimSpace(string(input))) {
+	case string(findings.SeverityCritical):
+		return findings.SeverityCritical
+	case string(findings.SeverityHigh):
+		return findings.SeverityHigh
+	case string(findings.SeverityMedium):
+		return findings.SeverityMedium
+	case string(findings.SeverityLow):
+		return findings.SeverityLow
+	case string(findings.SeverityInfo):
+		return findings.SeverityInfo
 	default:
-		return "info"
+		return findings.SeverityInfo
 	}
 }

--- a/internal/reporter/md_test.go
+++ b/internal/reporter/md_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 func TestRenderMarkdown(t *testing.T) {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	findings := []findings.Finding{
-		{ID: "1", Target: "https://a", Severity: "high"},
-		{ID: "2", Target: "https://a", Severity: "med"},
-		{ID: "3", Target: "https://b", Severity: "low"},
+		{ID: "1", Plugin: "p1", Type: "t", Message: "m", Target: "https://a", Severity: findings.SeverityHigh, DetectedAt: base},
+		{ID: "2", Plugin: "p1", Type: "t", Message: "m", Target: "https://a", Severity: findings.SeverityMedium, DetectedAt: base},
+		{ID: "3", Plugin: "p2", Type: "t", Message: "m", Target: "https://b", Severity: findings.SeverityLow, DetectedAt: base},
 	}
 	md := RenderMarkdown(findings, 5)
 	if !strings.Contains(md, "Total findings: 3") {
@@ -34,7 +35,15 @@ func TestRenderReportWritesFile(t *testing.T) {
 	output := filepath.Join(dir, "report.md")
 
 	writer := NewJSONL(input)
-	sample := findings.Finding{ID: "x", Plugin: "p", Target: "", Evidence: "", Severity: "crit", TS: time.Unix(1710000000, 0).UTC()}
+	sample := findings.Finding{
+		ID:         "x",
+		Plugin:     "p",
+		Type:       "t",
+		Message:    "m",
+		Evidence:   "",
+		Severity:   findings.SeverityCritical,
+		DetectedAt: time.Unix(1710000000, 0).UTC(),
+	}
 	if err := writer.Write(sample); err != nil {
 		t.Fatalf("write finding: %v", err)
 	}

--- a/plugins/ALLOWLIST
+++ b/plugins/ALLOWLIST
@@ -1,0 +1,2 @@
+# hash  relative-path
+32d875c188927ebc3f1a1afa38d74533bed5be852ae261a9d0c16b3bb8e40f76 samples/passive-header-scan/main.go

--- a/plugins/manifest.schema.json
+++ b/plugins/manifest.schema.json
@@ -2,12 +2,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Glyph Plugin Manifest",
   "type": "object",
-  "required": ["name", "version", "entry", "capabilities"],
+  "required": ["name", "version", "entry", "artifact", "capabilities"],
   "additionalProperties": false,
   "properties": {
     "name": { "type": "string", "minLength": 1 },
     "version": { "type": "string", "minLength": 1 },
     "entry": { "type": "string", "minLength": 1 },
+    "artifact": { "type": "string", "minLength": 1 },
     "capabilities": {
       "type": "array",
       "minItems": 1,

--- a/plugins/samples/passive-header-scan/main.go
+++ b/plugins/samples/passive-header-scan/main.go
@@ -55,9 +55,12 @@ func main() {
 				if headers.Get(header) == "" {
 					missing = append(missing, header)
 					if err := ctx.EmitFinding(pluginsdk.Finding{
-						Type:     "missing-security-header",
-						Message:  fmt.Sprintf("response missing %s header", header),
-						Severity: pluginsdk.SeverityMedium,
+						Type:       "missing-security-header",
+						Message:    fmt.Sprintf("response missing %s header", header),
+						Target:     event.Response.Headers.Get("Host"),
+						Evidence:   fmt.Sprintf("Missing %s header", header),
+						Severity:   pluginsdk.SeverityMedium,
+						DetectedAt: time.Now().UTC(),
 						Metadata: map[string]string{
 							"header":         header,
 							"recommendation": recommended,

--- a/plugins/samples/passive-header-scan/main_test.go
+++ b/plugins/samples/passive-header-scan/main_test.go
@@ -85,8 +85,17 @@ func TestSampleEmitsFinding(t *testing.T) {
 		t.Fatalf("timed out waiting for finding\nstdout: %s\nstderr: %s", stdout.String(), stderr.String())
 	}
 
-	if finding.ID != "missing-security-header" {
-		t.Fatalf("unexpected finding id: %s", finding.ID)
+	if finding.ID == "" {
+		t.Fatal("expected finding id to be populated")
+	}
+	if finding.Type != "missing-security-header" {
+		t.Fatalf("unexpected finding type: %s", finding.Type)
+	}
+	if finding.Severity != findings.SeverityMedium {
+		t.Fatalf("unexpected severity: %s", finding.Severity)
+	}
+	if finding.DetectedAt.IsZero() {
+		t.Fatal("expected detected_at to be set")
 	}
 	if !strings.HasPrefix(finding.Plugin, "passive-header-scan-") {
 		t.Fatalf("unexpected plugin id: %s", finding.Plugin)

--- a/plugins/samples/passive-header-scan/manifest.json
+++ b/plugins/samples/passive-header-scan/manifest.json
@@ -2,6 +2,7 @@
   "name": "passive-header-scan",
   "version": "0.1.0",
   "entry": "passive-header-scan",
+  "artifact": "plugins/samples/passive-header-scan/main.go",
   "capabilities": ["CAP_HTTP_PASSIVE", "CAP_EMIT_FINDINGS"],
   "config": {
     "includeResponseHeaders": true

--- a/specs/finding.schema.json
+++ b/specs/finding.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/RowanDark/Glyph/specs/finding.schema.json",
+  "title": "Glyph Finding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "plugin", "type", "message", "severity", "detected_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for the finding."
+    },
+    "plugin": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the plugin that produced the finding."
+    },
+    "type": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Machine readable finding type."
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human friendly message describing the finding."
+    },
+    "target": {
+      "type": "string",
+      "description": "Target asset associated with the finding."
+    },
+    "evidence": {
+      "type": "string",
+      "description": "Optional evidence string from the plugin."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"],
+      "description": "Severity level assigned to the finding."
+    },
+    "detected_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 timestamp indicating when the finding was observed."
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Arbitrary plugin supplied key/value metadata."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define a normalized finding contract, JSON schema, and rotation-aware writer to enforce strict severity handling and RFC3339 timestamps
- add network gate enforcement, a resource-limited runner, and artifact allowlisting so plugins are verified and sandboxed before execution
- extend glyphctl with plugin run/version commands, wire a smoke test that drives glyphd and the sample plugin, and harden CI/security automation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cac97560dc832aac2dbcec6f55a1d1