### PR TITLE
Embed glyphctl versioning and add security docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
           name: Glyph ${{ github.ref_name }}
           body: |
             ## Glyph ${{ github.ref_name }}
+            This release publishes glyphctl binaries for Linux and macOS (amd64 and arm64).
+            SHA256 checksum files are included alongside the archives for verification.
             See the [CHANGELOG](https://github.com/RowanDark/Glyph/blob/${{ github.ref_name }}/CHANGELOG.md) for details.
           files: |
             dist/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Glyph
+
+Glyph is an automation toolkit for orchestrating red-team and detection workflows.
+It coordinates plugins such as Galdr (HTTP rewriting proxy), Excavator (Playwright
+crawler), Seer (secret/PII detector), Ranker, and Scribe to turn raw telemetry into
+ranked findings and human-readable reports.
+
+## Quickstart
+
+Clone the repository and run the end-to-end demo target:
+
+```bash
+make demo
+```
+
+The pipeline builds fresh binaries, starts Galdr and Seer locally, captures a crawl
+with Excavator, ranks any emitted findings, and renders an HTML summary. The terminal
+prints the absolute path to `report.html` once the run completes. See
+[`docs/quickstart.md`](docs/quickstart.md) for a full walkthrough and troubleshooting
+notes.
+
+## Documentation
+
+* [Configuration reference](docs/configuration.md)
+* [Plugin catalogue](docs/plugins.md)
+* [Threat model](docs/security/threat-model.md)
+* [Contributing guide](CONTRIBUTING.md)
+
+## Security
+
+Please review our [security policy](SECURITY.md) for instructions on reporting
+vulnerabilities and understanding the supported scope.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+We take the security of Glyph deployments seriously. Responsible disclosure helps the
+community remediate issues quickly and protect operators who rely on the toolkit.
+
+## Reporting a Vulnerability
+
+* **Do not file public GitHub issues for security problems.**
+* Submit a private report through the [GitHub Security Advisories portal](https://github.com/RowanDark/Glyph/security/advisories/new).
+* If you cannot use the portal, email the maintainers at [security@rowandark.dev](mailto:security@rowandark.dev).
+
+Please include the following details to help us triage your report:
+
+* A description of the vulnerability and the affected Glyph components.
+* Steps to reproduce the issue, including configuration snippets or sample inputs.
+* Any suggested mitigations.
+
+We aim to acknowledge new reports within **two business days**. Once validated we will
+coordinate a fix, publish release notes, and credit reporters who opt in to disclosure.
+
+## Scope
+
+The policy covers the Glyph core (`glyphd`, `glyphctl`), bundled plugins, SDKs, and
+example tooling. Third-party plugins or forks maintained outside this repository are
+out of scope.
+
+## Coordinated Disclosure
+
+We ask reporters to keep issues private for at least **30 days** after confirmation to
+give maintainers time to ship patches. We will provide status updates throughout the
+process and share a final advisory once mitigations are available.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,36 @@
+# Threat Model Overview
+
+Glyph is designed to run untrusted plugins while protecting the host operator and
+keeping findings attributable. This document summarises the guardrails that ship with
+the default configuration.
+
+## Plugin sandboxing
+
+Glyph runs every plugin in a dedicated subprocess with strict resource limits. The
+sandbox code assigns each run a temporary working directory and constrains `HOME`,
+`TMPDIR`, and the inherited `PATH` to that directory so plugins cannot write outside
+of their scratch space by default. [`runner.Config`](../../internal/plugins/runner/runner.go)
+exposes CPU-, memory-, and wall-clock limits that are enforced through POSIX
+`RLIMIT` calls before the plugin starts. Exceeding these limits terminates the process
+group and propagates an error back to the supervisor.
+
+The supervisor captures the termination reason and emits a
+`glyph.supervisor.termination` finding containing structured metadata such as the task
+ID, CPU/heap usage, and configured timeouts. Operations teams can trace why a plugin
+stopped and correlate the event with downstream automation.
+
+## Network posture
+
+The glyphd proxy is disabled by default. The built-in configuration keeps
+`proxy.enable` set to `false`, leaving Glyph in a no-network posture unless operators
+explicitly toggle interception through `glyph.yml` or environment overrides. When the
+proxy is enabled it must be pointed at explicit rule and history paths, reinforcing
+intentional deployment rather than accidental active scanning.
+
+## Finding provenance
+
+Findings emitted by core detectors include enough metadata to audit their origin.
+Seer annotates each result with the pattern identifier, the number of characters
+matched, entropy measurements, and the redacted evidence that triggered the alert.
+Combined with the supervisor termination findings above, teams can establish an
+end-to-end paper trail for every automated decision Glyph makes.


### PR DESCRIPTION
## Summary
- stamp glyphctl builds with the git describe version, reuse the flagging in the demo flow, and note release assets in the tag workflow
- assert Galdr’s reverse proxy emits structured error logs and document Seer’s default thresholds plus allowlisting guidance
- add a top-level README alongside security policy and threat model documentation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d57f630bb0832ab6f8828df5eff585