### PR TITLE
Fix provenance filenames for release workflows

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -18,9 +18,11 @@ jobs:
       contents: write
       id-token: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generic-post-build-provenance@v1.10.0
+    env:
+      RELEASE_REF: ${{ github.event.workflow_run.head_branch || github.event.workflow_run.head_sha || replace(github.event.workflow_run.display_title, ' ', '-') }}
     with:
       slsa-workflow-recipient: ${{ github.event.workflow_run.url }}
-      provenance-name: glyph-${{ github.event.workflow_run.head_branch }}-binaries.intoto.jsonl
+      provenance-name: glyph-${{ env.RELEASE_REF }}-binaries.intoto.jsonl
       download-artifacts: true
       artifacts: release-dist
       subject-path: |
@@ -36,9 +38,11 @@ jobs:
       id-token: write
       packages: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/container-post-push-provenance@v1.10.0
+    env:
+      RELEASE_REF: ${{ github.event.workflow_run.head_branch || github.event.workflow_run.head_sha || replace(github.event.workflow_run.display_title, ' ', '-') }}
     with:
       slsa-workflow-recipient: ${{ github.event.workflow_run.url }}
-      provenance-name: glyph-${{ github.event.workflow_run.head_branch }}-image.intoto.jsonl
+      provenance-name: glyph-${{ env.RELEASE_REF }}-image.intoto.jsonl
       download-artifacts: true
       artifacts: release-image-metadata
       digest-file: image-digest.txt


### PR DESCRIPTION
## Summary
- ensure SLSA provenance assets use a release reference even when workflow_run.head_branch is null
- reuse the derived reference for both binaries and container provenance uploads to avoid name collisions

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d6743cfa6c832a86ec484b34dbc2b8