### PR TITLE
Document Galdr proxy CA workflow and add cert cache test

### DIFF
--- a/internal/proxy/ca_test.go
+++ b/internal/proxy/ca_test.go
@@ -1,0 +1,39 @@
+package proxy
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestCertificateForHostCachesLeaf(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "ca.pem")
+	keyPath := filepath.Join(tempDir, "ca.key")
+
+	store, err := newCAStore(certPath, keyPath)
+	if err != nil {
+		t.Fatalf("newCAStore: %v", err)
+	}
+
+	first, err := store.certificateForHost("example.com")
+	if err != nil {
+		t.Fatalf("first certificateForHost: %v", err)
+	}
+	if first == nil {
+		t.Fatal("first certificate is nil")
+	}
+
+	second, err := store.certificateForHost("example.com")
+	if err != nil {
+		t.Fatalf("second certificateForHost: %v", err)
+	}
+	if second == nil {
+		t.Fatal("second certificate is nil")
+	}
+
+	if first != second {
+		t.Fatalf("expected cached certificate pointer, got different instances")
+	}
+}

--- a/plugins/galdr-proxy/README.md
+++ b/plugins/galdr-proxy/README.md
@@ -9,10 +9,11 @@ Galdr Proxy is the interception layer for Glyph. It terminates client HTTP/HTTPS
 
 ## Running the proxy service
 
-`glyphd` now embeds the proxy. Launch it with your authentication token:
+`glyphd` now embeds the proxy. Launch it with your authentication token and enable the interception layer:
 
 ```bash
-glyphd --token <TOKEN>
+glyphd --token <TOKEN> --enable-proxy --proxy-port 8080 \
+  --proxy-rules /out/proxy_rules.json --proxy-history /out/proxy_history.jsonl
 ```
 
 Key files are written beneath `/out` by default:
@@ -23,15 +24,18 @@ Key files are written beneath `/out` by default:
 | CA private key | `/out/galdr_proxy_ca.key` | Used to mint leaf certificates for intercepted hosts |
 | History log | `/out/proxy_history.jsonl` | JSONL file containing every intercepted request/response |
 
-Use `--proxy-port`, `--proxy-rules`, `--proxy-history`, `--proxy-ca-cert`, and `--proxy-ca-key` to override the defaults.
+Use `--proxy-port`, `--proxy-rules`, `--proxy-history`, `--proxy-ca-cert`, and `--proxy-ca-key` to override the defaults. For a quick-start ruleset, copy `plugins/galdr-proxy/examples/rules.example.json` into your output directory and point `--proxy-rules` at the copied file.
 
-### Generate and trust the CA certificate
+### Install the Galdr CA
 
 1. Start `glyphd` once so the proxy can generate a root CA and private key.
-2. Import `/out/galdr_proxy_ca.pem` into your browser or system trust store. The certificate common name is **Galdr Proxy Root CA**.
+2. Export the certificate found at `/out/galdr_proxy_ca.pem` to the system that will run the browser.
+3. Import the PEM into your browser or system trust store. The certificate common name is **Galdr Proxy Root CA**.
    - **macOS:** Keychain Access → System → Certificates → import the PEM → set to “Always Trust”.
-   - **Firefox:** Settings → Privacy & Security → Certificates → View Certificates → Authorities → Import.
+   - **Firefox:** Settings → Privacy & Security → Certificates → View Certificates → Authorities → Import, then trust for website identification.
    - **Linux/Windows:** Use the native certificate manager for your distribution.
+
+To remove the proxy trust anchor later, delete the **Galdr Proxy Root CA** entry from the same trust store.
 
 Until the CA is trusted, HTTPS interception will surface security warnings.
 
@@ -60,7 +64,24 @@ Save changes to the rules file and the proxy will pick them up automatically wit
 
 ### History log
 
-Every flow is appended to `/out/proxy_history.jsonl` along with metadata (timestamp, client IP, protocol, matched rules, headers, and payload sizes). The file can be tailed or post-processed by other Glyph plugins for analysis.
+Every flow is appended to `/out/proxy_history.jsonl` as JSON Lines. Each entry matches the following schema:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `timestamp` | RFC 3339 string | When the request was completed. |
+| `client_ip` | string | Source IP observed by the proxy. |
+| `protocol` | string | Transport protocol (e.g., `http`, `https`, `ws`). |
+| `method` | string | HTTP method used by the client. |
+| `url` | string | Full request URL. |
+| `status_code` | integer | Upstream response status code. |
+| `latency_ms` | integer | End-to-end latency in milliseconds. |
+| `request_size_bytes` | integer | Number of bytes received from the client. |
+| `response_size_bytes` | integer | Number of bytes sent back to the client. |
+| `request_headers` | object | Map of header name → array of values sent upstream. |
+| `response_headers` | object | Map of header name → array of values returned downstream. |
+| `matched_rules` | array (optional) | Names of any modification rules applied to the flow. |
+
+The log can be tailed or post-processed by other Glyph plugins for analysis. Override the path with `--proxy-history` if you prefer a custom location.
 
 ### WebSocket traffic
 

--- a/plugins/galdr-proxy/examples/rules.example.json
+++ b/plugins/galdr-proxy/examples/rules.example.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "add-glyph-header",
+    "match": {"url_contains": ""},
+    "request": {"add_headers": {"X-Glyph": "on"}},
+    "response": {
+      "add_headers": {"X-Glyph-Proxy": "active"},
+      "remove_headers": ["Server"]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- document the Galdr proxy quick-start flow, CA installation/removal steps, and the JSONL history schema
- add an example rules file that injects headers so new users can test the proxy quickly
- add a unit test to ensure leaf certificates are cached per SNI for reuse

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd720c9658832aa43e4a5f9ed6ffbe