### PR TITLE
Add JWT and Google API key detection to seer

### DIFF
--- a/plugins/seer/README.md
+++ b/plugins/seer/README.md
@@ -12,9 +12,11 @@ The detector library in [`internal/seer`](../../internal/seer) powers the plugin
 - AWS access key identifiers (e.g. `AKIA...`).
 - Slack tokens (`xoxb-`, `xoxp-`, `xoxa-`, `xoxr-`, `xoxs-`).
 - High-entropy generic API keys surfaced through common `api_key=`, `token=`, or `secret=` patterns.
+- Google API keys beginning with `AIza` that also satisfy entropy requirements.
+- JSON Web Tokens (JWTs) that contain valid base64url-encoded header and payload segments.
 - Email addresses to aid triage. Evidence is redacted to the first and last character of the local-part (for example `alerts@example.com` is reported as `a****s@example.com`).
 
-Evidence for tokens is redacted to only retain the last four characters (e.g. `AKIAABCDEFGHIJKLMNOP` becomes `****************MNOP`). This keeps operator tooling actionable without leaking the full secret.
+Evidence for tokens is redacted to only retain the last four characters (e.g. `AKIAABCDEFGHIJKLMNOP` becomes `****************MNOP`). This keeps operator tooling actionable without leaking the full secret. Never store real credentials in fixtures or logs—synthetic examples keep the training corpus safe.
 
 ## Configuration
 The binary accepts the following flags (defaults can also be provided through environment variables):
@@ -25,7 +27,7 @@ The binary accepts the following flags (defaults can also be provided through en
 | `--token` | `GLYPH_AUTH_TOKEN` | Authentication token for glyphd (defaults to `supersecrettoken`). |
 | `--allowlist` | `SEER_ALLOWLIST_FILE` | Optional path to a newline-separated allowlist file. Lines starting with `#` are treated as comments. |
 
-In addition, `SEER_ALLOWLIST` can supply a comma-separated list of allowlisted tokens or email addresses. All allowlist sources are merged, deduplicated case-insensitively, and applied before any findings are emitted.
+In addition, `SEER_ALLOWLIST` can supply a comma-separated list of allowlisted tokens or email addresses. All allowlist sources are merged, deduplicated case-insensitively, and applied before any findings are emitted. The plugin also skips binary payloads based on response metadata and byte heuristics to reduce noise from non-text artifacts.
 
 ## Safety
 Fixtures and documentation only contain fake credential shapes. Do not record genuine secrets in tests or repositories—always use synthetic values when exercising the detectors.

--- a/plugins/seer/tests/fixtures/binary.json
+++ b/plugins/seer/tests/fixtures/binary.json
@@ -1,0 +1,6 @@
+{
+  "name": "binary-skip",
+  "target": "https://example.com/assets",
+  "content": "\u0000\u0001\u0002AKIAABCDEFGHIJKLMNOP",
+  "expect": []
+}

--- a/plugins/seer/tests/fixtures/secrets.json
+++ b/plugins/seer/tests/fixtures/secrets.json
@@ -2,7 +2,7 @@
   "name": "secrets-detected",
   "target": "https://example.com/app",
   "allowlist": ["alerts@example.com"],
-  "content": "AWS key: AKIAABCDEFGHIJKLMNOP\nSlack token: xoxb-123456789012-abcdefghijklmnop\nGeneric key: api_key = sk_live_a1B2c3D4e5F6g7H8\nEmail: incident-response@example.com\nEmail: alerts@example.com",
+  "content": "AWS key: AKIAABCDEFGHIJKLMNOP\nSlack token: xoxb-123456789012-abcdefghijklmnop\nGeneric key: api_key = sk_live_a1B2c3D4e5F6g7H8\nGoogle key: AIzaSyA1234567890bcdefGhijklmnopqrstuVw\nJWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\nEmail: incident-response@example.com\nEmail: alerts@example.com",
   "expect": [
     {
       "type": "seer.aws_access_key",
@@ -19,6 +19,18 @@
       "severity": "med",
       "evidence": "sk_l…g7H8",
       "min_entropy": 3.5
+    },
+    {
+      "type": "seer.google_api_key",
+      "severity": "high",
+      "evidence": "AIza…tuVw",
+      "min_entropy": 3.5
+    },
+    {
+      "type": "seer.jwt_token",
+      "severity": "med",
+      "evidence": "eyJh…sw5c",
+      "min_entropy": 3.0
     },
     {
       "type": "seer.slack_token",


### PR DESCRIPTION
## Summary
- add JWT and Google API key detectors with entropy safeguards and metadata enrichment
- ensure seer plugin skips binary responses using content-type hints and new fixtures covering binaries and secrets
- document the expanded pattern coverage and safety guidance in the plugin README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d43207cad0832a86b82026afe22ed8