### PR TITLE
docs: add plugin author guide and example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,14 @@ build:
 validate-manifests:
 	@./hack/validate_manifests.sh
 
+.PHONY: new-plugin
+new-plugin:
+	@hack/new_plugin.sh "$(name)"
+
 .PHONY: plugins-skeleton
 plugins-skeleton: $(GLYPHCTL)
 	@set -euo pipefail; \
-		plugins="galdr-proxy cartographer excavator raider osint-well seer scribe ranker grapher cryptographer"; \
+	plugins="galdr-proxy cartographer excavator raider osint-well seer scribe ranker grapher cryptographer"; \
 		for plugin in $$plugins; do \
 			manifest="plugins/$${plugin}/manifest.json"; \
 			if [ ! -f "$$manifest" ]; then \
@@ -58,15 +62,15 @@ plugins-skeleton: $(GLYPHCTL)
 
 .PHONY: demo-report
 demo-report:
-        @mkdir -p out
-        @cp examples/findings-sample.jsonl out/findings.jsonl
-        @go run ./cmd/glyphctl report --input out/findings.jsonl --out out/report.md
-        @echo "Report written to out/report.md"
+	@mkdir -p out
+	@cp examples/findings-sample.jsonl out/findings.jsonl
+	@go run ./cmd/glyphctl report --input out/findings.jsonl --out out/report.md
+	@echo "Report written to out/report.md"
 
 .PHONY: crawl-demo
 crawl-demo:
-        @npm --prefix plugins/excavator install --no-audit --no-fund >/dev/null
-        @node plugins/excavator/crawl.js --target=https://example.com --depth=1
+	@npm --prefix plugins/excavator install --no-audit --no-fund >/dev/null
+	@node plugins/excavator/crawl.js --target=https://example.com --depth=1
 
 .PHONY: verify
 verify: build

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,15 @@
-# Plugin Roster
+# Plugin Author Guide
 
-The following plugins form the foundation of the Glyph platform. Each directory under `plugins/` contains a manifest, stub implementation, documentation, and test fixtures to accelerate future development.
+Glyph plugins are Go binaries that connect to the platform over gRPC using the SDK
+provided in `sdk/plugin-sdk`. This guide documents the lifecycle hooks exposed by
+the runtime, the capabilities that can be requested in a manifest, and the rules
+for emitting JSONL findings safely.
+
+## Plugin Roster
+
+The following plugins form the foundation of the Glyph platform. Each directory
+under `plugins/` contains a manifest, implementation, documentation, and test
+fixtures to accelerate future development.
 
 | Plugin | Description |
 | ------ | ----------- |
@@ -14,5 +23,100 @@ The following plugins form the foundation of the Glyph platform. Each directory 
 | `ranker` | Prioritization service that scores leads and findings to focus remediation efforts. |
 | `grapher` | Relationship engine that models assets and signals as a navigable graph. |
 | `cryptographer` | CyberChef-inspired utility UI for transforming payloads during investigations. |
+| `example-hello` | Minimal starter plugin that emits a greeting finding during startup. |
 
-Refer to each plugin's README for setup guidance and roadmap notes.
+## Getting started
+
+1. Scaffold a new plugin with `make new-plugin name=<id>`. The target creates a
+   directory under `plugins/<id>/` with a manifest and Go stub wired to the SDK.
+   The stub compiles out of the box so you can iterate from a working baseline.
+2. Study `plugins/example-hello/` for a compact end-to-end example. It includes a
+   manifest, runnable plugin, and test fixture demonstrating how to assert emitted
+   findings.
+3. Run `go test ./...` frequently to execute plugin unit tests alongside the rest
+   of the repository. The example plugin test shows how to stand up the in-memory
+   bus exposed by `internal/bus` so findings can be asserted without a full Glyph
+   deployment.
+
+## Lifecycle hooks
+
+Plugins implement behaviour by registering callbacks in `pluginsdk.Hooks` before
+calling `pluginsdk.Run` or `pluginsdk.Serve`. The SDK manages the connection to
+`glyphd`, performs capability enforcement, and invokes hooks on the same goroutine
+that receives events.
+
+### `OnStart(*pluginsdk.Context) error`
+
+Invoked once after the plugin authenticates with `glyphd`. Use the hook for
+lightweight initialisation, emitting startup findings, and launching background
+goroutines scoped to the supplied context. Returning an error terminates the
+plugin immediately.
+
+### `OnHTTPPassive(*pluginsdk.Context, pluginsdk.HTTPPassiveEvent) error`
+
+Triggered for every passive HTTP response streamed to the plugin when
+`CAP_HTTP_PASSIVE` is granted. The hook is ideal for analytics that react to
+captured traffic. Returning an error stops the event loop and terminates the
+plugin.
+
+The SDK automatically wires graceful shutdown through `pluginsdk.Run`, cancelling
+the context when the process receives `SIGINT` or `SIGTERM`. Long-running work
+should honour `ctx.Context().Done()` to exit promptly.
+
+## Capabilities
+
+Capabilities gate access to host features. Declare them in `manifest.json` under
+`capabilities`, and ensure the same set is configured in `pluginsdk.Config` so the
+SDK can enforce permissions locally.
+
+| Capability | Purpose |
+| ---------- | ------- |
+| `CAP_EMIT_FINDINGS` | Allows the plugin to emit findings back to the host via `ctx.EmitFinding`. |
+| `CAP_HTTP_PASSIVE` | Streams passive HTTP flow events into the plugin. Required when registering `OnHTTPPassive`. |
+| `CAP_HTTP_ACTIVE` | Grants access to active HTTP helpers exposed by `internal/netgate` for probe-style plugins. |
+| `CAP_WS` | Enables WebSocket interaction primitives for realtime protocol analysis. |
+| `CAP_SPIDER` | Permits scheduling crawl jobs through the Glyph spider/queue components. |
+| `CAP_REPORT` | Allows plugins to submit rendered reports that downstream tooling (for example `scribe`) can publish. |
+| `CAP_STORAGE` | Grants access to managed storage buckets for large artefacts or binary blobs. |
+
+Only request capabilities the plugin actively needs. The manifest validator under
+`hack/validate_manifests.sh` enforces the whitelist above.
+
+## Emitting findings
+
+Findings are serialised to `findings.jsonl` using the schema defined in
+`plugins/findings.schema.json`. The SDK handles common safety checks when calling
+`ctx.EmitFinding`, but plugin authors must still:
+
+- Provide non-empty `Type` and `Message` fields. Use reverse-DNS style identifiers
+  for `Type` to keep namespaces distinct.
+- Populate `Target` and `Evidence` when applicable so analysts can reproduce the
+  issue. Empty strings are omitted for compactness.
+- Select an appropriate severity (`SeverityInfo`, `SeverityLow`, `SeverityMedium`,
+  `SeverityHigh`, or `SeverityCritical`). The SDK normalises timestamps to
+  RFC3339 and generates ULIDs automatically when `ID` is left blank.
+- Store additional context in the `Metadata` map. Keys must be non-empty strings.
+
+When exporting findings to disk or downstream systems, the host enforces the
+schema described in `specs/finding.md`. Run `go run ./cmd/glyphctl findings
+validate --input <path>` to verify JSONL output before distribution.
+
+## Performance and safety guidelines
+
+- **Respect backpressure**: Hooks run on the gRPC receive loop. Avoid blocking
+  operations inside handlers. Offload expensive work to goroutines and use the
+  provided context for cancellation.
+- **Timeout external calls**: Always bound network and filesystem operations with
+  timeouts derived from the hook context to prevent hung plugins.
+- **Limit memory usage**: Stream large payloads instead of buffering them in
+  memory. Persist bulky artefacts with `CAP_STORAGE` rather than embedding them in
+  findings.
+- **Validate inputs**: Treat host-provided data (including HTTP flows) as
+  untrusted. Parse defensively and handle errors gracefully to avoid terminating
+  the plugin loop.
+- **Log responsibly**: Use the `ctx.Logger()` provided by the SDK so log output is
+  correlated with the plugin name. Avoid logging secrets such as authentication
+  tokens.
+
+Following these practices keeps plugins responsive, observable, and safe to run in
+shared Glyph deployments.

--- a/hack/new_plugin.sh
+++ b/hack/new_plugin.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+        echo "usage: hack/new_plugin.sh <plugin-name>" >&2
+        exit 1
+fi
+
+name="$1"
+if [[ -z "$name" ]]; then
+        echo "error: plugin name is required" >&2
+        exit 1
+fi
+if [[ "$name" =~ [^a-z0-9-] ]]; then
+        echo "error: plugin name must match [a-z0-9-]+" >&2
+        exit 1
+fi
+if [[ "$name" == -* ]]; then
+        echo "error: plugin name must not start with '-'" >&2
+        exit 1
+fi
+
+dir="plugins/${name}"
+if [[ -e "$dir" ]]; then
+        echo "error: ${dir} already exists" >&2
+        exit 1
+fi
+
+mkdir -p "$dir"
+
+cat >"${dir}/manifest.json" <<EOF_MANIFEST
+{
+  "name": "${name}",
+  "version": "0.1.0",
+  "entry": "${name}",
+  "artifact": "plugins/${name}/main.go",
+  "capabilities": ["CAP_EMIT_FINDINGS"]
+}
+EOF_MANIFEST
+
+cat >"${dir}/main.go" <<EOF_MAIN
+package main
+
+import (
+        "flag"
+        "log/slog"
+        "os"
+
+        pluginsdk "github.com/RowanDark/Glyph/sdk/plugin-sdk"
+)
+
+func main() {
+        var (
+                serverAddr = flag.String("server", "127.0.0.1:50051", "glyphd gRPC address")
+                authToken  = flag.String("token", "dev-token", "authentication token")
+        )
+        flag.Parse()
+
+        logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+        cfg := pluginsdk.Config{
+                PluginName: "${name}",
+                Host:       *serverAddr,
+                AuthToken:  *authToken,
+                Capabilities: []pluginsdk.Capability{
+                        pluginsdk.CapabilityEmitFindings,
+                },
+                Logger: logger,
+        }
+
+        hooks := pluginsdk.Hooks{
+                OnStart: func(ctx *pluginsdk.Context) error {
+                        ctx.Logger().Info("plugin initialised")
+                        return nil
+                },
+        }
+
+        if err := pluginsdk.Run(cfg, hooks); err != nil {
+                logger.Error("plugin terminated", "error", err)
+                os.Exit(1)
+        }
+}
+EOF_MAIN
+
+gofmt -w "${dir}/main.go"
+
+echo "Created plugin skeleton in ${dir}"

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,12 +2,15 @@
 
 Glyph plugins are Go binaries that connect to `glyphd` using the SDK in
 `sdk/plugin-sdk`. The SDK handles the gRPC transport, lifecycle hooks and safely
-emitting findings back to the host.
+emitting findings back to the host. Consult [docs/plugins.md](../docs/plugins.md)
+for the full author guide, capability matrix, and JSONL emission rules.
 
 ## Hello world example
 
 The sample below emits a single finding when the plugin starts. It matches the
-behaviour of the `emit-on-start` sample bundled with the repository.
+behaviour of the `emit-on-start` sample bundled with the repository. A complete
+end-to-end reference (manifest, plugin, and test) lives in
+`plugins/example-hello/`.
 
 ```go
 package main

--- a/plugins/example-hello/main.go
+++ b/plugins/example-hello/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"flag"
+	"log/slog"
+	"os"
+	"time"
+
+	pluginsdk "github.com/RowanDark/Glyph/sdk/plugin-sdk"
+)
+
+func main() {
+	var (
+		serverAddr = flag.String("server", "127.0.0.1:50051", "glyphd gRPC address")
+		authToken  = flag.String("token", "dev-token", "authentication token")
+	)
+	flag.Parse()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	cfg := pluginsdk.Config{
+		PluginName: "example-hello",
+		Host:       *serverAddr,
+		AuthToken:  *authToken,
+		Capabilities: []pluginsdk.Capability{
+			pluginsdk.CapabilityEmitFindings,
+		},
+		Logger: logger,
+	}
+
+	hooks := pluginsdk.Hooks{
+		OnStart: func(ctx *pluginsdk.Context) error {
+			ctx.Logger().Info("sending hello finding")
+			return ctx.EmitFinding(pluginsdk.Finding{
+				Type:       "example.hello",
+				Message:    "Hello from example-hello!",
+				Target:     "example://hello",
+				Severity:   pluginsdk.SeverityInfo,
+				DetectedAt: time.Now().UTC(),
+				Metadata: map[string]string{
+					"example": "true",
+				},
+			})
+		},
+	}
+
+	if err := pluginsdk.Run(cfg, hooks); err != nil {
+		logger.Error("plugin terminated", "error", err)
+		os.Exit(1)
+	}
+}

--- a/plugins/example-hello/main_test.go
+++ b/plugins/example-hello/main_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/bus"
+	"github.com/RowanDark/Glyph/internal/findings"
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
+	"google.golang.org/grpc"
+)
+
+type expectedFinding struct {
+	Type     string `json:"type"`
+	Message  string `json:"message"`
+	Target   string `json:"target"`
+	Severity string `json:"severity"`
+}
+
+func TestExampleHelloEmitsFinding(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	findingsBus := findings.NewBus()
+	server := bus.NewServer("test-token", findingsBus)
+	grpcServer := grpc.NewServer()
+	pb.RegisterPluginBusServer(grpcServer, server)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = lis.Close()
+	})
+
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Logf("grpc server error: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		grpcServer.GracefulStop()
+	})
+
+	go server.StartEventGenerator(ctx)
+
+	findingsCh := findingsBus.Subscribe(ctx)
+
+	cmdCtx, cmdCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cmdCancel()
+
+	var stdout, stderr bytes.Buffer
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	binaryPath := filepath.Join(t.TempDir(), "example-hello")
+	buildCmd := exec.CommandContext(cmdCtx, "go", "build", "-o", binaryPath, ".")
+	buildCmd.Dir = wd
+	var buildOutput bytes.Buffer
+	buildCmd.Stdout = &buildOutput
+	buildCmd.Stderr = &buildOutput
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("build plugin: %v\noutput: %s", err, buildOutput.String())
+	}
+
+	cmd := exec.CommandContext(cmdCtx, binaryPath, "--server", lis.Addr().String(), "--token", "test-token")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start plugin: %v", err)
+	}
+
+	var finding findings.Finding
+	select {
+	case finding = <-findingsCh:
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for finding\nstdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join("testdata", "expected_finding.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var expected expectedFinding
+	if err := json.Unmarshal(data, &expected); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	if finding.ID == "" {
+		t.Fatal("expected finding id to be populated")
+	}
+	if finding.Version != findings.SchemaVersion {
+		t.Fatalf("unexpected schema version: %s", finding.Version)
+	}
+	if finding.Type != expected.Type {
+		t.Fatalf("unexpected finding type: %s", finding.Type)
+	}
+	if finding.Message != expected.Message {
+		t.Fatalf("unexpected finding message: %s", finding.Message)
+	}
+	if finding.Target != expected.Target {
+		t.Fatalf("unexpected finding target: %s", finding.Target)
+	}
+	if string(finding.Severity) != expected.Severity {
+		t.Fatalf("unexpected severity: %s", finding.Severity)
+	}
+	if finding.DetectedAt.IsZero() {
+		t.Fatal("expected detected_at timestamp to be set")
+	}
+	if !strings.HasPrefix(finding.Plugin, "example-hello-") {
+		t.Fatalf("unexpected plugin id: %s", finding.Plugin)
+	}
+	if finding.Metadata["example"] != "true" {
+		t.Fatalf("missing metadata entry: %v", finding.Metadata)
+	}
+
+	if cmd.Process != nil {
+		_ = cmd.Process.Signal(os.Interrupt)
+	}
+
+	if err := cmd.Wait(); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "signal: killed") && !strings.Contains(err.Error(), "signal: interrupt") {
+		t.Fatalf("plugin exit: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+}

--- a/plugins/example-hello/manifest.json
+++ b/plugins/example-hello/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "example-hello",
+  "version": "0.1.0",
+  "entry": "example-hello",
+  "artifact": "plugins/example-hello/main.go",
+  "capabilities": ["CAP_EMIT_FINDINGS"]
+}

--- a/plugins/example-hello/testdata/expected_finding.json
+++ b/plugins/example-hello/testdata/expected_finding.json
@@ -1,0 +1,6 @@
+{
+  "type": "example.hello",
+  "message": "Hello from example-hello!",
+  "target": "example://hello",
+  "severity": "info"
+}


### PR DESCRIPTION
## Summary
- expand `docs/plugins.md` into a plugin author guide covering lifecycle hooks, capabilities, and JSONL rules
- link the guide from the plugin README and add a minimal `example-hello` plugin with tests and fixtures
- add a `make new-plugin` scaffold target backed by `hack/new_plugin.sh`

## Testing
- `go test ./...`
- `make validate-manifests` *(fails: npm cannot download ajv-cli in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d51e72d650832aa5438e0bc4f2dcbd