### PR TITLE
Update golangci-lint configuration for v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,8 @@
-version: 2
+version: "2"   # v2 requires a string
 
 run:
   timeout: 5m
+
 linters:
   enable:
     - govet
@@ -9,9 +10,12 @@ linters:
     - ineffassign
     - misspell
     - errcheck
+
 formatters:
   enable:
     - gofmt
     - goimports
-issues:
-  exclude-use-default: false
+
+# v2 removed 'exclude-use-default'. If you need exclusions later,
+# use 'linters.exclusions' / 'formatters.exclusions'.
+issues: {}


### PR DESCRIPTION
## Summary
- update .golangci.yml to use the v2 schema and remove deprecated options
- keep gofmt/goimports configured as formatters and document new exclusion guidance

## Testing
- ⚠️ `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.1.6` *(fails: proxy access forbidden in container)*
- ⚠️ `golangci-lint config verify` *(fails: schema download forbidden in container)*
- ⚠️ `golangci-lint run ./...` *(interrupted due to hanging, likely waiting on network)*

------
https://chatgpt.com/codex/tasks/task_e_68caf9396334832a9d8e110766d186b7