### PR TITLE
Enforce plugin capability grants with sandbox tokens

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -68,7 +68,10 @@ should honour `ctx.Context().Done()` to exit promptly.
 
 Capabilities gate access to host features. Declare them in `manifest.json` under
 `capabilities`, and ensure the same set is configured in `pluginsdk.Config` so the
-SDK can enforce permissions locally.
+SDK can enforce permissions locally. At runtime the host injects a
+`GLYPH_CAPABILITY_TOKEN` environment variable that must be supplied via
+`pluginsdk.Config.CapabilityToken`; the host refuses the handshake if the token is
+missing or the plugin requests undeclared privileges.
 
 | Capability | Purpose |
 | ---------- | ------- |

--- a/hack/new_plugin.sh
+++ b/hack/new_plugin.sh
@@ -45,6 +45,7 @@ import (
         "flag"
         "log/slog"
         "os"
+        "strings"
 
         pluginsdk "github.com/RowanDark/Glyph/sdk/plugin-sdk"
 )
@@ -58,10 +59,17 @@ func main() {
 
         logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
+        capToken := strings.TrimSpace(os.Getenv("GLYPH_CAPABILITY_TOKEN"))
+        if capToken == "" {
+                logger.Error("missing GLYPH_CAPABILITY_TOKEN environment variable")
+                os.Exit(1)
+        }
+
         cfg := pluginsdk.Config{
-                PluginName: "${name}",
-                Host:       *serverAddr,
-                AuthToken:  *authToken,
+                PluginName:      "${name}",
+                Host:            *serverAddr,
+                AuthToken:       *authToken,
+                CapabilityToken: capToken,
                 Capabilities: []pluginsdk.Capability{
                         pluginsdk.CapabilityEmitFindings,
                 },

--- a/internal/plugins/capabilities/manager.go
+++ b/internal/plugins/capabilities/manager.go
@@ -1,0 +1,154 @@
+package capabilities
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultTokenTTL = time.Minute
+
+// Manager issues and validates short-lived capability grants for plugins.
+type Manager struct {
+	mu     sync.Mutex
+	grants map[string]grant
+	clock  func() time.Time
+	ttl    time.Duration
+}
+
+type grant struct {
+	plugin       string
+	capabilities map[string]struct{}
+	expires      time.Time
+}
+
+// Option configures the manager.
+type Option func(*Manager)
+
+// WithClock overrides the clock used for expiry calculations.
+func WithClock(clock func() time.Time) Option {
+	return func(m *Manager) {
+		if clock != nil {
+			m.clock = clock
+		}
+	}
+}
+
+// WithTTL overrides the duration for which issued tokens remain valid.
+func WithTTL(ttl time.Duration) Option {
+	return func(m *Manager) {
+		if ttl > 0 {
+			m.ttl = ttl
+		}
+	}
+}
+
+// NewManager constructs a Manager with sane defaults.
+func NewManager(opts ...Option) *Manager {
+	m := &Manager{
+		grants: make(map[string]grant),
+		clock:  time.Now,
+		ttl:    defaultTokenTTL,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// Issue registers the provided capability list for the plugin and returns a
+// short-lived token that must be presented during the runtime handshake.
+func (m *Manager) Issue(plugin string, capabilities []string) (token string, expires time.Time, err error) {
+	plugin = strings.TrimSpace(plugin)
+	if plugin == "" {
+		return "", time.Time{}, errors.New("plugin name is required")
+	}
+	capSet := make(map[string]struct{}, len(capabilities))
+	for _, cap := range capabilities {
+		cap = strings.ToUpper(strings.TrimSpace(cap))
+		if cap == "" {
+			continue
+		}
+		capSet[cap] = struct{}{}
+	}
+	if len(capSet) == 0 {
+		return "", time.Time{}, errors.New("at least one capability is required")
+	}
+
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", time.Time{}, fmt.Errorf("generate token: %w", err)
+	}
+	token = base64.RawURLEncoding.EncodeToString(raw)
+
+	expires = m.clock().Add(m.ttl)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.grants[token] = grant{plugin: plugin, capabilities: capSet, expires: expires}
+	return token, expires, nil
+}
+
+// Validate consumes the token and ensures the requested capabilities are a
+// subset of the issued grant. The returned slice contains the normalised
+// capability names that remain valid for the session.
+func (m *Manager) Validate(token, plugin string, requested []string) ([]string, error) {
+	token = strings.TrimSpace(token)
+	plugin = strings.TrimSpace(plugin)
+	if token == "" {
+		return nil, errors.New("capability token is required")
+	}
+	if plugin == "" {
+		return nil, errors.New("plugin name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	grant, ok := m.grants[token]
+	if !ok {
+		return nil, errors.New("capability token not recognised")
+	}
+	delete(m.grants, token)
+
+	if grant.plugin != plugin {
+		return nil, errors.New("capability token issued for different plugin")
+	}
+	if m.clock().After(grant.expires) {
+		return nil, errors.New("capability token expired")
+	}
+
+	if len(requested) == 0 {
+		return nil, errors.New("no capabilities requested")
+	}
+
+	normalised := make([]string, 0, len(requested))
+	for _, cap := range requested {
+		cap = strings.ToUpper(strings.TrimSpace(cap))
+		if cap == "" {
+			continue
+		}
+		if _, ok := grant.capabilities[cap]; !ok {
+			return nil, fmt.Errorf("capability %s not granted", cap)
+		}
+		normalised = append(normalised, cap)
+	}
+	if len(normalised) == 0 {
+		return nil, errors.New("no valid capabilities requested")
+	}
+
+	slices.Sort(normalised)
+	return normalised, nil
+}
+
+// Remaining returns the number of active grants. It is intended for testing.
+func (m *Manager) Remaining() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.grants)
+}

--- a/internal/plugins/capabilities/manager_test.go
+++ b/internal/plugins/capabilities/manager_test.go
@@ -1,0 +1,74 @@
+package capabilities
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManagerIssueAndValidate(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	manager := NewManager(WithClock(clock), WithTTL(time.Minute))
+
+	token, expires, err := manager.Issue("plugin", []string{"cap_one", "CAP_TWO"})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected token to be populated")
+	}
+	if !expires.Equal(now.Add(time.Minute)) {
+		t.Fatalf("unexpected expiry: %s", expires)
+	}
+
+	caps, err := manager.Validate(token, "plugin", []string{"cap_two"})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(caps) != 1 || caps[0] != "CAP_TWO" {
+		t.Fatalf("unexpected capabilities: %v", caps)
+	}
+
+	if manager.Remaining() != 0 {
+		t.Fatalf("expected grant to be consumed, remaining=%d", manager.Remaining())
+	}
+}
+
+func TestManagerValidateRejectsEscalation(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	manager := NewManager(WithClock(clock), WithTTL(time.Minute))
+
+	token, _, err := manager.Issue("plugin", []string{"CAP_ONE"})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+
+	_, err = manager.Validate(token, "plugin", []string{"CAP_TWO"})
+	if err == nil {
+		t.Fatal("expected validation to fail")
+	}
+	if !strings.Contains(err.Error(), "CAP_TWO") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestManagerValidateRejectsExpired(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	manager := NewManager(WithClock(clock), WithTTL(time.Millisecond))
+
+	token, _, err := manager.Issue("plugin", []string{"CAP_ONE"})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+
+	// Advance clock beyond expiry.
+	late := func() time.Time { return now.Add(time.Second) }
+	manager.clock = late
+
+	if _, err := manager.Validate(token, "plugin", []string{"CAP_ONE"}); err == nil {
+		t.Fatal("expected expired token to be rejected")
+	}
+}

--- a/plugins/ALLOWLIST
+++ b/plugins/ALLOWLIST
@@ -1,3 +1,3 @@
 # SHA-256 allowlist for trusted plugin artifacts
 42f6b8e3ba4bd5c4b36c4b6e8cf694a3d50c5b14c568d6e27ce2823a87848511 samples/passive-header-scan/main.go
-9fd50a314deed257f82e490caa5b06117070e1078c73607d65ea4e4d19e574b4 samples/emit-on-start/main.go
+bccc9c6307efb1dcb2dd33dca93d0b4832abd74350c12cff338e796371453aff samples/emit-on-start/main.go

--- a/plugins/example-hello/main.go
+++ b/plugins/example-hello/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	pluginsdk "github.com/RowanDark/Glyph/sdk/plugin-sdk"
@@ -18,10 +19,17 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
+	capToken := strings.TrimSpace(os.Getenv("GLYPH_CAPABILITY_TOKEN"))
+	if capToken == "" {
+		logger.Error("missing GLYPH_CAPABILITY_TOKEN environment variable")
+		os.Exit(1)
+	}
+
 	cfg := pluginsdk.Config{
-		PluginName: "example-hello",
-		Host:       *serverAddr,
-		AuthToken:  *authToken,
+		PluginName:      "example-hello",
+		Host:            *serverAddr,
+		AuthToken:       *authToken,
+		CapabilityToken: capToken,
 		Capabilities: []pluginsdk.Capability{
 			pluginsdk.CapabilityEmitFindings,
 		},

--- a/plugins/samples/emit-on-start/main.go
+++ b/plugins/samples/emit-on-start/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -28,10 +29,17 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
+	capToken := strings.TrimSpace(os.Getenv("GLYPH_CAPABILITY_TOKEN"))
+	if capToken == "" {
+		logger.Error("missing GLYPH_CAPABILITY_TOKEN environment variable")
+		os.Exit(1)
+	}
+
 	cfg := pluginsdk.Config{
-		PluginName: "emit-on-start",
-		Host:       *serverAddr,
-		AuthToken:  *authToken,
+		PluginName:      "emit-on-start",
+		Host:            *serverAddr,
+		AuthToken:       *authToken,
+		CapabilityToken: capToken,
 		Capabilities: []pluginsdk.Capability{
 			pluginsdk.CapabilityEmitFindings,
 		},

--- a/plugins/samples/passive-header-scan/main.go
+++ b/plugins/samples/passive-header-scan/main.go
@@ -26,10 +26,17 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
+	capToken := strings.TrimSpace(os.Getenv("GLYPH_CAPABILITY_TOKEN"))
+	if capToken == "" {
+		logger.Error("missing GLYPH_CAPABILITY_TOKEN environment variable")
+		os.Exit(1)
+	}
+
 	cfg := pluginsdk.Config{
-		PluginName: "passive-header-scan",
-		Host:       *serverAddr,
-		AuthToken:  *authToken,
+		PluginName:      "passive-header-scan",
+		Host:            *serverAddr,
+		AuthToken:       *authToken,
+		CapabilityToken: capToken,
 		Capabilities: []pluginsdk.Capability{
 			pluginsdk.CapabilityHTTPPassive,
 			pluginsdk.CapabilityEmitFindings,

--- a/plugins/samples/passive-header-scan/main_test.go
+++ b/plugins/samples/passive-header-scan/main_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/RowanDark/Glyph/internal/findings"
 	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestSampleEmitsFinding(t *testing.T) {
@@ -70,9 +71,32 @@ func TestSampleEmitsFinding(t *testing.T) {
 		t.Fatalf("build plugin: %v\noutput: %s", err, buildOutput.String())
 	}
 
+	conn, err := grpc.DialContext(ctx, lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+	grantCtx, grantCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer grantCancel()
+	grant, err := pb.NewPluginBusClient(conn).GrantCapabilities(grantCtx, &pb.PluginCapabilityRequest{
+		AuthToken:    "test-token",
+		PluginName:   "passive-header-scan",
+		Capabilities: []string{"CAP_HTTP_PASSIVE", "CAP_EMIT_FINDINGS"},
+	})
+	if err != nil {
+		t.Fatalf("grant capabilities: %v", err)
+	}
+	token := strings.TrimSpace(grant.GetCapabilityToken())
+	if token == "" {
+		t.Fatal("expected capability token")
+	}
+
 	cmd := exec.CommandContext(cmdCtx, binaryPath, "--server", lis.Addr().String(), "--token", "test-token")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), "GLYPH_CAPABILITY_TOKEN="+token)
 
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start plugin: %v", err)
@@ -85,15 +109,15 @@ func TestSampleEmitsFinding(t *testing.T) {
 		t.Fatalf("timed out waiting for finding\nstdout: %s\nstderr: %s", stdout.String(), stderr.String())
 	}
 
-        if finding.ID == "" {
-                t.Fatal("expected finding id to be populated")
-        }
-        if finding.Version != findings.SchemaVersion {
-                t.Fatalf("unexpected version: %s", finding.Version)
-        }
-        if finding.Type != "missing-security-header" {
-                t.Fatalf("unexpected finding type: %s", finding.Type)
-        }
+	if finding.ID == "" {
+		t.Fatal("expected finding id to be populated")
+	}
+	if finding.Version != findings.SchemaVersion {
+		t.Fatalf("unexpected version: %s", finding.Version)
+	}
+	if finding.Type != "missing-security-header" {
+		t.Fatalf("unexpected finding type: %s", finding.Type)
+	}
 	if finding.Severity != findings.SeverityMedium {
 		t.Fatalf("unexpected severity: %s", finding.Severity)
 	}

--- a/plugins/seer/main.go
+++ b/plugins/seer/main.go
@@ -52,10 +52,17 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
+	capToken := strings.TrimSpace(os.Getenv("GLYPH_CAPABILITY_TOKEN"))
+	if capToken == "" {
+		logger.Error("missing GLYPH_CAPABILITY_TOKEN environment variable")
+		os.Exit(1)
+	}
+
 	cfg := pluginsdk.Config{
-		PluginName: "seer",
-		Host:       *serverAddr,
-		AuthToken:  *authToken,
+		PluginName:      "seer",
+		Host:            *serverAddr,
+		AuthToken:       *authToken,
+		CapabilityToken: capToken,
 		Capabilities: []pluginsdk.Capability{
 			pluginsdk.CapabilityHTTPPassive,
 			pluginsdk.CapabilityEmitFindings,

--- a/proto/gen/go/proto/glyph/plugin_bus.pb.go
+++ b/proto/gen/go/proto/glyph/plugin_bus.pb.go
@@ -121,9 +121,11 @@ type PluginHello struct {
 	Subscriptions []string `protobuf:"bytes,4,rep,name=subscriptions,proto3" json:"subscriptions,omitempty"`
 	// The list of capabilities the plugin requires.
 	// e.g., "CAP_EMIT_FINDINGS"
-	Capabilities  []string `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Capabilities []string `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	// Capability token issued by the host prior to runtime.
+	CapabilityToken string `protobuf:"bytes,6,opt,name=capability_token,json=capabilityToken,proto3" json:"capability_token,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *PluginHello) Reset() {
@@ -191,6 +193,128 @@ func (x *PluginHello) GetCapabilities() []string {
 	return nil
 }
 
+func (x *PluginHello) GetCapabilityToken() string {
+	if x != nil {
+		return x.CapabilityToken
+	}
+	return ""
+}
+
+// PluginCapabilityRequest captures the parameters required to mint a capability
+// token for a plugin invocation.
+type PluginCapabilityRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AuthToken     string                 `protobuf:"bytes,1,opt,name=auth_token,json=authToken,proto3" json:"auth_token,omitempty"`
+	PluginName    string                 `protobuf:"bytes,2,opt,name=plugin_name,json=pluginName,proto3" json:"plugin_name,omitempty"`
+	Capabilities  []string               `protobuf:"bytes,3,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginCapabilityRequest) Reset() {
+	*x = PluginCapabilityRequest{}
+	mi := &file_glyph_plugin_bus_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginCapabilityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginCapabilityRequest) ProtoMessage() {}
+
+func (x *PluginCapabilityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_glyph_plugin_bus_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginCapabilityRequest.ProtoReflect.Descriptor instead.
+func (*PluginCapabilityRequest) Descriptor() ([]byte, []int) {
+	return file_glyph_plugin_bus_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PluginCapabilityRequest) GetAuthToken() string {
+	if x != nil {
+		return x.AuthToken
+	}
+	return ""
+}
+
+func (x *PluginCapabilityRequest) GetPluginName() string {
+	if x != nil {
+		return x.PluginName
+	}
+	return ""
+}
+
+func (x *PluginCapabilityRequest) GetCapabilities() []string {
+	if x != nil {
+		return x.Capabilities
+	}
+	return nil
+}
+
+// PluginCapabilityGrant returns the issued token and expiry metadata.
+type PluginCapabilityGrant struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	CapabilityToken string                 `protobuf:"bytes,1,opt,name=capability_token,json=capabilityToken,proto3" json:"capability_token,omitempty"`
+	ExpiresAtUnix   int64                  `protobuf:"varint,2,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *PluginCapabilityGrant) Reset() {
+	*x = PluginCapabilityGrant{}
+	mi := &file_glyph_plugin_bus_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginCapabilityGrant) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginCapabilityGrant) ProtoMessage() {}
+
+func (x *PluginCapabilityGrant) ProtoReflect() protoreflect.Message {
+	mi := &file_glyph_plugin_bus_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginCapabilityGrant.ProtoReflect.Descriptor instead.
+func (*PluginCapabilityGrant) Descriptor() ([]byte, []int) {
+	return file_glyph_plugin_bus_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *PluginCapabilityGrant) GetCapabilityToken() string {
+	if x != nil {
+		return x.CapabilityToken
+	}
+	return ""
+}
+
+func (x *PluginCapabilityGrant) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
 // HostEvent is a message sent from the host to a plugin.
 type HostEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -208,7 +332,7 @@ type HostEvent struct {
 
 func (x *HostEvent) Reset() {
 	*x = HostEvent{}
-	mi := &file_glyph_plugin_bus_proto_msgTypes[2]
+	mi := &file_glyph_plugin_bus_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -220,7 +344,7 @@ func (x *HostEvent) String() string {
 func (*HostEvent) ProtoMessage() {}
 
 func (x *HostEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_glyph_plugin_bus_proto_msgTypes[2]
+	mi := &file_glyph_plugin_bus_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -233,7 +357,7 @@ func (x *HostEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostEvent.ProtoReflect.Descriptor instead.
 func (*HostEvent) Descriptor() ([]byte, []int) {
-	return file_glyph_plugin_bus_proto_rawDescGZIP(), []int{2}
+	return file_glyph_plugin_bus_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *HostEvent) GetCoreVersion() string {
@@ -277,7 +401,7 @@ const file_glyph_plugin_bus_proto_rawDesc = "" +
 	"\vPluginEvent\x125\n" +
 	"\x05hello\x18\x01 \x01(\v2\x1d.glyph.plugin_bus.PluginHelloH\x00R\x05hello\x121\n" +
 	"\afinding\x18\x02 \x01(\v2\x15.glyph.common.FindingH\x00R\afindingB\a\n" +
-	"\x05event\"\xa9\x01\n" +
+	"\x05event\"\xd4\x01\n" +
 	"\vPluginHello\x12\x1d\n" +
 	"\n" +
 	"auth_token\x18\x01 \x01(\tR\tauthToken\x12\x1f\n" +
@@ -285,14 +409,25 @@ const file_glyph_plugin_bus_proto_rawDesc = "" +
 	"pluginName\x12\x10\n" +
 	"\x03pid\x18\x03 \x01(\x05R\x03pid\x12$\n" +
 	"\rsubscriptions\x18\x04 \x03(\tR\rsubscriptions\x12\"\n" +
-	"\fcapabilities\x18\x05 \x03(\tR\fcapabilities\"q\n" +
+	"\fcapabilities\x18\x05 \x03(\tR\fcapabilities\x12)\n" +
+	"\x10capability_token\x18\x06 \x01(\tR\x0fcapabilityToken\"}\n" +
+	"\x17PluginCapabilityRequest\x12\x1d\n" +
+	"\n" +
+	"auth_token\x18\x01 \x01(\tR\tauthToken\x12\x1f\n" +
+	"\vplugin_name\x18\x02 \x01(\tR\n" +
+	"pluginName\x12\"\n" +
+	"\fcapabilities\x18\x03 \x03(\tR\fcapabilities\"j\n" +
+	"\x15PluginCapabilityGrant\x12)\n" +
+	"\x10capability_token\x18\x01 \x01(\tR\x0fcapabilityToken\x12&\n" +
+	"\x0fexpires_at_unix\x18\x02 \x01(\x03R\rexpiresAtUnix\"q\n" +
 	"\tHostEvent\x12!\n" +
 	"\fcore_version\x18\x01 \x01(\tR\vcoreVersion\x128\n" +
 	"\n" +
 	"flow_event\x18\x02 \x01(\v2\x17.glyph.common.FlowEventH\x00R\tflowEventB\a\n" +
-	"\x05event2Z\n" +
+	"\x05event2\xc3\x01\n" +
 	"\tPluginBus\x12M\n" +
-	"\vEventStream\x12\x1d.glyph.plugin_bus.PluginEvent\x1a\x1b.glyph.plugin_bus.HostEvent(\x010\x01B.Z,github.com/RowanDark/Glyph/proto/glyph;glyphb\x06proto3"
+	"\vEventStream\x12\x1d.glyph.plugin_bus.PluginEvent\x1a\x1b.glyph.plugin_bus.HostEvent(\x010\x01\x12g\n" +
+	"\x11GrantCapabilities\x12).glyph.plugin_bus.PluginCapabilityRequest\x1a'.glyph.plugin_bus.PluginCapabilityGrantB.Z,github.com/RowanDark/Glyph/proto/glyph;glyphb\x06proto3"
 
 var (
 	file_glyph_plugin_bus_proto_rawDescOnce sync.Once
@@ -306,22 +441,26 @@ func file_glyph_plugin_bus_proto_rawDescGZIP() []byte {
 	return file_glyph_plugin_bus_proto_rawDescData
 }
 
-var file_glyph_plugin_bus_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_glyph_plugin_bus_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_glyph_plugin_bus_proto_goTypes = []any{
-	(*PluginEvent)(nil), // 0: glyph.plugin_bus.PluginEvent
-	(*PluginHello)(nil), // 1: glyph.plugin_bus.PluginHello
-	(*HostEvent)(nil),   // 2: glyph.plugin_bus.HostEvent
-	(*Finding)(nil),     // 3: glyph.common.Finding
-	(*FlowEvent)(nil),   // 4: glyph.common.FlowEvent
+	(*PluginEvent)(nil),             // 0: glyph.plugin_bus.PluginEvent
+	(*PluginHello)(nil),             // 1: glyph.plugin_bus.PluginHello
+	(*PluginCapabilityRequest)(nil), // 2: glyph.plugin_bus.PluginCapabilityRequest
+	(*PluginCapabilityGrant)(nil),   // 3: glyph.plugin_bus.PluginCapabilityGrant
+	(*HostEvent)(nil),               // 4: glyph.plugin_bus.HostEvent
+	(*Finding)(nil),                 // 5: glyph.common.Finding
+	(*FlowEvent)(nil),               // 6: glyph.common.FlowEvent
 }
 var file_glyph_plugin_bus_proto_depIdxs = []int32{
 	1, // 0: glyph.plugin_bus.PluginEvent.hello:type_name -> glyph.plugin_bus.PluginHello
-	3, // 1: glyph.plugin_bus.PluginEvent.finding:type_name -> glyph.common.Finding
-	4, // 2: glyph.plugin_bus.HostEvent.flow_event:type_name -> glyph.common.FlowEvent
+	5, // 1: glyph.plugin_bus.PluginEvent.finding:type_name -> glyph.common.Finding
+	6, // 2: glyph.plugin_bus.HostEvent.flow_event:type_name -> glyph.common.FlowEvent
 	0, // 3: glyph.plugin_bus.PluginBus.EventStream:input_type -> glyph.plugin_bus.PluginEvent
-	2, // 4: glyph.plugin_bus.PluginBus.EventStream:output_type -> glyph.plugin_bus.HostEvent
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
+	2, // 4: glyph.plugin_bus.PluginBus.GrantCapabilities:input_type -> glyph.plugin_bus.PluginCapabilityRequest
+	4, // 5: glyph.plugin_bus.PluginBus.EventStream:output_type -> glyph.plugin_bus.HostEvent
+	3, // 6: glyph.plugin_bus.PluginBus.GrantCapabilities:output_type -> glyph.plugin_bus.PluginCapabilityGrant
+	5, // [5:7] is the sub-list for method output_type
+	3, // [3:5] is the sub-list for method input_type
 	3, // [3:3] is the sub-list for extension type_name
 	3, // [3:3] is the sub-list for extension extendee
 	0, // [0:3] is the sub-list for field type_name
@@ -337,7 +476,7 @@ func file_glyph_plugin_bus_proto_init() {
 		(*PluginEvent_Hello)(nil),
 		(*PluginEvent_Finding)(nil),
 	}
-	file_glyph_plugin_bus_proto_msgTypes[2].OneofWrappers = []any{
+	file_glyph_plugin_bus_proto_msgTypes[4].OneofWrappers = []any{
 		(*HostEvent_FlowEvent)(nil),
 	}
 	type x struct{}
@@ -346,7 +485,7 @@ func file_glyph_plugin_bus_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_glyph_plugin_bus_proto_rawDesc), len(file_glyph_plugin_bus_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/glyph/plugin_bus.proto
+++ b/proto/glyph/plugin_bus.proto
@@ -12,6 +12,9 @@ service PluginBus {
   // EventStream is a long-lived, bi-directional stream between the host
   // (`glyphd`) and a single plugin.
   rpc EventStream(stream PluginEvent) returns (stream HostEvent);
+  // GrantCapabilities issues a short-lived token binding a plugin to the
+  // capabilities declared in its manifest.
+  rpc GrantCapabilities(PluginCapabilityRequest) returns (PluginCapabilityGrant);
 }
 
 // PluginEvent is a message sent from a plugin to the host.
@@ -39,6 +42,22 @@ message PluginHello {
   // The list of capabilities the plugin requires.
   // e.g., "CAP_EMIT_FINDINGS"
   repeated string capabilities = 5;
+  // Capability token issued by the host prior to runtime.
+  string capability_token = 6;
+}
+
+// PluginCapabilityRequest captures the parameters required to mint a capability
+// token for a plugin invocation.
+message PluginCapabilityRequest {
+  string auth_token = 1;
+  string plugin_name = 2;
+  repeated string capabilities = 3;
+}
+
+// PluginCapabilityGrant returns the issued token and expiry metadata.
+message PluginCapabilityGrant {
+  string capability_token = 1;
+  int64 expires_at_unix = 2;
 }
 
 // HostEvent is a message sent from the host to a plugin.

--- a/sdk/plugin-sdk/sdk.go
+++ b/sdk/plugin-sdk/sdk.go
@@ -85,6 +85,8 @@ type Config struct {
 	Host string
 	// AuthToken is the shared secret required by the host.
 	AuthToken string
+	// CapabilityToken binds this invocation to the capabilities granted by the host.
+	CapabilityToken string
 	// Capabilities is the set of capabilities granted by the manifest.
 	Capabilities []Capability
 	// Subscriptions lists the host events the plugin wants to receive.
@@ -241,6 +243,9 @@ func Serve(parent context.Context, cfg Config, hooks Hooks) error {
 	if cfg.AuthToken == "" {
 		return errors.New("auth token is required")
 	}
+	if cfg.CapabilityToken == "" {
+		return errors.New("capability token is required")
+	}
 
 	logger := cfg.Logger
 	if logger == nil {
@@ -280,11 +285,12 @@ func Serve(parent context.Context, cfg Config, hooks Hooks) error {
 	}()
 
 	hello := &pb.PluginHello{
-		AuthToken:     cfg.AuthToken,
-		PluginName:    cfg.PluginName,
-		Pid:           int32(os.Getpid()),
-		Subscriptions: mapSubscriptions(subs),
-		Capabilities:  mapCapabilities(caps),
+		AuthToken:       cfg.AuthToken,
+		PluginName:      cfg.PluginName,
+		Pid:             int32(os.Getpid()),
+		Subscriptions:   mapSubscriptions(subs),
+		Capabilities:    mapCapabilities(caps),
+		CapabilityToken: cfg.CapabilityToken,
 	}
 	if err := stream.Send(&pb.PluginEvent{Event: &pb.PluginEvent_Hello{Hello: hello}}); err != nil {
 		return fmt.Errorf("send hello: %w", err)


### PR DESCRIPTION
## Summary
- add a capability manager that issues short-lived grants and wire it into the plugin bus for handshake validation
- require capability tokens end-to-end by updating the SDK, glyphctl runner, plugin samples, and documentation
- expose a gRPC GrantCapabilities RPC and extend tests to cover denied escalations and token issuance

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dbacf20df0832a957e38a1f19764ab