### PR TITLE
ci: expand fuzz corpora for URLs, headers, and JSONL

### DIFF
--- a/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-array
+++ b/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-array
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"items\":[1,2,3]}\n{\"items\":[]}\n")

--- a/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-escaped-newline
+++ b/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-escaped-newline
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"message\":\"first line\\nsecond\"}\n")

--- a/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-large-numbers
+++ b/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-large-numbers
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"count\":999999999999,\"values\":[-1,0,1]}\n")

--- a/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-whitespace-padding
+++ b/internal/reporter/testdata/fuzz/FuzzJSONLReadAll/seed-whitespace-padding
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("  \n{\"message\":\" spaced \"}\n\n")

--- a/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-invalid-encoding
+++ b/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-invalid-encoding
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("https://example.com/%zz/resource")

--- a/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-ipv6
+++ b/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-ipv6
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("https://[2001:db8::1]:8080/metrics")

--- a/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-mixed-case-scheme
+++ b/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-mixed-case-scheme
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("HtTp://Example.COM/path?q=1#frag")

--- a/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-relative-scheme
+++ b/plugins/grapher/testdata/fuzz/FuzzNormalizeURL/seed-relative-scheme
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("//example.com:9090/api")

--- a/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-duplicate-headers
+++ b/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-duplicate-headers
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Type: application/json\nX-Custom: value\n\n{}")

--- a/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-folded-header
+++ b/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-folded-header
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("HTTP/1.1 200 OK\nX-Trace: part1\n part2\nContent-Length: 5\n\nhello")

--- a/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-status-missing
+++ b/sdk/plugin-sdk/testdata/fuzz/FuzzHeaderParse/seed-status-missing
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("Content-Type: text/plain\nX-Thing: true\n\nbody without status")


### PR DESCRIPTION
## Summary
- add additional normalize URL fuzz seeds covering mixed-case schemes, IPv6 hosts, scheme-relative URLs, and invalid escapes
- expand the header parse corpus with duplicate headers, folded values, and missing status lines
- grow the JSONL corpus with whitespace padding, large numbers, escaped newlines, and multi-object documents

## Testing
- go test ./plugins/grapher -run FuzzNormalizeURL -fuzz FuzzNormalizeURL -fuzztime=1s
- go test ./sdk/plugin-sdk -run FuzzHeaderParse -fuzz FuzzHeaderParse -fuzztime=1s
- go test ./internal/reporter -run FuzzJSONLReadAll -fuzz FuzzJSONLReadAll -fuzztime=1s


------
https://chatgpt.com/codex/tasks/task_e_68d6b97a9404832aa802781fd88f3801