### PR TITLE
feat: add structured audit logging across core components

### DIFF
--- a/cmd/glyphd/main.go
+++ b/cmd/glyphd/main.go
@@ -83,11 +83,7 @@ func run(ctx context.Context, cfg config) error {
 	}
 	defer coreLogger.Close()
 
-	busLogger, err := newAuditLogger("plugin_bus")
-	if err != nil {
-		return fmt.Errorf("configure plugin bus logger: %w", err)
-	}
-	defer busLogger.Close()
+	busLogger := coreLogger.WithComponent("plugin_bus")
 
 	proxyEnabled := cfg.enableProxy || os.Getenv("GLYPH_ENABLE_PROXY") == "1"
 

--- a/cmd/glyphd/main.go
+++ b/cmd/glyphd/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"os/signal"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/RowanDark/Glyph/internal/bus"
 	"github.com/RowanDark/Glyph/internal/findings"
+	"github.com/RowanDark/Glyph/internal/logging"
 	"github.com/RowanDark/Glyph/internal/proxy"
 	"github.com/RowanDark/Glyph/internal/reporter"
 	pb "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph"
@@ -77,6 +77,18 @@ func selectProxyAddr(addrFlag, portFlag string) string {
 }
 
 func run(ctx context.Context, cfg config) error {
+	coreLogger, err := newAuditLogger("glyphd")
+	if err != nil {
+		return fmt.Errorf("configure audit logger: %w", err)
+	}
+	defer coreLogger.Close()
+
+	busLogger, err := newAuditLogger("plugin_bus")
+	if err != nil {
+		return fmt.Errorf("configure plugin bus logger: %w", err)
+	}
+	defer busLogger.Close()
+
 	proxyEnabled := cfg.enableProxy || os.Getenv("GLYPH_ENABLE_PROXY") == "1"
 
 	cancelProxy := func() {}
@@ -89,6 +101,14 @@ func run(ctx context.Context, cfg config) error {
 		var err error
 		proxySrv, err = proxy.New(cfg.proxy)
 		if err != nil {
+			emitAudit(coreLogger, logging.AuditEvent{
+				EventType: logging.EventProxyLifecycle,
+				Decision:  logging.DecisionDeny,
+				Reason:    err.Error(),
+				Metadata: map[string]any{
+					"phase": "initialise",
+				},
+			})
 			return fmt.Errorf("initialise proxy: %w", err)
 		}
 
@@ -107,12 +127,27 @@ func run(ctx context.Context, cfg config) error {
 			select {
 			case errRun := <-proxyErrCh:
 				if errRun != nil {
-					log.Printf("proxy startup error: %v", errRun)
+					emitAudit(coreLogger, logging.AuditEvent{
+						EventType: logging.EventProxyLifecycle,
+						Decision:  logging.DecisionDeny,
+						Reason:    errRun.Error(),
+						Metadata: map[string]any{
+							"phase": "startup",
+						},
+					})
 				}
 			default:
 			}
 			return fmt.Errorf("start proxy: %w", err)
 		}
+		emitAudit(coreLogger, logging.AuditEvent{
+			EventType: logging.EventProxyLifecycle,
+			Decision:  logging.DecisionAllow,
+			Metadata: map[string]any{
+				"phase":   "ready",
+				"address": proxySrv.Addr(),
+			},
+		})
 	}
 
 	lis, err := net.Listen("tcp", cfg.addr)
@@ -120,14 +155,28 @@ func run(ctx context.Context, cfg config) error {
 		cancelProxy()
 		if proxyErrCh != nil {
 			if errRun := <-proxyErrCh; errRun != nil {
-				log.Printf("proxy terminated: %v", errRun)
+				emitAudit(coreLogger, logging.AuditEvent{
+					EventType: logging.EventProxyLifecycle,
+					Decision:  logging.DecisionDeny,
+					Reason:    errRun.Error(),
+					Metadata: map[string]any{
+						"phase": "listen_failed",
+					},
+				})
 			}
 		}
 		return fmt.Errorf("failed to listen on %s: %w", cfg.addr, err)
 	}
 	defer func() {
 		if err := lis.Close(); err != nil {
-			log.Printf("failed to close listener: %v", err)
+			emitAudit(coreLogger, logging.AuditEvent{
+				EventType: logging.EventRPCCall,
+				Decision:  logging.DecisionInfo,
+				Reason:    err.Error(),
+				Metadata: map[string]any{
+					"phase": "close_listener",
+				},
+			})
 		}
 	}()
 
@@ -136,7 +185,7 @@ func run(ctx context.Context, cfg config) error {
 
 	grpcErrCh := make(chan error, 1)
 	go func() {
-		grpcErrCh <- serve(serviceCtx, lis, cfg.token)
+		grpcErrCh <- serve(serviceCtx, lis, cfg.token, coreLogger, busLogger)
 	}()
 
 	select {
@@ -144,7 +193,14 @@ func run(ctx context.Context, cfg config) error {
 		cancelProxy()
 		if proxyErrCh != nil {
 			if pErr := <-proxyErrCh; pErr != nil {
-				log.Printf("proxy terminated: %v", pErr)
+				emitAudit(coreLogger, logging.AuditEvent{
+					EventType: logging.EventProxyLifecycle,
+					Decision:  logging.DecisionDeny,
+					Reason:    pErr.Error(),
+					Metadata: map[string]any{
+						"phase": "grpc_shutdown",
+					},
+				})
 			}
 		}
 		return err
@@ -160,33 +216,53 @@ func run(ctx context.Context, cfg config) error {
 		cancelProxy()
 		if proxyErrCh != nil {
 			if pErr := <-proxyErrCh; pErr != nil {
-				log.Printf("proxy terminated: %v", pErr)
+				emitAudit(coreLogger, logging.AuditEvent{
+					EventType: logging.EventProxyLifecycle,
+					Decision:  logging.DecisionDeny,
+					Reason:    pErr.Error(),
+					Metadata: map[string]any{
+						"phase": "context_cancel",
+					},
+				})
 			}
 		}
 		return ctx.Err()
 	}
 }
 
-func serve(ctx context.Context, lis net.Listener, token string) error {
+func serve(ctx context.Context, lis net.Listener, token string, coreLogger, busLogger *logging.AuditLogger) error {
 	if token == "" {
 		return errors.New("auth token must be provided")
 	}
 
 	findingsBus := findings.NewBus()
 	findingsPath := resolveFindingsPath()
-	log.Printf("writing findings to %s", findingsPath)
+	emitAudit(coreLogger, logging.AuditEvent{
+		EventType: logging.EventReporter,
+		Decision:  logging.DecisionInfo,
+		Metadata: map[string]any{
+			"findings_path": findingsPath,
+		},
+	})
 	jsonlWriter := reporter.NewJSONL(findingsPath)
 	findingsCh := findingsBus.Subscribe(ctx)
 	go func() {
 		for finding := range findingsCh {
 			if err := jsonlWriter.Write(finding); err != nil {
-				log.Printf("failed to persist finding: %v", err)
+				emitAudit(coreLogger, logging.AuditEvent{
+					EventType: logging.EventReporter,
+					Decision:  logging.DecisionDeny,
+					Reason:    err.Error(),
+					Metadata: map[string]any{
+						"action": "persist_finding",
+					},
+				})
 			}
 		}
 	}()
 
 	srv := grpc.NewServer()
-	busServer := bus.NewServer(token, findingsBus)
+	busServer := bus.NewServer(token, findingsBus, bus.WithAuditLogger(busLogger))
 	pb.RegisterPluginBusServer(srv, busServer)
 
 	// Create a background context used by the event generator. It is cancelled
@@ -227,4 +303,29 @@ func resolveFindingsPath() string {
 		return filepath.Join(custom, "findings.jsonl")
 	}
 	return reporter.DefaultFindingsPath
+}
+
+func newAuditLogger(component string) (*logging.AuditLogger, error) {
+	opts := []logging.Option{}
+	if disableStdout(os.Getenv("GLYPH_AUDIT_LOG_STDOUT")) {
+		opts = append(opts, logging.WithoutStdout())
+	}
+	if path := strings.TrimSpace(os.Getenv("GLYPH_AUDIT_LOG_PATH")); path != "" {
+		opts = append(opts, logging.WithFile(path))
+	}
+	return logging.NewAuditLogger(component, opts...)
+}
+
+func disableStdout(value string) bool {
+	value = strings.TrimSpace(strings.ToLower(value))
+	return value == "0" || value == "false" || value == "no"
+}
+
+func emitAudit(logger *logging.AuditLogger, event logging.AuditEvent) {
+	if logger == nil {
+		return
+	}
+	if err := logger.Emit(event); err != nil {
+		fmt.Fprintf(os.Stderr, "audit log error: %v\n", err)
+	}
 }

--- a/internal/logging/audit.go
+++ b/internal/logging/audit.go
@@ -1,0 +1,165 @@
+package logging
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type EventType string
+
+const (
+	EventPluginLoad       EventType = "plugin_load"
+	EventPluginDisconnect EventType = "plugin_disconnect"
+	EventCapabilityGrant  EventType = "capability_grant"
+	EventCapabilityDenied EventType = "capability_denied"
+	EventRPCCall          EventType = "rpc_call"
+	EventRPCDenied        EventType = "rpc_denied"
+	EventScopeViolation   EventType = "scope_violation"
+	EventFindingReceived  EventType = "finding_received"
+	EventFindingRejected  EventType = "finding_rejected"
+	EventProxyLifecycle   EventType = "proxy_lifecycle"
+	EventReporter         EventType = "reporter_event"
+)
+
+type Decision string
+
+const (
+	DecisionInfo  Decision = "info"
+	DecisionAllow Decision = "allow"
+	DecisionDeny  Decision = "deny"
+)
+
+type AuditEvent struct {
+	Timestamp time.Time      `json:"timestamp"`
+	Component string         `json:"component"`
+	PluginID  string         `json:"plugin_id,omitempty"`
+	EventType EventType      `json:"event_type"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+	Decision  Decision       `json:"decision,omitempty"`
+	Reason    string         `json:"reason,omitempty"`
+}
+
+type Option func(*config) error
+
+type config struct {
+	writers          []io.Writer
+	closers          []io.Closer
+	useDefaultWriter bool
+}
+
+func defaultConfig() *config {
+	return &config{writers: []io.Writer{os.Stdout}, useDefaultWriter: true}
+}
+
+func WithWriter(w io.Writer) Option {
+	return func(cfg *config) error {
+		if w == nil {
+			return errors.New("writer cannot be nil")
+		}
+		cfg.writers = append(cfg.writers, w)
+		return nil
+	}
+}
+
+func WithFile(path string) Option {
+	return func(cfg *config) error {
+		if strings.TrimSpace(path) == "" {
+			return errors.New("file path cannot be empty")
+		}
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			return err
+		}
+		cfg.writers = append(cfg.writers, f)
+		cfg.closers = append(cfg.closers, f)
+		return nil
+	}
+}
+
+func WithoutStdout() Option {
+	return func(cfg *config) error {
+		cfg.useDefaultWriter = false
+		filtered := cfg.writers[:0]
+		for _, w := range cfg.writers {
+			if w == os.Stdout {
+				continue
+			}
+			filtered = append(filtered, w)
+		}
+		cfg.writers = filtered
+		return nil
+	}
+}
+
+type AuditLogger struct {
+	mu        sync.Mutex
+	encoder   *json.Encoder
+	component string
+	closers   []io.Closer
+}
+
+func NewAuditLogger(component string, opts ...Option) (*AuditLogger, error) {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			for _, closer := range cfg.closers {
+				_ = closer.Close()
+			}
+			return nil, err
+		}
+	}
+	if !cfg.useDefaultWriter && len(cfg.writers) == 0 {
+		return nil, errors.New("no writers configured for audit logger")
+	}
+	writer := io.MultiWriter(cfg.writers...)
+	enc := json.NewEncoder(writer)
+	enc.SetEscapeHTML(false)
+	return &AuditLogger{
+		encoder:   enc,
+		component: component,
+		closers:   cfg.closers,
+	}, nil
+}
+
+func MustNewAuditLogger(component string, opts ...Option) *AuditLogger {
+	logger, err := NewAuditLogger(component, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return logger
+}
+
+func (l *AuditLogger) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var firstErr error
+	for _, closer := range l.closers {
+		if err := closer.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	l.closers = nil
+	return firstErr
+}
+
+func (l *AuditLogger) Emit(event AuditEvent) error {
+	if l == nil {
+		return errors.New("nil audit logger")
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	} else {
+		event.Timestamp = event.Timestamp.UTC()
+	}
+	if event.Component == "" {
+		event.Component = l.component
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.encoder.Encode(event)
+}

--- a/internal/logging/audit_test.go
+++ b/internal/logging/audit_test.go
@@ -1,0 +1,38 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestAuditLoggerEmit(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger, err := NewAuditLogger("test", WithoutStdout(), WithWriter(buf))
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+
+	event := AuditEvent{EventType: EventPluginLoad, Decision: DecisionAllow}
+	if err := logger.Emit(event); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	var decoded AuditEvent
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if decoded.Component != "test" {
+		t.Fatalf("expected component 'test', got %q", decoded.Component)
+	}
+	if decoded.EventType != EventPluginLoad {
+		t.Fatalf("expected event type %q, got %q", EventPluginLoad, decoded.EventType)
+	}
+	if decoded.Decision != DecisionAllow {
+		t.Fatalf("expected decision %q, got %q", DecisionAllow, decoded.Decision)
+	}
+	if decoded.Timestamp.IsZero() {
+		t.Fatalf("expected timestamp to be set")
+	}
+}

--- a/internal/logging/audit_test.go
+++ b/internal/logging/audit_test.go
@@ -36,3 +36,47 @@ func TestAuditLoggerEmit(t *testing.T) {
 		t.Fatalf("expected timestamp to be set")
 	}
 }
+
+func TestAuditLoggerWithComponent(t *testing.T) {
+	buf := &bytes.Buffer{}
+	base, err := NewAuditLogger("base", WithoutStdout(), WithWriter(buf))
+	if err != nil {
+		t.Fatalf("NewAuditLogger: %v", err)
+	}
+	child := base.WithComponent("child")
+	if child == nil {
+		t.Fatalf("expected child logger")
+	}
+
+	if err := base.Emit(AuditEvent{EventType: EventPluginLoad}); err != nil {
+		t.Fatalf("base Emit: %v", err)
+	}
+	if err := child.Emit(AuditEvent{EventType: EventRPCDenied}); err != nil {
+		t.Fatalf("child Emit: %v", err)
+	}
+
+	child.Close()
+	if err := base.Close(); err != nil {
+		t.Fatalf("base Close: %v", err)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 audit events, got %d", len(lines))
+	}
+
+	var first, second AuditEvent
+	if err := json.Unmarshal(lines[0], &first); err != nil {
+		t.Fatalf("unmarshal first: %v", err)
+	}
+	if err := json.Unmarshal(lines[1], &second); err != nil {
+		t.Fatalf("unmarshal second: %v", err)
+	}
+
+	if first.Component != "base" {
+		t.Fatalf("expected first component 'base', got %q", first.Component)
+	}
+	if second.Component != "child" {
+		t.Fatalf("expected second component 'child', got %q", second.Component)
+	}
+}


### PR DESCRIPTION
## Summary
- add an internal audit logging package that emits structured JSON events with configurable destinations
- wire glyphd and the plugin bus to record proxy lifecycle, capability, and plugin decision points in the audit log
- extend unit tests to cover the audit logger and assert denied plugin connections produce audit entries

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dbfb51c2f0832aa6520baafe6ee226