### PR TITLE
chore: orchestrate releases with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,16 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
-  release:
+  goreleaser:
+    name: GoReleaser
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,27 +25,25 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build release artifacts
-        run: scripts/build_release.sh
-
-      - name: Upload release artifacts for provenance
-        uses: actions/upload-artifact@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         with:
-          name: release-dist
-          path: dist/
+          platforms: all
 
-      - name: Publish release
-        uses: softprops/action-gh-release@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Glyph ${{ github.ref_name }}
-          body: |
-            ## Glyph ${{ github.ref_name }}
-            This release publishes glyphctl binaries for Linux and macOS (amd64 and arm64).
-            SHA256 checksum files are included alongside the archives for verification.
-            See the [CHANGELOG](https://github.com/RowanDark/Glyph/blob/${{ github.ref_name }}/CHANGELOG.md) for details.
-          files: |
-            dist/*.tar.gz
-            dist/*SHA256SUMS.txt
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,95 @@
+project_name: glyph
+
+before:
+  hooks:
+    - go test ./...
+
+builds:
+  - id: glyphctl
+    main: ./cmd/glyphctl
+    binary: glyphctl
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+  - id: glyphd
+    main: ./cmd/glyphd
+    binary: glyphd
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+  - id: quickstartseed
+    main: ./cmd/quickstartseed
+    binary: quickstartseed
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: glyphctl-archive
+    builds:
+      - glyphctl
+    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+  - id: glyphd-archive
+    builds:
+      - glyphd
+    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+  - id: quickstartseed-archive
+    builds:
+      - quickstartseed
+    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "glyph_{{ .Version }}_checksums.txt"
+
+dockers:
+  - id: glyphctl-image
+    use: buildx
+    image_templates:
+      - ghcr.io/rowandark/glyphctl:{{ .Version }}
+      - ghcr.io/rowandark/glyphctl:latest
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--build-arg=VERSION={{ .Version }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+
+release:
+  github:
+    owner: RowanDark
+    name: Glyph
+
+changelog:
+  use: git


### PR DESCRIPTION
## Summary
- add a GoReleaser configuration that builds glyphctl, glyphd, quickstartseed, archives, checksums, and a container image
- update the release workflow to invoke GoReleaser with Buildx and GHCR authentication

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68d6af9ca284832abbfa8d32449e2691