### PR TITLE
feat: add AI case builder pipeline

### DIFF
--- a/internal/cases/builder.go
+++ b/internal/cases/builder.go
@@ -1,0 +1,327 @@
+package cases
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/base32"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+// Builder reduces raw plugin findings into high-confidence Cases.
+type Builder struct {
+	summarizer    Summarizer
+	cache         SummaryCache
+	deterministic bool
+	seed          int64
+	now           func() time.Time
+	mu            sync.Mutex
+}
+
+// Option controls Builder behaviour.
+type Option func(*Builder)
+
+// WithSummarizer configures a custom summarizer implementation.
+func WithSummarizer(s Summarizer) Option {
+	return func(b *Builder) {
+		if s != nil {
+			b.summarizer = s
+		}
+	}
+}
+
+// WithCache registers a cache used to store summarisation results.
+func WithCache(cache SummaryCache) Option {
+	return func(b *Builder) {
+		b.cache = cache
+	}
+}
+
+// WithDeterministicMode enables deterministic replay using the provided seed.
+func WithDeterministicMode(seed int64) Option {
+	return func(b *Builder) {
+		b.deterministic = true
+		b.seed = seed
+	}
+}
+
+// WithClock replaces the time source used for generated timestamps.
+func WithClock(now func() time.Time) Option {
+	return func(b *Builder) {
+		if now != nil {
+			b.now = now
+		}
+	}
+}
+
+// NewBuilder constructs a Builder with optional configuration.
+func NewBuilder(opts ...Option) *Builder {
+	b := &Builder{
+		summarizer: DefaultSummarizer(),
+		cache:      NewMemoryCache(),
+		now:        time.Now,
+	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	if b.cache == nil {
+		b.cache = NewMemoryCache()
+	}
+	return b
+}
+
+// Build collapses the provided findings into deterministic cases.
+func (b *Builder) Build(ctx context.Context, findingsList []findings.Finding) ([]Case, error) {
+	if len(findingsList) == 0 {
+		return nil, nil
+	}
+
+	grouped := make(map[string][]findings.Finding)
+	order := make([]string, 0, len(findingsList))
+
+	for _, f := range findingsList {
+		key := b.groupKey(f)
+		grouped[key] = append(grouped[key], f)
+		order = append(order, key)
+	}
+
+	// Ensure deterministic ordering when iterating over maps.
+	sort.Strings(order)
+	order = dedupeStrings(order)
+
+	cases := make([]Case, 0, len(grouped))
+
+	for _, key := range order {
+		fs := grouped[key]
+		if len(fs) == 0 {
+			continue
+		}
+		casePrototype := b.derivePrototype(fs)
+		summaryInput := b.buildSummaryInput(casePrototype, fs)
+		summaryOutput, err := b.summarize(ctx, summaryInput)
+		if err != nil {
+			return nil, fmt.Errorf("summarise case: %w", err)
+		}
+		assembled := b.assembleCase(casePrototype, fs, summaryOutput)
+		cases = append(cases, assembled)
+	}
+
+	sort.SliceStable(cases, func(i, j int) bool {
+		return cases[i].ID < cases[j].ID
+	})
+
+	return cases, nil
+}
+
+func (b *Builder) summarize(ctx context.Context, input SummaryInput) (SummaryOutput, error) {
+	cacheKey := hashSummaryInput(input)
+	if b.cache != nil {
+		if cached, ok := b.cache.Get(cacheKey); ok {
+			return cached, nil
+		}
+	}
+	output, err := b.summarizer.Summarize(ctx, input)
+	if err != nil {
+		return SummaryOutput{}, err
+	}
+	if b.cache != nil {
+		b.cache.Set(cacheKey, output)
+	}
+	return output, nil
+}
+
+func (b *Builder) derivePrototype(fs []findings.Finding) Case {
+	dominant := selectDominantFinding(fs)
+	asset := normaliseAsset(dominant)
+	vector := normaliseVector(fs)
+	id := b.generateID(asset, vector)
+	labels := mergeLabels(fs)
+	return Case{
+		Version:     CaseSchemaVersion,
+		ID:          id,
+		Asset:       asset,
+		Vector:      vector,
+		Evidence:    make([]EvidenceItem, 0, len(fs)),
+		Sources:     make([]SourceFinding, 0, len(fs)),
+		GeneratedAt: findings.NewTimestamp(b.resolveNow()),
+		Labels:      labels,
+	}
+}
+
+func (b *Builder) assembleCase(proto Case, fs []findings.Finding, summary SummaryOutput) Case {
+	caseCopy := proto
+	caseCopy.Summary = summary.Summary
+	caseCopy.Proof = ProofOfConcept{Summary: summary.ProofSummary, Steps: append([]string(nil), summary.ReproductionSteps...)}
+	caseCopy.Risk = Risk{
+		Severity:  summary.RiskSeverity,
+		Score:     summary.RiskScore,
+		Rationale: summary.RiskRationale,
+	}
+	caseCopy.Confidence = summary.ConfidenceScore
+	caseCopy.ConfidenceLog = summary.ConfidenceLog
+	caseCopy.Evidence = append(caseCopy.Evidence, buildEvidence(fs)...)
+	caseCopy.Sources = append(caseCopy.Sources, buildSources(fs)...)
+	return caseCopy
+}
+
+func (b *Builder) resolveNow() time.Time {
+	if b.now == nil {
+		return time.Now()
+	}
+	return b.now().UTC().Truncate(time.Second)
+}
+
+func (b *Builder) generateID(asset Asset, vector AttackVector) string {
+	key := asset.Kind + "|" + asset.Identifier + "|" + vector.Kind + "|" + vector.Value
+	if b.deterministic {
+		h := sha1.New()
+		buf := make([]byte, 8)
+		for i := 0; i < 8; i++ {
+			buf[i] = byte(b.seed >> (8 * i))
+		}
+		_, _ = h.Write(buf)
+		_, _ = h.Write([]byte(strings.ToLower(key)))
+		sum := h.Sum(nil)
+		encoding := base32.StdEncoding.WithPadding(base32.NoPadding)
+		encoded := encoding.EncodeToString(sum)
+		if len(encoded) > 26 {
+			encoded = encoded[:26]
+		}
+		return encoded
+	}
+	return findings.NewID()
+}
+
+func (b *Builder) buildSummaryInput(proto Case, fs []findings.Finding) SummaryInput {
+	normals := make([]NormalisedFinding, len(fs))
+	for i, f := range fs {
+		normals[i] = normaliseFinding(f)
+	}
+	sort.SliceStable(normals, func(i, j int) bool {
+		if normals[i].Severity == normals[j].Severity {
+			if normals[i].Plugin == normals[j].Plugin {
+				return normals[i].Type < normals[j].Type
+			}
+			return normals[i].Plugin < normals[j].Plugin
+		}
+		return normals[i].Severity > normals[j].Severity
+	})
+	prompts := BuildPrompts(proto, normals)
+	return SummaryInput{
+		Case:     proto,
+		Findings: normals,
+		Prompts:  prompts,
+	}
+}
+
+func (b *Builder) groupKey(f findings.Finding) string {
+	if explicit := strings.TrimSpace(f.Metadata["case_key"]); explicit != "" {
+		return strings.ToLower(explicit)
+	}
+	if target := canonicalTarget(f.Target); target != "" {
+		return target
+	}
+	asset := normaliseAsset(f)
+	return strings.ToLower(asset.Kind) + "|" + strings.ToLower(asset.Identifier)
+}
+
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	var prev string
+	for i, v := range in {
+		if i == 0 || v != prev {
+			out = append(out, v)
+			prev = v
+		}
+	}
+	return out
+}
+
+func mergeLabels(fs []findings.Finding) map[string]string {
+	labels := make(map[string]string)
+	for _, f := range fs {
+		for k, v := range f.Metadata {
+			if strings.HasPrefix(k, "label:") {
+				key := strings.TrimPrefix(k, "label:")
+				labels[key] = v
+			}
+		}
+	}
+	if len(labels) == 0 {
+		return nil
+	}
+	return labels
+}
+
+func hashSummaryInput(input SummaryInput) string {
+	buf, _ := json.Marshal(input)
+	sum := sha1.Sum(buf)
+	return hex.EncodeToString(sum[:])
+}
+
+func buildEvidence(fs []findings.Finding) []EvidenceItem {
+	evidence := make([]EvidenceItem, 0, len(fs))
+	for _, f := range fs {
+		evidence = append(evidence, EvidenceItem{
+			Plugin:   f.Plugin,
+			Type:     f.Type,
+			Message:  f.Message,
+			Evidence: f.Evidence,
+			Metadata: cloneMetadata(f.Metadata),
+		})
+	}
+	sort.SliceStable(evidence, func(i, j int) bool {
+		if evidence[i].Plugin == evidence[j].Plugin {
+			if evidence[i].Type == evidence[j].Type {
+				return evidence[i].Message < evidence[j].Message
+			}
+			return evidence[i].Type < evidence[j].Type
+		}
+		return evidence[i].Plugin < evidence[j].Plugin
+	})
+	return evidence
+}
+
+func buildSources(fs []findings.Finding) []SourceFinding {
+	sources := make([]SourceFinding, 0, len(fs))
+	for _, f := range fs {
+		sources = append(sources, SourceFinding{
+			ID:       f.ID,
+			Plugin:   f.Plugin,
+			Type:     f.Type,
+			Severity: f.Severity,
+			Target:   f.Target,
+		})
+	}
+	sort.SliceStable(sources, func(i, j int) bool {
+		if sources[i].Plugin == sources[j].Plugin {
+			if sources[i].Type == sources[j].Type {
+				return sources[i].ID < sources[j].ID
+			}
+			return sources[i].Type < sources[j].Type
+		}
+		return sources[i].Plugin < sources[j].Plugin
+	})
+	return sources
+}
+
+func cloneMetadata(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/cases/builder_test.go
+++ b/internal/cases/builder_test.go
@@ -1,0 +1,191 @@
+package cases
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+func TestBuilderCollapsesFindings(t *testing.T) {
+	builder := NewBuilder(
+		WithDeterministicMode(42),
+		WithClock(func() time.Time { return time.Unix(1700000000, 0).UTC() }),
+	)
+
+	findingsList := []findings.Finding{
+		{
+			Version:    findings.SchemaVersion,
+			ID:         "F1",
+			Plugin:     "seer",
+			Type:       "seer.generic_api_key",
+			Message:    "High entropy API key discovered",
+			Target:     "https://example.com/app.js",
+			Severity:   findings.SeverityHigh,
+			DetectedAt: findings.NewTimestamp(time.Unix(1700000000, 0)),
+			Metadata:   map[string]string{"vector": "code", "asset_kind": "repo", "asset_id": "example/app"},
+		},
+		{
+			Version:  findings.SchemaVersion,
+			ID:       "F2",
+			Plugin:   "excavator",
+			Type:     "excavator.open_directory",
+			Message:  "Directory listing enabled",
+			Target:   "https://example.com/app.js",
+			Severity: findings.SeverityMedium,
+			Metadata: map[string]string{"vector": "web", "label:environment": "prod"},
+		},
+		{
+			Version:  findings.SchemaVersion,
+			ID:       "F3",
+			Plugin:   "proxy",
+			Type:     "proxy.session",
+			Message:  "Captured authenticated request",
+			Target:   "https://example.com/api",
+			Severity: findings.SeverityHigh,
+			Evidence: "GET /api/key",
+		},
+	}
+
+	cases, err := builder.Build(context.Background(), findingsList)
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if len(cases) != 1 {
+		t.Fatalf("expected 1 case, got %d", len(cases))
+	}
+
+	c := cases[0]
+	if got := len(c.Sources); got != len(findingsList) {
+		t.Fatalf("expected %d sources, got %d", len(findingsList), got)
+	}
+	if c.Risk.Severity != findings.SeverityHigh {
+		t.Fatalf("unexpected risk severity: %s", c.Risk.Severity)
+	}
+	if !strings.Contains(c.Summary, "example.com") {
+		t.Fatalf("summary did not mention target: %q", c.Summary)
+	}
+}
+
+func TestDeterministicReplayStableJSON(t *testing.T) {
+	cache := NewMemoryCache()
+	builder := NewBuilder(
+		WithDeterministicMode(1234),
+		WithClock(func() time.Time { return time.Unix(1700001000, 0).UTC() }),
+		WithCache(cache),
+	)
+
+	fs := []findings.Finding{{
+		Version:  findings.SchemaVersion,
+		ID:       "A",
+		Plugin:   "seer",
+		Type:     "seer.jwt_token",
+		Message:  "Potential JWT detected",
+		Target:   "https://api.example.com",
+		Evidence: "header.payload.signature",
+		Severity: findings.SeverityMedium,
+	}, {
+		Version:  findings.SchemaVersion,
+		ID:       "B",
+		Plugin:   "proxy",
+		Type:     "proxy.flow",
+		Message:  "Replayable request captured",
+		Target:   "https://api.example.com",
+		Severity: findings.SeverityMedium,
+	}}
+
+	run := func() string {
+		cases, err := builder.Build(context.Background(), fs)
+		if err != nil {
+			t.Fatalf("build failed: %v", err)
+		}
+		if len(cases) != 1 {
+			t.Fatalf("expected single case, got %d", len(cases))
+		}
+		data, err := ExportJSON(cases[0])
+		if err != nil {
+			t.Fatalf("ExportJSON failed: %v", err)
+		}
+		return string(data)
+	}
+
+	first := run()
+	second := run()
+	if first != second {
+		t.Fatalf("deterministic runs produced different JSON\nfirst: %s\nsecond: %s", first, second)
+	}
+}
+
+func TestGoldenSummary(t *testing.T) {
+	builder := NewBuilder(
+		WithDeterministicMode(2024),
+		WithClock(func() time.Time { return time.Unix(1700003000, 0).UTC() }),
+	)
+
+	fs := []findings.Finding{{
+		Version:  findings.SchemaVersion,
+		ID:       "1",
+		Plugin:   "seer",
+		Type:     "seer.email",
+		Message:  "Email address found",
+		Target:   "https://corp.example.com",
+		Severity: findings.SeverityLow,
+	}, {
+		Version:  findings.SchemaVersion,
+		ID:       "2",
+		Plugin:   "excavator",
+		Type:     "excavator.exposed_file",
+		Message:  "Public log leak",
+		Target:   "https://corp.example.com/logs",
+		Evidence: "access.log",
+		Severity: findings.SeverityMedium,
+	}}
+
+	cases, err := builder.Build(context.Background(), fs)
+	if err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("expected single case, got %d", len(cases))
+	}
+
+	got, err := json.MarshalIndent(cases[0], "", "  ")
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got = append(got, '\n')
+
+	goldenPath := filepath.Join("testdata", "golden_case.json")
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+
+	if string(want) != string(got) {
+		t.Fatalf("golden mismatch\nwant:\n%s\ngot:\n%s", string(want), string(got))
+	}
+}
+
+func TestPromptsIncludeEvidence(t *testing.T) {
+	proto := Case{Asset: Asset{Identifier: "api.example.com", Kind: "web"}, Vector: AttackVector{Kind: "web_crawl"}}
+	findings := []NormalisedFinding{{
+		Plugin:   "seer",
+		Severity: findings.SeverityHigh,
+		Message:  "API key exposed",
+		Evidence: "AKIA...",
+	}}
+
+	prompts := BuildPrompts(proto, findings)
+	if !strings.Contains(prompts.SummaryPrompt, "API key exposed") {
+		t.Fatalf("summary prompt missing message: %q", prompts.SummaryPrompt)
+	}
+	if !strings.Contains(prompts.ReproductionPrompt, "AKIA") {
+		t.Fatalf("reproduction prompt missing evidence: %q", prompts.ReproductionPrompt)
+	}
+}

--- a/internal/cases/cache.go
+++ b/internal/cases/cache.go
@@ -1,0 +1,41 @@
+package cases
+
+import "sync"
+
+// SummaryCache stores summariser outputs for deterministic replay.
+type SummaryCache interface {
+	Get(key string) (SummaryOutput, bool)
+	Set(key string, value SummaryOutput)
+}
+
+// MemoryCache is a threadsafe in-memory cache implementation suitable for tests.
+type MemoryCache struct {
+	mu sync.RWMutex
+	m  map[string]SummaryOutput
+}
+
+// NewMemoryCache constructs an empty memory cache.
+func NewMemoryCache() *MemoryCache {
+	return &MemoryCache{m: make(map[string]SummaryOutput)}
+}
+
+// Get retrieves a cached summary.
+func (c *MemoryCache) Get(key string) (SummaryOutput, bool) {
+	if c == nil {
+		return SummaryOutput{}, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	v, ok := c.m[key]
+	return v, ok
+}
+
+// Set stores a summary output.
+func (c *MemoryCache) Set(key string, value SummaryOutput) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.m[key] = value
+	c.mu.Unlock()
+}

--- a/internal/cases/case.go
+++ b/internal/cases/case.go
@@ -1,0 +1,163 @@
+package cases
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+// CaseSchemaVersion captures the version of the Case JSON structure emitted by the builder.
+const CaseSchemaVersion = "1.0"
+
+// Case represents a deduplicated issue that merges evidence from multiple plugins.
+type Case struct {
+	Version       string             `json:"version"`
+	ID            string             `json:"id"`
+	Asset         Asset              `json:"asset"`
+	Vector        AttackVector       `json:"vector"`
+	Summary       string             `json:"summary"`
+	Evidence      []EvidenceItem     `json:"evidence"`
+	Proof         ProofOfConcept     `json:"proof"`
+	Risk          Risk               `json:"risk"`
+	Confidence    float64            `json:"confidence"`
+	ConfidenceLog string             `json:"confidence_log,omitempty"`
+	Sources       []SourceFinding    `json:"sources"`
+	GeneratedAt   findings.Timestamp `json:"generated_at"`
+	Labels        map[string]string  `json:"labels,omitempty"`
+}
+
+// Asset describes the affected resource in a normalised form.
+type Asset struct {
+	Kind       string `json:"kind"`
+	Identifier string `json:"identifier"`
+	Details    string `json:"details,omitempty"`
+}
+
+// AttackVector captures the avenue that led to the case being raised.
+type AttackVector struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value,omitempty"`
+}
+
+// EvidenceItem collates raw signals that contributed to the case.
+type EvidenceItem struct {
+	Plugin   string            `json:"plugin"`
+	Type     string            `json:"type"`
+	Message  string            `json:"message"`
+	Evidence string            `json:"evidence,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// ProofOfConcept aggregates reproduction steps and rationale.
+type ProofOfConcept struct {
+	Summary string   `json:"summary,omitempty"`
+	Steps   []string `json:"steps"`
+}
+
+// Risk captures the severity and supporting rationale for the case.
+type Risk struct {
+	Severity  findings.Severity `json:"severity"`
+	Score     float64           `json:"score"`
+	Rationale string            `json:"rationale,omitempty"`
+}
+
+// SourceFinding references the plugin findings that were rolled up into the case.
+type SourceFinding struct {
+	ID       string            `json:"id"`
+	Plugin   string            `json:"plugin"`
+	Type     string            `json:"type"`
+	Severity findings.Severity `json:"severity"`
+	Target   string            `json:"target,omitempty"`
+}
+
+// Clone returns a deep copy of the case ensuring cached results cannot be mutated by callers.
+func (c Case) Clone() Case {
+	clone := c
+	if len(c.Evidence) > 0 {
+		clone.Evidence = make([]EvidenceItem, len(c.Evidence))
+		for i, item := range c.Evidence {
+			clone.Evidence[i] = item.Clone()
+		}
+	}
+	if len(c.Sources) > 0 {
+		clone.Sources = make([]SourceFinding, len(c.Sources))
+		copy(clone.Sources, c.Sources)
+	}
+	if len(c.Proof.Steps) > 0 {
+		clone.Proof.Steps = append([]string(nil), c.Proof.Steps...)
+	}
+	if len(c.Labels) > 0 {
+		clone.Labels = make(map[string]string, len(c.Labels))
+		for k, v := range c.Labels {
+			clone.Labels[k] = v
+		}
+	}
+	return clone
+}
+
+// Clone returns a deep copy of the evidence item.
+func (e EvidenceItem) Clone() EvidenceItem {
+	clone := e
+	if len(e.Metadata) > 0 {
+		clone.Metadata = make(map[string]string, len(e.Metadata))
+		for k, v := range e.Metadata {
+			clone.Metadata[k] = v
+		}
+	}
+	return clone
+}
+
+// MarshalJSON ensures evidence metadata is emitted in a stable order to aid golden tests.
+func (e EvidenceItem) MarshalJSON() ([]byte, error) {
+	type Alias EvidenceItem
+	alias := Alias(e.Clone())
+	if len(alias.Metadata) > 0 {
+		keys := make([]string, 0, len(alias.Metadata))
+		for k := range alias.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		ordered := make(map[string]string, len(alias.Metadata))
+		for _, k := range keys {
+			ordered[k] = alias.Metadata[k]
+		}
+		alias.Metadata = ordered
+	}
+	return json.Marshal(alias)
+}
+
+// MarshalJSON ensures labels are emitted in stable order.
+func (c Case) MarshalJSON() ([]byte, error) {
+	type Alias Case
+	alias := Alias(c.Clone())
+	if len(alias.Labels) > 0 {
+		keys := make([]string, 0, len(alias.Labels))
+		for k := range alias.Labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		ordered := make(map[string]string, len(alias.Labels))
+		for _, k := range keys {
+			ordered[k] = alias.Labels[k]
+		}
+		alias.Labels = ordered
+	}
+	return json.Marshal(alias)
+}
+
+// NormalisedKey returns a stable identifier used when deduplicating plugin findings.
+func (c Case) NormalisedKey() string {
+	var b strings.Builder
+	b.WriteString(strings.ToLower(strings.TrimSpace(c.Asset.Kind)))
+	b.WriteString("|")
+	b.WriteString(strings.ToLower(strings.TrimSpace(c.Asset.Identifier)))
+	b.WriteString("|")
+	b.WriteString(strings.ToLower(strings.TrimSpace(c.Vector.Kind)))
+	if v := strings.TrimSpace(c.Vector.Value); v != "" {
+		b.WriteString("|")
+		b.WriteString(strings.ToLower(v))
+	}
+	return b.String()
+}

--- a/internal/cases/export.go
+++ b/internal/cases/export.go
@@ -1,0 +1,130 @@
+package cases
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+// ExportJSON renders the case as pretty-printed JSON.
+func ExportJSON(c Case) ([]byte, error) {
+	buf, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	buf = append(buf, '\n')
+	return buf, nil
+}
+
+// ExportMarkdown renders a human readable markdown report for the case.
+func ExportMarkdown(c Case) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Case %s\n\n", c.ID)
+	fmt.Fprintf(&b, "- Asset: **%s** (%s)\n", c.Asset.Identifier, c.Asset.Kind)
+	fmt.Fprintf(&b, "- Attack vector: **%s**", c.Vector.Kind)
+	if c.Vector.Value != "" {
+		fmt.Fprintf(&b, " (%s)", c.Vector.Value)
+	}
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "- Risk: **%s** (score %.1f)\n", strings.ToUpper(string(c.Risk.Severity)), c.Risk.Score)
+	fmt.Fprintf(&b, "- Confidence: %.2f\n\n", c.Confidence)
+
+	b.WriteString("## Summary\n")
+	b.WriteString(c.Summary)
+	b.WriteString("\n\n")
+
+	if len(c.Proof.Steps) > 0 {
+		b.WriteString("## Reproduction steps\n")
+		for i, step := range c.Proof.Steps {
+			fmt.Fprintf(&b, "%d. %s\n", i+1, step)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(c.Evidence) > 0 {
+		b.WriteString("## Evidence\n")
+		for _, e := range c.Evidence {
+			fmt.Fprintf(&b, "- **%s** (%s): %s\n", strings.Title(e.Plugin), e.Type, e.Message)
+			if e.Evidence != "" {
+				fmt.Fprintf(&b, "  - Evidence: `%s`\n", e.Evidence)
+			}
+		}
+	}
+
+	return b.String()
+}
+
+var htmlTemplate = template.Must(template.New("case").Funcs(template.FuncMap{
+	"title": strings.Title,
+	"upper": strings.ToUpper,
+	"splitLines": func(s string) []string {
+		s = strings.ReplaceAll(s, "\r\n", "\n")
+		parts := strings.Split(s, "\n")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			out = append(out, p)
+		}
+		return out
+	},
+}).Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Case {{ .ID }}</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; line-height: 1.5; }
+h1 { font-size: 1.8rem; }
+section { margin-bottom: 1.5rem; }
+ul { padding-left: 1.2rem; }
+code { background: #f6f8fa; padding: 0.2rem 0.4rem; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>Case {{ .ID }}</h1>
+<section>
+  <p><strong>Asset:</strong> {{ .Asset.Identifier }} ({{ .Asset.Kind }})<br/>
+     <strong>Vector:</strong> {{ .Vector.Kind }}{{ if .Vector.Value }} ({{ .Vector.Value }}){{ end }}<br/>
+     <strong>Risk:</strong> {{ .Risk.Severity | upper }} ({{ printf "%.1f" .Risk.Score }})<br/>
+     <strong>Confidence:</strong> {{ printf "%.2f" .Confidence }}</p>
+</section>
+<section>
+  <h2>Summary</h2>
+  {{ range splitLines .Summary }}<p>{{ . }}</p>{{ end }}
+</section>
+{{ if gt (len .Proof.Steps) 0 }}
+<section>
+  <h2>Reproduction steps</h2>
+  <ol>
+    {{ range .Proof.Steps }}<li>{{ . }}</li>{{ end }}
+  </ol>
+</section>
+{{ end }}
+{{ if gt (len .Evidence) 0 }}
+<section>
+  <h2>Evidence</h2>
+  <ul>
+    {{ range .Evidence }}<li><strong>{{ title .Plugin }}</strong> ({{ .Type }}): {{ .Message }}{{ if .Evidence }}<br/><code>{{ .Evidence }}</code>{{ end }}</li>{{ end }}
+  </ul>
+</section>
+{{ end }}
+</body>
+</html>`))
+
+// ExportHTML renders an HTML snapshot suitable for sharing.
+func ExportHTML(c Case) (string, error) {
+	var buf bytes.Buffer
+	data := struct {
+		Case
+	}{Case: c}
+	err := htmlTemplate.Execute(&buf, data)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/internal/cases/normalise.go
+++ b/internal/cases/normalise.go
@@ -1,0 +1,173 @@
+package cases
+
+import (
+	"net"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+var severityOrder = map[findings.Severity]int{
+	findings.SeverityCritical: 5,
+	findings.SeverityHigh:     4,
+	findings.SeverityMedium:   3,
+	findings.SeverityLow:      2,
+	findings.SeverityInfo:     1,
+}
+
+func selectDominantFinding(fs []findings.Finding) findings.Finding {
+	if len(fs) == 0 {
+		return findings.Finding{}
+	}
+	dominant := fs[0]
+	for _, f := range fs[1:] {
+		if severityOrder[f.Severity] > severityOrder[dominant.Severity] {
+			dominant = f
+			continue
+		}
+		if severityOrder[f.Severity] == severityOrder[dominant.Severity] {
+			if strings.Compare(f.Message, dominant.Message) < 0 {
+				dominant = f
+			}
+		}
+	}
+	return dominant
+}
+
+func normaliseAsset(f findings.Finding) Asset {
+	target := strings.TrimSpace(f.Target)
+	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+		if u, err := url.Parse(target); err == nil && u.Host != "" {
+			host := strings.ToLower(u.Host)
+			if h, _, err := net.SplitHostPort(host); err == nil && h != "" {
+				host = h
+			}
+			details := strings.TrimSpace(f.Metadata["asset_detail"])
+			if details == "" {
+				details = u.String()
+			}
+			return Asset{Kind: "web", Identifier: host, Details: details}
+		}
+	}
+
+	kind := strings.TrimSpace(f.Metadata["asset_kind"])
+	identifier := strings.TrimSpace(f.Metadata["asset_id"])
+	details := strings.TrimSpace(f.Metadata["asset_detail"])
+
+	if kind != "" && identifier != "" {
+		return Asset{Kind: strings.ToLower(kind), Identifier: identifier, Details: details}
+	}
+
+	if target == "" {
+		return Asset{Kind: "generic", Identifier: f.Plugin}
+	}
+
+	if strings.Contains(target, "@") && !strings.Contains(target, " ") {
+		return Asset{Kind: "account", Identifier: strings.ToLower(target)}
+	}
+
+	if strings.Contains(target, ":") {
+		parts := strings.Split(target, ":")
+		if len(parts) > 1 {
+			return Asset{Kind: strings.ToLower(parts[0]), Identifier: strings.Join(parts[1:], ":")}
+		}
+	}
+
+	return Asset{Kind: "generic", Identifier: strings.ToLower(target)}
+}
+
+func normaliseVector(fs []findings.Finding) AttackVector {
+	if len(fs) == 0 {
+		return AttackVector{Kind: "unknown"}
+	}
+	vectorCounts := make(map[string]int)
+	for _, f := range fs {
+		vector := extractVectorFromFinding(f)
+		if vector == "" {
+			vector = "unknown"
+		}
+		vectorCounts[vector]++
+	}
+	type vectorCount struct {
+		key   string
+		count int
+	}
+	ranking := make([]vectorCount, 0, len(vectorCounts))
+	for k, v := range vectorCounts {
+		ranking = append(ranking, vectorCount{key: k, count: v})
+	}
+	sort.SliceStable(ranking, func(i, j int) bool {
+		if ranking[i].count == ranking[j].count {
+			return ranking[i].key < ranking[j].key
+		}
+		return ranking[i].count > ranking[j].count
+	})
+	top := ranking[0]
+	parts := strings.SplitN(top.key, "|", 2)
+	kind := parts[0]
+	value := ""
+	if len(parts) > 1 {
+		value = parts[1]
+	}
+	if kind == "" {
+		kind = "unknown"
+	}
+	return AttackVector{Kind: kind, Value: value}
+}
+
+func extractVectorFromFinding(f findings.Finding) string {
+	vector := strings.TrimSpace(f.Metadata["vector"])
+	if vector != "" {
+		return strings.ToLower(vector)
+	}
+	switch strings.ToLower(f.Plugin) {
+	case "seer":
+		return "source_code"
+	case "excavator":
+		return "web_crawl"
+	case "proxy":
+		return "http_proxy"
+	default:
+		return "unknown"
+	}
+}
+
+func canonicalTarget(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		if u, err := url.Parse(raw); err == nil && u.Host != "" {
+			host := strings.ToLower(u.Host)
+			if h, _, err := net.SplitHostPort(host); err == nil && h != "" {
+				host = h
+			}
+			return host
+		}
+	}
+	return strings.ToLower(raw)
+}
+
+// NormalisedFinding represents a plugin finding prepared for summarisation.
+type NormalisedFinding struct {
+	Plugin   string            `json:"plugin"`
+	Type     string            `json:"type"`
+	Message  string            `json:"message"`
+	Evidence string            `json:"evidence,omitempty"`
+	Severity findings.Severity `json:"severity"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+func normaliseFinding(f findings.Finding) NormalisedFinding {
+	return NormalisedFinding{
+		Plugin:   f.Plugin,
+		Type:     f.Type,
+		Message:  f.Message,
+		Evidence: f.Evidence,
+		Severity: f.Severity,
+		Metadata: cloneMetadata(f.Metadata),
+	}
+}

--- a/internal/cases/prompts.go
+++ b/internal/cases/prompts.go
@@ -1,0 +1,61 @@
+package cases
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// PromptSet contains the LLM-ready prompts generated for a case.
+type PromptSet struct {
+	SummaryPrompt      string `json:"summary_prompt"`
+	ReproductionPrompt string `json:"reproduction_prompt"`
+}
+
+// BuildPrompts generates deterministic prompts that can be fed to an LLM for richer summaries.
+func BuildPrompts(proto Case, findings []NormalisedFinding) PromptSet {
+	summary := buildSummaryPrompt(proto, findings)
+	repro := buildReproductionPrompt(proto, findings)
+	return PromptSet{SummaryPrompt: summary, ReproductionPrompt: repro}
+}
+
+func buildSummaryPrompt(proto Case, findings []NormalisedFinding) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "You are an AI security analyst. Summarise why the following signals combine into a single case.\n")
+	fmt.Fprintf(&buf, "Asset: %s (%s)\n", proto.Asset.Identifier, proto.Asset.Kind)
+	fmt.Fprintf(&buf, "Attack vector: %s", proto.Vector.Kind)
+	if proto.Vector.Value != "" {
+		fmt.Fprintf(&buf, " (%s)", proto.Vector.Value)
+	}
+	buf.WriteString("\nEvidence:\n")
+	for _, f := range findings {
+		fmt.Fprintf(&buf, "- Plugin=%s Severity=%s Message=%s\n", f.Plugin, strings.ToUpper(string(f.Severity)), f.Message)
+	}
+	buf.WriteString("Provide a concise narrative and highlight overlapping evidence.\n")
+	return buf.String()
+}
+
+func buildReproductionPrompt(proto Case, findings []NormalisedFinding) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Synthesize deterministic reproduction steps for asset %s (%s).\n", proto.Asset.Identifier, proto.Asset.Kind)
+	buf.WriteString("Use at most 4 steps. Incorporate plugin observations:\n")
+	for _, f := range findings {
+		if strings.TrimSpace(f.Evidence) != "" {
+			fmt.Fprintf(&buf, "- %s evidence: %s\n", strings.Title(f.Plugin), truncate(f.Evidence, 200))
+		} else {
+			fmt.Fprintf(&buf, "- %s observed: %s\n", strings.Title(f.Plugin), f.Message)
+		}
+	}
+	buf.WriteString("Return concise imperative steps.")
+	return buf.String()
+}
+
+func truncate(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/internal/cases/summarizer.go
+++ b/internal/cases/summarizer.go
@@ -1,0 +1,129 @@
+package cases
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+// SummaryInput contains the data passed to the summariser implementation.
+type SummaryInput struct {
+	Case     Case                `json:"case"`
+	Findings []NormalisedFinding `json:"findings"`
+	Prompts  PromptSet           `json:"prompts"`
+}
+
+// SummaryOutput captures the structured content returned by the summariser.
+type SummaryOutput struct {
+	Summary           string            `json:"summary"`
+	ProofSummary      string            `json:"proof_summary"`
+	ReproductionSteps []string          `json:"reproduction_steps"`
+	RiskSeverity      findings.Severity `json:"risk_severity"`
+	RiskScore         float64           `json:"risk_score"`
+	RiskRationale     string            `json:"risk_rationale"`
+	ConfidenceScore   float64           `json:"confidence_score"`
+	ConfidenceLog     string            `json:"confidence_log"`
+}
+
+// Summarizer collapses multiple findings into a single explanation and proof of concept.
+type Summarizer interface {
+	Summarize(ctx context.Context, input SummaryInput) (SummaryOutput, error)
+}
+
+// DefaultSummarizer returns a deterministic summarizer that does not require network calls.
+func DefaultSummarizer() Summarizer {
+	return deterministicSummarizer{}
+}
+
+type deterministicSummarizer struct{}
+
+func (deterministicSummarizer) Summarize(_ context.Context, input SummaryInput) (SummaryOutput, error) {
+	if len(input.Findings) == 0 {
+		return SummaryOutput{}, fmt.Errorf("no findings supplied to summarizer")
+	}
+
+	asset := input.Case.Asset.Identifier
+	if input.Case.Asset.Details != "" {
+		asset = fmt.Sprintf("%s (%s)", asset, input.Case.Asset.Details)
+	}
+
+	pluginSet := make(map[string]struct{})
+	severity := findings.SeverityInfo
+	var summaryLines []string
+	for _, f := range input.Findings {
+		pluginSet[f.Plugin] = struct{}{}
+		if severityOrder[f.Severity] > severityOrder[severity] {
+			severity = f.Severity
+		}
+		summaryLines = append(summaryLines, fmt.Sprintf("- [%s] %s (%s)", strings.Title(f.Plugin), f.Message, strings.ToUpper(string(f.Severity))))
+	}
+
+	summary := fmt.Sprintf("%d plugin signal(s) indicate an issue affecting %s.", len(pluginSet), asset)
+	summary += "\n\nKey evidence:\n" + strings.Join(summaryLines, "\n")
+
+	steps := buildReproductionSteps(input)
+	confidence, log := scoreConfidence(pluginSet, input.Findings)
+	riskScore := scoreRisk(severity)
+
+	return SummaryOutput{
+		Summary:           summary,
+		ProofSummary:      fmt.Sprintf("Reproduce the issue on %s by following %d synthesised steps.", input.Case.Asset.Identifier, len(steps)),
+		ReproductionSteps: steps,
+		RiskSeverity:      severity,
+		RiskScore:         riskScore,
+		RiskRationale:     fmt.Sprintf("Highest severity reported by contributing plugins: %s", strings.ToUpper(string(severity))),
+		ConfidenceScore:   confidence,
+		ConfidenceLog:     log,
+	}, nil
+}
+
+func buildReproductionSteps(input SummaryInput) []string {
+	if len(input.Prompts.ReproductionPrompt) > 0 {
+		// Provide deterministic synthetic steps derived from prompts to emulate prompt chaining.
+		return []string{
+			fmt.Sprintf("Review plugin evidence: %s", strings.TrimSpace(input.Prompts.SummaryPrompt)),
+			fmt.Sprintf("Execute reproduction instructions synthesised from prompt: %s", strings.TrimSpace(input.Prompts.ReproductionPrompt)),
+		}
+	}
+	return []string{"Review plugin evidence", "Attempt to recreate based on gathered artefacts"}
+}
+
+func scoreConfidence(plugins map[string]struct{}, findings []NormalisedFinding) (float64, string) {
+	uniquePlugins := len(plugins)
+	totalFindings := len(findings)
+	if totalFindings == 0 {
+		return 0, "no findings"
+	}
+	base := 0.35 + 0.2*float64(uniquePlugins-1)
+	if base < 0.2 {
+		base = 0.2
+	}
+	if base > 0.9 {
+		base = 0.9
+	}
+	// Reward corroborating evidence from the same plugin without exceeding 1.0.
+	corroboration := 0.05 * float64(totalFindings-uniquePlugins)
+	score := base + corroboration
+	if score > 1.0 {
+		score = 1.0
+	}
+	log := fmt.Sprintf("%d plugin(s), %d finding(s)", uniquePlugins, totalFindings)
+	return score, log
+}
+
+func scoreRisk(severity findings.Severity) float64 {
+	switch severity {
+	case findings.SeverityCritical:
+		return 9.5
+	case findings.SeverityHigh:
+		return 8.0
+	case findings.SeverityMedium:
+		return 5.5
+	case findings.SeverityLow:
+		return 3.0
+	default:
+		return 1.0
+	}
+}

--- a/internal/cases/testdata/golden_case.json
+++ b/internal/cases/testdata/golden_case.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "id": "TFYQRWYLW5TXVDTX7357DBU4BT",
+  "asset": {
+    "kind": "web",
+    "identifier": "corp.example.com",
+    "details": "https://corp.example.com/logs"
+  },
+  "vector": {
+    "kind": "source_code"
+  },
+  "summary": "2 plugin signal(s) indicate an issue affecting corp.example.com (https://corp.example.com/logs).\n\nKey evidence:\n- [Excavator] Public log leak (MED)\n- [Seer] Email address found (LOW)",
+  "evidence": [
+    {
+      "plugin": "excavator",
+      "type": "excavator.exposed_file",
+      "message": "Public log leak",
+      "evidence": "access.log"
+    },
+    {
+      "plugin": "seer",
+      "type": "seer.email",
+      "message": "Email address found"
+    }
+  ],
+  "proof": {
+    "summary": "Reproduce the issue on corp.example.com by following 2 synthesised steps.",
+    "steps": [
+      "Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\nAsset: corp.example.com (web)\nAttack vector: source_code\nEvidence:\n- Plugin=excavator Severity=MED Message=Public log leak\n- Plugin=seer Severity=LOW Message=Email address found\nProvide a concise narrative and highlight overlapping evidence.",
+      "Execute reproduction instructions synthesised from prompt: Synthesize deterministic reproduction steps for asset corp.example.com (web).\nUse at most 4 steps. Incorporate plugin observations:\n- Excavator evidence: access.log\n- Seer observed: Email address found\nReturn concise imperative steps."
+    ]
+  },
+  "risk": {
+    "severity": "med",
+    "score": 5.5,
+    "rationale": "Highest severity reported by contributing plugins: MED"
+  },
+  "confidence": 0.55,
+  "confidence_log": "2 plugin(s), 2 finding(s)",
+  "sources": [
+    {
+      "id": "2",
+      "plugin": "excavator",
+      "type": "excavator.exposed_file",
+      "severity": "med",
+      "target": "https://corp.example.com/logs"
+    },
+    {
+      "id": "1",
+      "plugin": "seer",
+      "type": "seer.email",
+      "severity": "low",
+      "target": "https://corp.example.com"
+    }
+  ],
+  "generated_at": "2023-11-14T23:03:20Z"
+}

--- a/proto/glyph/case.proto
+++ b/proto/glyph/case.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package glyph.casebuilder;
+
+option go_package = "github.com/RowanDark/Glyph/proto/gen/go/proto/glyph";
+
+import "glyph/common.proto";
+
+message Case {
+  string version = 1;
+  string id = 2;
+  Asset asset = 3;
+  AttackVector vector = 4;
+  string summary = 5;
+  repeated Evidence evidence = 6;
+  ProofOfConcept proof = 7;
+  Risk risk = 8;
+  double confidence = 9;
+  string confidence_log = 10;
+  repeated SourceFinding sources = 11;
+  string generated_at = 12;
+  map<string, string> labels = 13;
+}
+
+message Asset {
+  string kind = 1;
+  string identifier = 2;
+  string details = 3;
+}
+
+message AttackVector {
+  string kind = 1;
+  string value = 2;
+}
+
+message Evidence {
+  string plugin = 1;
+  string type = 2;
+  string message = 3;
+  string evidence = 4;
+  map<string, string> metadata = 5;
+}
+
+message ProofOfConcept {
+  string summary = 1;
+  repeated string steps = 2;
+}
+
+message Risk {
+  glyph.common.Severity severity = 1;
+  double score = 2;
+  string rationale = 3;
+}
+
+message SourceFinding {
+  string id = 1;
+  string plugin = 2;
+  string type = 3;
+  glyph.common.Severity severity = 4;
+  string target = 5;
+}
+
+message CaseExport {
+  repeated Case cases = 1;
+}


### PR DESCRIPTION
## Summary
- introduce an internal case builder that merges plugin findings, normalises assets/vectors, and produces deterministic summaries, repro steps, and exports
- add caching, LLM prompt generation, and golden tests to ensure replayable outputs with reproducible JSON/Markdown/HTML renders
- define a Case protobuf schema for downstream HTML/Markdown/JSON exporters

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd21d24d40832a9f761bff769b578f