### PR TITLE
Add pipeline E2E coverage and fuzzers

### DIFF
--- a/internal/bus/server_fuzz_test.go
+++ b/internal/bus/server_fuzz_test.go
@@ -1,0 +1,129 @@
+package bus
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+)
+
+type fuzzStream struct {
+	events []*pb.PluginEvent
+	index  int
+	ctx    context.Context
+}
+
+func (s *fuzzStream) Context() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return context.Background()
+}
+
+func (s *fuzzStream) SetHeader(metadata.MD) error  { return nil }
+func (s *fuzzStream) SendHeader(metadata.MD) error { return nil }
+func (s *fuzzStream) SetTrailer(metadata.MD)       {}
+func (s *fuzzStream) Send(event *pb.HostEvent) error {
+	// Discard events; the fuzzer only checks for panics.
+	_ = event
+	return nil
+}
+
+func (s *fuzzStream) Recv() (*pb.PluginEvent, error) {
+	if s.index >= len(s.events) {
+		return nil, io.EOF
+	}
+	evt := s.events[s.index]
+	s.index++
+	if evt == nil {
+		return nil, io.EOF
+	}
+	return evt, nil
+}
+
+func (s *fuzzStream) SendMsg(interface{}) error { return nil }
+func (s *fuzzStream) RecvMsg(interface{}) error { return io.EOF }
+
+func FuzzPluginRPCFraming(f *testing.F) {
+	hello := &pb.PluginEvent{
+		Event: &pb.PluginEvent_Hello{Hello: &pb.PluginHello{
+			AuthToken:       "token",
+			PluginName:      "sample",
+			Pid:             42,
+			CapabilityToken: "grant",
+			Capabilities:    []string{CapEmitFindings},
+			Subscriptions:   []string{"FLOW_RESPONSE"},
+		}},
+	}
+	finding := &pb.PluginEvent{
+		Event: &pb.PluginEvent_Finding{Finding: &pb.Finding{
+			Type:    "demo",
+			Message: "demo",
+		}},
+	}
+	f.Add(encodeEvents(hello))
+	f.Add(encodeEvents(hello, finding))
+	f.Add([]byte{0x00, 0x00, 0x01})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		events := decodeEvents(data)
+		srv := NewServer("token", findings.NewBus())
+
+		authStream := &fuzzStream{events: events}
+		_, _ = srv.authenticate(authStream)
+
+		recvStream := &fuzzStream{events: events}
+		pluginConn := &plugin{
+			eventChan:    make(chan *pb.HostEvent, 1),
+			capabilities: map[string]struct{}{CapEmitFindings: {}},
+		}
+		_ = srv.receiveEvents(recvStream, pluginConn, "fuzz-plugin")
+	})
+}
+
+func encodeEvents(events ...*pb.PluginEvent) []byte {
+	buf := &bytes.Buffer{}
+	for _, evt := range events {
+		if evt == nil {
+			continue
+		}
+		payload, err := proto.Marshal(evt)
+		if err != nil {
+			continue
+		}
+		if len(payload) > 0xFFFF {
+			payload = payload[:0xFFFF]
+		}
+		_ = binary.Write(buf, binary.LittleEndian, uint16(len(payload)))
+		buf.Write(payload)
+	}
+	return buf.Bytes()
+}
+
+func decodeEvents(data []byte) []*pb.PluginEvent {
+	events := []*pb.PluginEvent{}
+	for len(data) >= 2 {
+		frameLen := int(binary.LittleEndian.Uint16(data[:2]))
+		data = data[2:]
+		if frameLen == 0 {
+			continue
+		}
+		if frameLen > len(data) {
+			break
+		}
+		frame := data[:frameLen]
+		data = data[frameLen:]
+		var evt pb.PluginEvent
+		if err := proto.Unmarshal(frame, &evt); err != nil {
+			continue
+		}
+		events = append(events, &evt)
+	}
+	return events
+}

--- a/internal/e2e/pipeline_test.go
+++ b/internal/e2e/pipeline_test.go
@@ -1,0 +1,258 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+	"github.com/RowanDark/Glyph/internal/reporter"
+)
+
+type goldenFinding struct {
+	Plugin   string            `json:"plugin"`
+	Type     string            `json:"type"`
+	Message  string            `json:"message"`
+	Severity findings.Severity `json:"severity"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+func TestPipelinePassiveHeaderScanGolden(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping pipeline golden test in short mode")
+	}
+
+	target := newPassiveTargetServer(t)
+	defer target.Close()
+
+	// Sanity check the deterministic response used by the pipeline.
+	resp, err := target.Client().Get(target.URL + "/security")
+	if err != nil {
+		t.Fatalf("failed to query test target: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected test target status: %d", resp.StatusCode)
+	}
+	for _, header := range []string{
+		"Strict-Transport-Security",
+		"Content-Security-Policy",
+		"X-Content-Type-Options",
+		"X-Frame-Options",
+	} {
+		if resp.Header.Get(header) != "" {
+			t.Fatalf("expected %s header to be empty", header)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	root := repoRoot(t)
+	glyphdBin := buildGlyphd(ctx, t, root)
+	glyphctlBin := buildGlyphctl(ctx, t, root)
+
+	outDir := t.TempDir()
+	findingsPath := filepath.Join(outDir, "findings.jsonl")
+
+	listenAddr, dialAddr := resolveAddresses(t)
+	cmdCtx, cmdCancel := context.WithCancel(ctx)
+	glyphd := exec.CommandContext(cmdCtx, glyphdBin, "--addr", listenAddr, "--token", "test-token")
+	glyphd.Dir = root
+	glyphd.Env = append(os.Environ(), "GLYPH_OUT="+outDir)
+
+	var stdout, stderr bytes.Buffer
+	glyphd.Stdout = &stdout
+	glyphd.Stderr = &stderr
+
+	if err := glyphd.Start(); err != nil {
+		t.Fatalf("failed to start glyphd: %v", err)
+	}
+
+	done := make(chan struct{})
+	var glyphdErr error
+	go func() {
+		glyphdErr = glyphd.Wait()
+		close(done)
+	}()
+
+	t.Cleanup(func() {
+		cmdCancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("glyphd did not exit after cancellation")
+		}
+	})
+
+	if err := waitForListener(cmdCtx, dialAddr, done, func() error { return glyphdErr }); err != nil {
+		t.Fatalf("glyphd did not become ready: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	pluginCmd := exec.CommandContext(ctx, glyphctlBin, "plugin", "run", "--sample", "passive-header-scan", "--server", dialAddr, "--token", "test-token", "--duration", "6s")
+	pluginCmd.Dir = root
+	pluginCmd.Env = append(os.Environ(), "GLYPH_OUT="+outDir)
+	var pluginOut, pluginErr bytes.Buffer
+	pluginCmd.Stdout = &pluginOut
+	pluginCmd.Stderr = &pluginErr
+
+	if err := pluginCmd.Run(); err != nil {
+		t.Fatalf("glyphctl plugin run failed: %v\nstdout:\n%s\nstderr:\n%s", err, pluginOut.String(), pluginErr.String())
+	}
+
+	findingsList := waitForFindings(t, findingsPath, 4, 10*time.Second)
+	comparable := normaliseFindings(findingsList)
+	sort.SliceStable(comparable, func(i, j int) bool {
+		left := comparable[i]
+		right := comparable[j]
+		leftHeader := ""
+		rightHeader := ""
+		if left.Metadata != nil {
+			leftHeader = left.Metadata["header"]
+		}
+		if right.Metadata != nil {
+			rightHeader = right.Metadata["header"]
+		}
+		if leftHeader == rightHeader {
+			return left.Message < right.Message
+		}
+		return leftHeader < rightHeader
+	})
+
+	goldenPath := filepath.Join(root, "internal", "e2e", "testdata", "passive_header_scan_golden.json")
+	golden := loadGoldenFindings(t, goldenPath)
+
+	if !reflect.DeepEqual(comparable, golden) {
+		encoded, err := json.MarshalIndent(comparable, "", "  ")
+		if err != nil {
+			t.Fatalf("failed to encode comparable findings: %v", err)
+		}
+		t.Fatalf("pipeline findings did not match golden file\nwant: %s\n got: %s", mustJSON(golden), string(encoded))
+	}
+}
+
+func newPassiveTargetServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/security", func(w http.ResponseWriter, r *http.Request) {
+		// Deliberately omit the security headers the passive scan plugin expects.
+		w.Header().Set("Server", "glyph-e2e")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/security", http.StatusFound)
+	})
+	return httptest.NewServer(mux)
+}
+
+func waitForFindings(t *testing.T, path string, minCount int, timeout time.Duration) []findings.Finding {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		findingsList, err := reporter.ReadJSONL(path)
+		if err != nil {
+			t.Fatalf("read findings: %v", err)
+		}
+		if len(findingsList) >= minCount {
+			return findingsList
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	findingsList, err := reporter.ReadJSONL(path)
+	if err != nil {
+		t.Fatalf("read findings after timeout: %v", err)
+	}
+	if len(findingsList) < minCount {
+		t.Fatalf("expected at least %d findings, got %d", minCount, len(findingsList))
+	}
+	return findingsList
+}
+
+func normaliseFindings(input []findings.Finding) []goldenFinding {
+	byHeader := make(map[string]goldenFinding)
+	for _, finding := range input {
+		if finding.Type != "missing-security-header" {
+			continue
+		}
+		header := finding.Metadata["header"]
+		if header == "" {
+			continue
+		}
+		if _, exists := byHeader[header]; exists {
+			continue
+		}
+		basePlugin := normalisePluginID(finding.Plugin)
+		metadata := make(map[string]string, len(finding.Metadata))
+		for k, v := range finding.Metadata {
+			metadata[k] = v
+		}
+		byHeader[header] = goldenFinding{
+			Plugin:   basePlugin,
+			Type:     finding.Type,
+			Message:  finding.Message,
+			Severity: finding.Severity,
+			Metadata: metadata,
+		}
+	}
+	comparable := make([]goldenFinding, 0, len(byHeader))
+	for _, gf := range byHeader {
+		comparable = append(comparable, gf)
+	}
+	return comparable
+}
+
+func normalisePluginID(id string) string {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return trimmed
+	}
+	idx := strings.LastIndex(trimmed, "-")
+	if idx == -1 {
+		return trimmed
+	}
+	suffix := trimmed[idx+1:]
+	if _, err := strconv.Atoi(suffix); err == nil {
+		return trimmed[:idx]
+	}
+	return trimmed
+}
+
+func loadGoldenFindings(t *testing.T, path string) []goldenFinding {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden file: %v", err)
+	}
+	var golden []goldenFinding
+	if err := json.Unmarshal(data, &golden); err != nil {
+		t.Fatalf("decode golden file: %v", err)
+	}
+	return golden
+}
+
+func mustJSON(v any) string {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}

--- a/internal/e2e/testdata/passive_header_scan_golden.json
+++ b/internal/e2e/testdata/passive_header_scan_golden.json
@@ -1,0 +1,42 @@
+[
+  {
+    "plugin": "passive-header-scan",
+    "type": "missing-security-header",
+    "message": "response missing Content-Security-Policy header",
+    "severity": "med",
+    "metadata": {
+      "header": "Content-Security-Policy",
+      "recommendation": "default-src 'none'"
+    }
+  },
+  {
+    "plugin": "passive-header-scan",
+    "type": "missing-security-header",
+    "message": "response missing Strict-Transport-Security header",
+    "severity": "med",
+    "metadata": {
+      "header": "Strict-Transport-Security",
+      "recommendation": "max-age=63072000; includeSubDomains; preload"
+    }
+  },
+  {
+    "plugin": "passive-header-scan",
+    "type": "missing-security-header",
+    "message": "response missing X-Content-Type-Options header",
+    "severity": "med",
+    "metadata": {
+      "header": "X-Content-Type-Options",
+      "recommendation": "nosniff"
+    }
+  },
+  {
+    "plugin": "passive-header-scan",
+    "type": "missing-security-header",
+    "message": "response missing X-Frame-Options header",
+    "severity": "med",
+    "metadata": {
+      "header": "X-Frame-Options",
+      "recommendation": "DENY"
+    }
+  }
+]

--- a/internal/raider/engine_fuzz_test.go
+++ b/internal/raider/engine_fuzz_test.go
@@ -1,0 +1,43 @@
+package raider
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"testing"
+)
+
+func FuzzBuildRequest(f *testing.F) {
+	seeds := []string{
+		"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+		"POST /submit HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhello",
+		"POST http://example.com/upload HTTP/1.1\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n",
+		"INVALID REQUEST",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		ctx := context.Background()
+		req, _, err := buildRequest(ctx, raw)
+		if err != nil {
+			return
+		}
+
+		if req == nil {
+			t.Fatalf("buildRequest returned nil request without error")
+		}
+
+		if req.Body == nil {
+			return
+		}
+
+		reader := bufio.NewReader(req.Body)
+		data, err := reader.ReadBytes(0)
+		if err != nil && !strings.Contains(err.Error(), "EOF") {
+			t.Fatalf("unexpected body read error: %v", err)
+		}
+		_ = data
+	})
+}

--- a/plugins/ALLOWLIST
+++ b/plugins/ALLOWLIST
@@ -1,3 +1,3 @@
 # SHA-256 allowlist for trusted plugin artifacts
-42f6b8e3ba4bd5c4b36c4b6e8cf694a3d50c5b14c568d6e27ce2823a87848511 samples/passive-header-scan/main.go
+242427e7b26e6f696203a3fe0c004ea94209a098aaf046949b1d6fe0d36e6cb6 samples/passive-header-scan/main.go
 f22ecb0b0cb2d205f3cd39990a5c339bb39354147d8e924a3cfb375a736c1987 samples/emit-on-start/main.go


### PR DESCRIPTION
## Summary
- add an end-to-end pipeline test that exercises the passive header scan plugin against a deterministic HTTP target and golden findings
- store golden output for the passive header scan sample and refresh the allowlist hash for its artifact
- introduce fuzzers for HTTP request construction and plugin RPC framing edge cases

## Testing
- `go test ./internal/e2e -run TestPipelinePassiveHeaderScanGolden -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68dbec8dd614832ab571fb2a67c09a37