### PR TITLE
Add Homebrew tap automation workflow

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -1,0 +1,41 @@
+name: Bump Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    if: startsWith(github.event.release.tag_name, 'v') && secrets.HOMEBREW_TAP_TOKEN != ''
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ github.event.release.tag_name }}
+      TAP_REPO: RowanDark/homebrew-glyph
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      - name: Checkout Glyph
+        uses: actions/checkout@v4
+
+      - name: Clone tap repository
+        run: |
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+
+      - name: Update formula
+        run: |
+          scripts/update_homebrew_formula.sh "${TAG_NAME}" tap
+
+      - name: Commit and push changes
+        run: |
+          cd tap
+          if git status --porcelain | grep . >/dev/null 2>&1; then
+            git config user.name "glyph-bot"
+            git config user.email "glyph-bot@users.noreply.github.com"
+            git add Formula/glyph.rb
+            git commit -m "Bump glyph to ${TAG_NAME}"
+            git push origin HEAD
+          else
+            echo "Homebrew formula already up to date"
+          fi

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ It coordinates plugins such as Galdr (HTTP rewriting proxy), Excavator (Playwrig
 crawler), Seer (secret/PII detector), Ranker, and Scribe to turn raw telemetry into
 ranked findings and human-readable reports.
 
+## Installation
+
+macOS users can install the prebuilt `glyphctl` binary via Homebrew using the
+[RowanDark/homebrew-glyph tap](https://github.com/RowanDark/homebrew-glyph):
+
+```bash
+brew install rowandark/glyph/glyph
+```
+
 ## Quickstart
 
 Clone the repository and run the end-to-end demo target:

--- a/scripts/update_homebrew_formula.sh
+++ b/scripts/update_homebrew_formula.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+        echo "Usage: $0 <tag> <tap_dir>" >&2
+        exit 1
+fi
+
+TAG="$1"
+TAP_DIR="$2"
+VERSION="${TAG#v}"
+
+if [[ -z "$VERSION" ]]; then
+        echo "Unable to determine version from tag: $TAG" >&2
+        exit 1
+fi
+
+RELEASE_OWNER="RowanDark"
+RELEASE_REPO="Glyph"
+
+BASE_URL="https://github.com/${RELEASE_OWNER}/${RELEASE_REPO}/releases/download/${TAG}"
+ARM_ARCHIVE="glyphctl_${VERSION}_darwin_arm64.tar.gz"
+INTEL_ARCHIVE="glyphctl_${VERSION}_darwin_amd64.tar.gz"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl -sSLf "${BASE_URL}/${ARM_ARCHIVE}" -o "${TMP_DIR}/${ARM_ARCHIVE}"
+ARM_SHA="$(sha256sum "${TMP_DIR}/${ARM_ARCHIVE}" | awk '{print $1}')"
+
+curl -sSLf "${BASE_URL}/${INTEL_ARCHIVE}" -o "${TMP_DIR}/${INTEL_ARCHIVE}"
+INTEL_SHA="$(sha256sum "${TMP_DIR}/${INTEL_ARCHIVE}" | awk '{print $1}')"
+
+FORMULA_DIR="${TAP_DIR}/Formula"
+mkdir -p "$FORMULA_DIR"
+FORMULA_PATH="${FORMULA_DIR}/glyph.rb"
+
+cat >"$FORMULA_PATH" <<'FORMULA'
+class Glyph < Formula
+  desc "Automation toolkit for orchestrating red-team and detection workflows"
+  homepage "https://github.com/${RELEASE_OWNER}/${RELEASE_REPO}"
+  version "${VERSION}"
+
+  on_macos do
+    on_arm do
+      url "${BASE_URL}/${ARM_ARCHIVE}"
+      sha256 "${ARM_SHA}"
+    end
+
+    on_intel do
+      url "${BASE_URL}/${INTEL_ARCHIVE}"
+      sha256 "${INTEL_SHA}"
+    end
+  end
+
+  def install
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    target = "glyphctl_#{version}_darwin_#{arch}"
+    bin.install "#{target}/glyphctl"
+    prefix.install "#{target}/LICENSE"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/glyphctl version")
+  end
+end
+FORMULA
+
+# Normalize Ruby formatting
+if command -v brew >/dev/null 2>&1; then
+        brew style --fix "$FORMULA_PATH" || true
+fi


### PR DESCRIPTION
## Summary
- document the Homebrew tap and install command in the README
- add a script that regenerates the tap formula from the latest release artifacts
- create a release-triggered workflow to push updated formulas to the tap repository

## Testing
- bash -n scripts/update_homebrew_formula.sh

------
https://chatgpt.com/codex/tasks/task_e_68d66b85efd4832aac3c30528c351337