### PR TITLE
Add manual excavator smoke workflow

### DIFF
--- a/.github/workflows/excavator-smoke.yml
+++ b/.github/workflows/excavator-smoke.yml
@@ -1,0 +1,42 @@
+name: Excavator smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  crawl:
+    name: Run excavator smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: plugins/excavator/package-lock.json
+
+      - name: Install dependencies
+        working-directory: plugins/excavator
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: plugins/excavator
+        run: npx playwright install --with-deps
+
+      - name: Run excavator crawl
+        run: |
+          mkdir -p artifacts
+          DEPTH=1 HOST_LIMIT=1 node plugins/excavator/crawl.js --target=https://example.com --depth=1 > artifacts/excavator-smoke.json
+
+      - name: Upload crawl artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: excavator-smoke
+          path: artifacts/excavator-smoke.json
+          if-no-files-found: error
+          retention-days: 7

--- a/plugins/excavator/README.md
+++ b/plugins/excavator/README.md
@@ -20,6 +20,10 @@ Excavator is the Playwright-powered crawler foundation for Glyph. It provides a 
    npm --prefix plugins/excavator run crawl -- --target=https://example.com --depth=1
    ```
 
+## Continuous integration
+
+- Manual smoke validation: [Excavator smoke workflow](../../.github/workflows/excavator-smoke.yml)
+
 ### Runtime configuration
 
 Excavator keeps crawls predictable and safe:


### PR DESCRIPTION
## Summary
- add a workflow_dispatch GitHub Actions workflow that installs Playwright browsers and runs the excavator crawl against example.com
- capture the crawl output and upload it as a run artifact for manual validation
- document the manual smoke workflow in the excavator plugin README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d195c7cd2c832a8df444d10d6b0623