### PR TITLE
feat: add replay artifact tooling

### DIFF
--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -62,23 +62,25 @@ func main() {
 			fmt.Fprintf(os.Stderr, "unknown history subcommand: %s\n", args[1])
 			os.Exit(2)
 		}
-	case "repeater":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "repeater subcommand required")
-			os.Exit(2)
-		}
-		switch args[1] {
-		case "send":
-			os.Exit(runRepeaterSend(args[2:]))
-		default:
-			fmt.Fprintf(os.Stderr, "unknown repeater subcommand: %s\n", args[1])
-			os.Exit(2)
-		}
-	case "version":
-		os.Exit(runVersion(args[1:]))
-	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
-		flag.Usage()
+        case "repeater":
+                if len(args) < 2 {
+                        fmt.Fprintln(os.Stderr, "repeater subcommand required")
+                        os.Exit(2)
+                }
+                switch args[1] {
+                case "send":
+                        os.Exit(runRepeaterSend(args[2:]))
+                default:
+                        fmt.Fprintf(os.Stderr, "unknown repeater subcommand: %s\n", args[1])
+                        os.Exit(2)
+                }
+        case "replay":
+                os.Exit(runReplay(args[1:]))
+        case "version":
+                os.Exit(runVersion(args[1:]))
+        default:
+                fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
+                flag.Usage()
 		os.Exit(2)
 	}
 }

--- a/cmd/glyphctl/replay.go
+++ b/cmd/glyphctl/replay.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/replay"
+	"github.com/RowanDark/Glyph/internal/reporter"
+)
+
+func runReplay(args []string) int {
+	fs := flag.NewFlagSet("replay", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	outDir := fs.String("out", "", "directory to write replay outputs (defaults to ${GLYPH_OUT:-.}/replay)")
+	verifyOnly := fs.Bool("verify-only", false, "only verify recorded cases without writing outputs")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: glyphctl replay [--out dir] <artifact>")
+		return 2
+	}
+
+	artefactPath := strings.TrimSpace(fs.Arg(0))
+	if artefactPath == "" {
+		fmt.Fprintln(os.Stderr, "artifact path is required")
+		return 2
+	}
+	if _, err := os.Stat(artefactPath); err != nil {
+		fmt.Fprintf(os.Stderr, "open artifact: %v\n", err)
+		return 1
+	}
+
+	dest := strings.TrimSpace(*outDir)
+	if dest == "" {
+		if env := strings.TrimSpace(os.Getenv("GLYPH_OUT")); env != "" {
+			dest = filepath.Join(env, "replay")
+		} else {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "determine working directory: %v\n", err)
+				return 1
+			}
+			dest = filepath.Join(cwd, "replay")
+		}
+	}
+
+	tmpDir, err := os.MkdirTemp("", "glyph-replay-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create temp dir: %v\n", err)
+		return 1
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	manifest, err := replay.ExtractArtifact(artefactPath, tmpDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "extract artifact: %v\n", err)
+		return 1
+	}
+
+	findingsPath := filepath.Join(tmpDir, filepath.FromSlash(manifest.FindingsFile))
+	findingsList, err := reporter.ReadJSONL(findingsPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load findings: %v\n", err)
+		return 1
+	}
+
+	builder := configureCaseBuilder(manifest)
+	builtCases, err := builder.Build(context.Background(), findingsList)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build cases: %v\n", err)
+		return 1
+	}
+
+	expectedCasesPath := filepath.Join(tmpDir, filepath.FromSlash(manifest.CasesFile))
+	expectedCases, err := replay.LoadCases(expectedCasesPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load recorded cases: %v\n", err)
+		return 1
+	}
+
+	if !replay.CasesEqual(builtCases, expectedCases) {
+		fmt.Fprintln(os.Stderr, "replayed cases diverged from recorded output")
+		return 1
+	}
+
+	if *verifyOnly {
+		fmt.Fprintf(os.Stdout, "verified %d cases from %s\n", len(builtCases), artefactPath)
+		return 0
+	}
+
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "create output directory: %v\n", err)
+		return 1
+	}
+
+	outputCasesPath := filepath.Join(dest, "cases.replay.json")
+	if err := replay.WriteCases(outputCasesPath, builtCases); err != nil {
+		fmt.Fprintf(os.Stderr, "write replay cases: %v\n", err)
+		return 1
+	}
+
+	if err := exportSupplemental(manifest, tmpDir, dest); err != nil {
+		fmt.Fprintf(os.Stderr, "export supplemental data: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(os.Stdout, "replayed %d cases to %s\n", len(builtCases), outputCasesPath)
+	return 0
+}
+
+func configureCaseBuilder(manifest replay.Manifest) *cases.Builder {
+	var opts []cases.Option
+	if manifest.CaseTimestamp.IsZero() {
+		manifest.CaseTimestamp = time.Now().UTC()
+	}
+	opts = append(opts, cases.WithClock(func() time.Time { return manifest.CaseTimestamp }))
+	if seed, ok := manifest.Seeds["cases"]; ok {
+		opts = append(opts, cases.WithDeterministicMode(seed))
+	}
+	return cases.NewBuilder(opts...)
+}
+
+func exportSupplemental(manifest replay.Manifest, root, dest string) error {
+	if len(manifest.Responses) == 0 && len(manifest.Robots) == 0 {
+		return nil
+	}
+	copyFile := func(relPath, targetDir string) error {
+		if strings.TrimSpace(relPath) == "" {
+			return nil
+		}
+		src := filepath.Join(root, filepath.FromSlash(relPath))
+		if _, err := os.Stat(src); err != nil {
+			return fmt.Errorf("missing supplemental file %s: %w", relPath, err)
+		}
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			return fmt.Errorf("create supplemental directory: %w", err)
+		}
+		dst := filepath.Join(targetDir, filepath.Base(relPath))
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read supplemental file %s: %w", relPath, err)
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return fmt.Errorf("write supplemental file %s: %w", relPath, err)
+		}
+		return nil
+	}
+
+	responsesDir := filepath.Join(dest, "responses")
+	for _, resp := range manifest.Responses {
+		if err := copyFile(resp.BodyFile, responsesDir); err != nil {
+			return err
+		}
+	}
+	robotsDir := filepath.Join(dest, "robots")
+	for _, rob := range manifest.Robots {
+		if err := copyFile(rob.BodyFile, robotsDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/glyphctl/replay_test.go
+++ b/cmd/glyphctl/replay_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/findings"
+	"github.com/RowanDark/Glyph/internal/replay"
+)
+
+func TestRunReplay(t *testing.T) {
+	dir := t.TempDir()
+	findingsPath := filepath.Join(dir, "findings.jsonl")
+	casesPath := filepath.Join(dir, "cases.json")
+
+	finding := findings.Finding{
+		Version:    findings.SchemaVersion,
+		ID:         "01HV7RCFF0J1AY7P5Z9Q4C1100",
+		Plugin:     "seer",
+		Type:       "demo",
+		Message:    "Demo finding",
+		Target:     "https://example.com",
+		Severity:   findings.SeverityHigh,
+		DetectedAt: findings.NewTimestamp(time.Unix(1700002000, 0).UTC()),
+	}
+	findingBytes, err := json.Marshal(finding)
+	if err != nil {
+		t.Fatalf("marshal finding: %v", err)
+	}
+	if err := os.WriteFile(findingsPath, append(findingBytes, '\n'), 0o644); err != nil {
+		t.Fatalf("write findings: %v", err)
+	}
+
+	builder := cases.NewBuilder(
+		cases.WithDeterministicMode(42),
+		cases.WithClock(func() time.Time { return time.Unix(1700002000, 0).UTC() }),
+	)
+	built, err := builder.Build(t.Context(), []findings.Finding{finding})
+	if err != nil {
+		t.Fatalf("build cases: %v", err)
+	}
+	if err := replay.WriteCases(casesPath, built); err != nil {
+		t.Fatalf("write cases: %v", err)
+	}
+
+	manifest := replay.Manifest{
+		Version:       replay.ManifestVersion,
+		CreatedAt:     time.Unix(1700002000, 0).UTC(),
+		Seeds:         map[string]int64{"cases": 42},
+		Runner:        replay.DefaultRunnerInfo(),
+		FindingsFile:  "findings.jsonl",
+		CasesFile:     "cases.json",
+		CaseTimestamp: time.Unix(1700002000, 0).UTC(),
+		Responses: []replay.ResponseRecord{{
+			RequestURL: "https://example.com",
+			Method:     "GET",
+			Status:     200,
+			BodyFile:   "responses/example.json",
+		}},
+	}
+
+	files := map[string][]byte{
+		"findings.jsonl":         mustReadFile(t, findingsPath),
+		"cases.json":             mustReadFile(t, casesPath),
+		"responses/example.json": []byte(`{"status":"ok"}`),
+	}
+
+	artefact := filepath.Join(dir, "glyph.replay.tgz")
+	if err := replay.CreateArtifact(artefact, manifest, files); err != nil {
+		t.Fatalf("CreateArtifact failed: %v", err)
+	}
+
+	outDir := filepath.Join(dir, "out")
+	if code := runReplay([]string{"--out", outDir, artefact}); code != 0 {
+		t.Fatalf("runReplay exited with %d", code)
+	}
+
+	generated, err := replay.LoadCases(filepath.Join(outDir, "cases.replay.json"))
+	if err != nil {
+		t.Fatalf("load replay cases: %v", err)
+	}
+	if !replay.CasesEqual(built, generated) {
+		t.Fatalf("replayed cases do not match original")
+	}
+
+	// Verify supplemental data copied.
+	if _, err := os.Stat(filepath.Join(outDir, "responses", "example.json")); err != nil {
+		t.Fatalf("supplemental response not exported: %v", err)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	return data
+}

--- a/internal/replay/artifact.go
+++ b/internal/replay/artifact.go
@@ -1,0 +1,251 @@
+package replay
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	manifestName = "manifest.json"
+	filesDir     = "files"
+)
+
+// CreateArtifact writes the replay manifest and referenced files to a gzipped tarball.
+func CreateArtifact(path string, manifest Manifest, files map[string][]byte) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("artefact path is required")
+	}
+	if manifest.Version == "" {
+		manifest.Version = ManifestVersion
+	}
+	if manifest.Runner.GlyphctlVersion == "" && manifest.Runner.GlyphdVersion == "" {
+		manifest.Runner = DefaultRunnerInfo()
+	}
+	var err error
+	manifest.FindingsFile, err = normalizeFileRef(manifest.FindingsFile)
+	if err != nil {
+		return err
+	}
+	manifest.CasesFile, err = normalizeFileRef(manifest.CasesFile)
+	if err != nil {
+		return err
+	}
+	for i := range manifest.Responses {
+		if manifest.Responses[i].BodyFile == "" {
+			continue
+		}
+		manifest.Responses[i].BodyFile, err = normalizeFileRef(manifest.Responses[i].BodyFile)
+		if err != nil {
+			return fmt.Errorf("normalise response[%d] body file: %w", i, err)
+		}
+	}
+	for i := range manifest.Robots {
+		if manifest.Robots[i].BodyFile == "" {
+			continue
+		}
+		manifest.Robots[i].BodyFile, err = normalizeFileRef(manifest.Robots[i].BodyFile)
+		if err != nil {
+			return fmt.Errorf("normalise robots[%d] body file: %w", i, err)
+		}
+	}
+	if err := manifest.Validate(); err != nil {
+		return err
+	}
+
+	findingsKey := strings.TrimPrefix(manifest.FindingsFile, filesDir+"/")
+	if _, ok := files[findingsKey]; !ok {
+		return fmt.Errorf("findings_file %q not provided", findingsKey)
+	}
+	casesKey := strings.TrimPrefix(manifest.CasesFile, filesDir+"/")
+	if _, ok := files[casesKey]; !ok {
+		return fmt.Errorf("cases_file %q not provided", casesKey)
+	}
+	for _, resp := range manifest.Responses {
+		if resp.BodyFile == "" {
+			continue
+		}
+		key := strings.TrimPrefix(resp.BodyFile, filesDir+"/")
+		if _, ok := files[key]; !ok {
+			return fmt.Errorf("response body file %q not provided", key)
+		}
+	}
+	for _, rob := range manifest.Robots {
+		if rob.BodyFile == "" {
+			continue
+		}
+		key := strings.TrimPrefix(rob.BodyFile, filesDir+"/")
+		if _, ok := files[key]; !ok {
+			return fmt.Errorf("robots body file %q not provided", key)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create artefact directory: %w", err)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create artefact: %w", err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	gz := gzip.NewWriter(file)
+	defer func() {
+		_ = gz.Close()
+	}()
+
+	tw := tar.NewWriter(gz)
+	defer func() {
+		_ = tw.Close()
+	}()
+
+	// Encode manifest with indentation for readability.
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode manifest: %w", err)
+	}
+	if err := writeTarFile(tw, manifestName, manifestData, 0o644); err != nil {
+		return err
+	}
+
+	for name, data := range files {
+		clean := sanitizeFileName(name)
+		if clean == "" {
+			return fmt.Errorf("invalid file name %q", name)
+		}
+		fullPath := filepath.ToSlash(filepath.Join(filesDir, clean))
+		if err := writeTarFile(tw, fullPath, data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ExtractArtifact expands the artefact under the destination directory and returns the manifest.
+func ExtractArtifact(path, dest string) (Manifest, error) {
+	var manifest Manifest
+	if strings.TrimSpace(path) == "" {
+		return manifest, errors.New("artefact path is required")
+	}
+	if strings.TrimSpace(dest) == "" {
+		return manifest, errors.New("destination path is required")
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return manifest, fmt.Errorf("create destination: %w", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return manifest, fmt.Errorf("open artefact: %w", err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		return manifest, fmt.Errorf("open gzip reader: %w", err)
+	}
+	defer func() {
+		_ = gz.Close()
+	}()
+
+	tr := tar.NewReader(gz)
+	manifestSeen := false
+
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return manifest, fmt.Errorf("read tar entry: %w", err)
+		}
+
+		name := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(name, "..") {
+			return manifest, fmt.Errorf("invalid entry name %q", hdr.Name)
+		}
+		target := filepath.Join(dest, name)
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return manifest, fmt.Errorf("create directory %s: %w", name, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return manifest, fmt.Errorf("create parent directory for %s: %w", name, err)
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(hdr.Mode))
+			if err != nil {
+				return manifest, fmt.Errorf("create file %s: %w", name, err)
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				_ = out.Close()
+				return manifest, fmt.Errorf("extract file %s: %w", name, err)
+			}
+			if err := out.Close(); err != nil {
+				return manifest, fmt.Errorf("close file %s: %w", name, err)
+			}
+			if name == manifestName {
+				manifestSeen = true
+				data, err := os.ReadFile(target)
+				if err != nil {
+					return manifest, fmt.Errorf("read manifest: %w", err)
+				}
+				if err := json.Unmarshal(data, &manifest); err != nil {
+					return manifest, fmt.Errorf("decode manifest: %w", err)
+				}
+			}
+		default:
+			// Skip unsupported entries to avoid breaking on extraneous metadata.
+		}
+	}
+
+	if !manifestSeen {
+		return manifest, errors.New("manifest not found in artefact")
+	}
+	return manifest, nil
+}
+
+func writeTarFile(tw *tar.Writer, name string, data []byte, mode int64) error {
+	hdr := &tar.Header{
+		Name: name,
+		Mode: mode,
+		Size: int64(len(data)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("write tar header for %s: %w", name, err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		return fmt.Errorf("write tar payload for %s: %w", name, err)
+	}
+	return nil
+}
+
+func sanitizeFileName(name string) string {
+	clean := filepath.Clean(name)
+	clean = strings.TrimPrefix(clean, string(filepath.Separator))
+	if clean == "." || strings.HasPrefix(clean, "..") {
+		return ""
+	}
+	return clean
+}
+
+func normalizeFileRef(ref string) (string, error) {
+	clean := sanitizeFileName(ref)
+	if clean == "" {
+		return "", fmt.Errorf("invalid file reference %q", ref)
+	}
+	return filepath.ToSlash(filepath.Join(filesDir, clean)), nil
+}

--- a/internal/replay/artifact_test.go
+++ b/internal/replay/artifact_test.go
@@ -1,0 +1,74 @@
+package replay
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCreateAndExtractArtifact(t *testing.T) {
+	dir := t.TempDir()
+	artefactPath := filepath.Join(dir, "glyph.replay.tgz")
+
+	manifest := Manifest{
+		Version:       ManifestVersion,
+		CreatedAt:     time.Unix(1700000000, 0).UTC(),
+		Seeds:         map[string]int64{"cases": 2024},
+		Runner:        DefaultRunnerInfo(),
+		Plugins:       []PluginInfo{{Name: "seer", Version: "1.0.0", ManifestPath: "plugins/seer/manifest.json", Signature: "sig", SHA256: "deadbeef"}},
+		FindingsFile:  "findings.jsonl",
+		CasesFile:     "cases.json",
+		CaseTimestamp: time.Unix(1700000000, 0).UTC(),
+		Responses: []ResponseRecord{{
+			RequestURL: "https://example.com",
+			Method:     "GET",
+			Status:     200,
+			Headers:    map[string][]string{"Content-Type": {"text/html"}},
+			BodyFile:   "responses/example.html",
+		}},
+	}
+
+	files := map[string][]byte{
+		"findings.jsonl":         []byte("{}\n"),
+		"cases.json":             []byte("[]"),
+		"responses/example.html": []byte("<html></html>"),
+	}
+
+	if err := CreateArtifact(artefactPath, manifest, files); err != nil {
+		t.Fatalf("CreateArtifact failed: %v", err)
+	}
+
+	extractedDir := filepath.Join(dir, "extracted")
+	gotManifest, err := ExtractArtifact(artefactPath, extractedDir)
+	if err != nil {
+		t.Fatalf("ExtractArtifact failed: %v", err)
+	}
+
+	if gotManifest.Version != ManifestVersion {
+		t.Fatalf("unexpected manifest version: %s", gotManifest.Version)
+	}
+	if gotManifest.FindingsFile != "files/findings.jsonl" {
+		t.Fatalf("unexpected findings file: %s", gotManifest.FindingsFile)
+	}
+
+	// Ensure files were extracted to the expected locations.
+	data, err := os.ReadFile(filepath.Join(extractedDir, "files", "responses", "example.html"))
+	if err != nil {
+		t.Fatalf("read extracted response: %v", err)
+	}
+	if string(data) != "<html></html>" {
+		t.Fatalf("unexpected response body: %q", string(data))
+	}
+
+	// Validate manifest round trip to JSON.
+	enc, err := json.Marshal(gotManifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	var decoded Manifest
+	if err := json.Unmarshal(enc, &decoded); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+}

--- a/internal/replay/cases.go
+++ b/internal/replay/cases.go
@@ -1,0 +1,79 @@
+package replay
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+)
+
+// LoadCases reads cases from a JSON file.
+func LoadCases(path string) ([]cases.Case, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read cases: %w", err)
+	}
+	var list []cases.Case
+	if err := json.Unmarshal(data, &list); err != nil {
+		return nil, fmt.Errorf("decode cases: %w", err)
+	}
+	return list, nil
+}
+
+// WriteCases writes the provided cases to disk using deterministic encoding.
+func WriteCases(path string, list []cases.Case) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create cases directory: %w", err)
+	}
+	normalised := cloneAndSortCases(list)
+	data, err := json.MarshalIndent(normalised, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode cases: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write cases: %w", err)
+	}
+	return nil
+}
+
+// CasesEqual compares two case slices after normalising ordering.
+func CasesEqual(a, b []cases.Case) bool {
+	normA := cloneAndSortCases(a)
+	normB := cloneAndSortCases(b)
+	if len(normA) != len(normB) {
+		return false
+	}
+	for i := range normA {
+		if !casesEqual(normA[i], normB[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneAndSortCases(list []cases.Case) []cases.Case {
+	cloned := make([]cases.Case, len(list))
+	for i, c := range list {
+		cloned[i] = c.Clone()
+	}
+	sort.SliceStable(cloned, func(i, j int) bool {
+		return cloned[i].ID < cloned[j].ID
+	})
+	return cloned
+}
+
+func casesEqual(a, b cases.Case) bool {
+	dataA, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	dataB, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	return string(dataA) == string(dataB)
+}

--- a/internal/replay/cases_test.go
+++ b/internal/replay/cases_test.go
@@ -1,0 +1,57 @@
+package replay
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+func TestCasesEqual(t *testing.T) {
+	ts := time.Unix(1700001000, 0).UTC()
+	base := cases.Case{
+		Version:     findings.SchemaVersion,
+		ID:          "CASE1",
+		Asset:       cases.Asset{Kind: "web", Identifier: "example.com"},
+		Vector:      cases.AttackVector{Kind: "http"},
+		GeneratedAt: findings.NewTimestamp(ts),
+		Risk:        cases.Risk{Severity: findings.SeverityMedium},
+	}
+	left := []cases.Case{base}
+	right := []cases.Case{base.Clone()}
+	if !CasesEqual(left, right) {
+		t.Fatalf("expected cases to be equal")
+	}
+
+	right[0].Summary = "changed"
+	if CasesEqual(left, right) {
+		t.Fatalf("expected cases to differ")
+	}
+}
+
+func TestWriteAndLoadCases(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cases.json")
+
+	c := cases.Case{
+		Version: findings.SchemaVersion,
+		ID:      "CASE-1",
+		Asset:   cases.Asset{Kind: "service", Identifier: "api"},
+		Vector:  cases.AttackVector{Kind: "api"},
+		Risk:    cases.Risk{Severity: findings.SeverityLow},
+	}
+
+	if err := WriteCases(path, []cases.Case{c}); err != nil {
+		t.Fatalf("WriteCases failed: %v", err)
+	}
+
+	loaded, err := LoadCases(path)
+	if err != nil {
+		t.Fatalf("LoadCases failed: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].ID != c.ID {
+		t.Fatalf("unexpected loaded cases: %+v", loaded)
+	}
+}

--- a/internal/replay/manifest.go
+++ b/internal/replay/manifest.go
@@ -1,0 +1,141 @@
+package replay
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"time"
+)
+
+// ManifestVersion captures the schema version for replay artefact manifests.
+const ManifestVersion = "1.0"
+
+// Manifest describes the metadata captured for a replayable pipeline run.
+type Manifest struct {
+	Version       string            `json:"version"`
+	CreatedAt     time.Time         `json:"created_at"`
+	Seeds         map[string]int64  `json:"seeds,omitempty"`
+	DNS           []DNSRecord       `json:"dns,omitempty"`
+	Robots        []RobotsRecord    `json:"robots,omitempty"`
+	RateLimits    []RateLimitRecord `json:"rate_limits,omitempty"`
+	Cookies       []CookieRecord    `json:"cookies,omitempty"`
+	Responses     []ResponseRecord  `json:"responses,omitempty"`
+	Runner        RunnerInfo        `json:"runner"`
+	Plugins       []PluginInfo      `json:"plugins"`
+	FindingsFile  string            `json:"findings_file"`
+	CasesFile     string            `json:"cases_file"`
+	CaseTimestamp time.Time         `json:"case_timestamp"`
+}
+
+// DNSRecord records resolved addresses for a host.
+type DNSRecord struct {
+	Host      string   `json:"host"`
+	Addresses []string `json:"addresses"`
+}
+
+// RobotsRecord stores the contents of robots.txt for a host.
+type RobotsRecord struct {
+	Host     string `json:"host"`
+	BodyFile string `json:"body_file"`
+}
+
+// RateLimitRecord captures observed rate limiting headers.
+type RateLimitRecord struct {
+	Host   string `json:"host"`
+	Policy string `json:"policy"`
+}
+
+// CookieRecord stores sanitised cookie values observed during the run.
+type CookieRecord struct {
+	Domain string `json:"domain"`
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+}
+
+// ResponseRecord references a sanitised HTTP response body.
+type ResponseRecord struct {
+	RequestURL string              `json:"request_url"`
+	Method     string              `json:"method"`
+	Status     int                 `json:"status"`
+	Headers    map[string][]string `json:"headers,omitempty"`
+	BodyFile   string              `json:"body_file,omitempty"`
+}
+
+// RunnerInfo records the versions of the primary executables.
+type RunnerInfo struct {
+	GlyphctlVersion string `json:"glyphctl_version"`
+	GlyphdVersion   string `json:"glyphd_version"`
+	GoVersion       string `json:"go_version,omitempty"`
+	OS              string `json:"os,omitempty"`
+	Arch            string `json:"arch,omitempty"`
+}
+
+// PluginInfo stores the manifest and signature metadata for a plugin.
+type PluginInfo struct {
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	ManifestPath string `json:"manifest_path"`
+	Signature    string `json:"signature"`
+	SHA256       string `json:"sha256"`
+}
+
+// DefaultRunnerInfo returns a baseline RunnerInfo populated from the runtime.
+func DefaultRunnerInfo() RunnerInfo {
+	return RunnerInfo{
+		GlyphctlVersion: "dev",
+		GlyphdVersion:   "dev",
+		GoVersion:       runtime.Version(),
+		OS:              runtime.GOOS,
+		Arch:            runtime.GOARCH,
+	}
+}
+
+// Validate ensures the manifest is structurally sound before packaging.
+func (m Manifest) Validate() error {
+	if m.Version == "" {
+		return errors.New("manifest version is required")
+	}
+	if m.FindingsFile == "" {
+		return errors.New("findings_file must reference a file within the artefact")
+	}
+	if m.CasesFile == "" {
+		return errors.New("cases_file must reference a file within the artefact")
+	}
+	if m.Runner.GlyphctlVersion == "" && m.Runner.GlyphdVersion == "" {
+		return errors.New("runner info must include at least one version")
+	}
+	if err := validateResponses(m.Responses); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateResponses(responses []ResponseRecord) error {
+	for i, resp := range responses {
+		if stringsTrim(resp.RequestURL) == "" {
+			return fmt.Errorf("response[%d] missing request_url", i)
+		}
+		if resp.Status < 100 || resp.Status > 599 {
+			return fmt.Errorf("response[%d] has invalid status %d", i, resp.Status)
+		}
+	}
+	return nil
+}
+
+func stringsTrim(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	start := 0
+	end := len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\n' || s[start] == '\t' || s[start] == '\r') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\n' || s[end-1] == '\t' || s[end-1] == '\r') {
+		end--
+	}
+	if start == 0 && end == len(s) {
+		return s
+	}
+	return s[start:end]
+}

--- a/internal/replay/sanitize.go
+++ b/internal/replay/sanitize.go
@@ -1,0 +1,69 @@
+package replay
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+var sensitiveHeaderNames = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"cookie":              {},
+	"set-cookie":          {},
+}
+
+var sensitiveBodyPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(authorization|token|password|secret)(=|\":?)[^&\s\"']+`),
+}
+
+// SanitizeHeaders redacts sensitive header values.
+func SanitizeHeaders(input map[string][]string) map[string][]string {
+	if len(input) == 0 {
+		return nil
+	}
+	cleaned := make(map[string][]string, len(input))
+	for k, values := range input {
+		lower := strings.ToLower(strings.TrimSpace(k))
+		if _, sensitive := sensitiveHeaderNames[lower]; sensitive {
+			cleaned[k] = []string{"[REDACTED]"}
+			continue
+		}
+		dup := make([]string, len(values))
+		copy(dup, values)
+		cleaned[k] = dup
+	}
+	return cleaned
+}
+
+// SanitizeCookieValue hashes cookie values to avoid leaking secrets.
+func SanitizeCookieValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return value
+	}
+	sum := sha256.Sum256([]byte(value))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// SanitizeBody redacts common credential tokens from HTTP bodies.
+func SanitizeBody(body []byte) []byte {
+	if len(body) == 0 {
+		return nil
+	}
+	sanitized := string(body)
+	for _, re := range sensitiveBodyPatterns {
+		sanitized = re.ReplaceAllStringFunc(sanitized, func(match string) string {
+			idx := strings.Index(match, "=")
+			if idx == -1 {
+				idx = strings.Index(match, ":")
+			}
+			if idx == -1 {
+				return match
+			}
+			prefix := strings.TrimSpace(match[:idx+1])
+			return prefix + "[REDACTED]"
+		})
+	}
+	return []byte(sanitized)
+}

--- a/internal/replay/sanitize_test.go
+++ b/internal/replay/sanitize_test.go
@@ -1,0 +1,40 @@
+package replay
+
+import "testing"
+
+func TestSanitizeHeaders(t *testing.T) {
+	headers := map[string][]string{
+		"Authorization": {"Bearer secret-token"},
+		"Content-Type":  {"application/json"},
+	}
+	cleaned := SanitizeHeaders(headers)
+	if cleaned["Authorization"][0] != "[REDACTED]" {
+		t.Fatalf("authorization header not redacted: %v", cleaned["Authorization"])
+	}
+	if cleaned["Content-Type"][0] != "application/json" {
+		t.Fatalf("content-type header changed: %v", cleaned["Content-Type"])
+	}
+}
+
+func TestSanitizeCookieValue(t *testing.T) {
+	value := "session-token"
+	sanitized := SanitizeCookieValue(value)
+	if sanitized == value || sanitized == "" {
+		t.Fatalf("expected hashed cookie value, got %q", sanitized)
+	}
+	again := SanitizeCookieValue(value)
+	if sanitized != again {
+		t.Fatalf("sanitization not deterministic: %q vs %q", sanitized, again)
+	}
+}
+
+func TestSanitizeBody(t *testing.T) {
+	body := []byte("token=abcdef12345&other=value")
+	sanitized := SanitizeBody(body)
+	if string(sanitized) == string(body) {
+		t.Fatalf("body not sanitised: %s", sanitized)
+	}
+	if want := "token=[REDACTED]&other=value"; string(sanitized) != want {
+		t.Fatalf("unexpected sanitised body: %s", sanitized)
+	}
+}


### PR DESCRIPTION
## Summary
- add a glyphctl replay command that replays recorded artifacts, validates cases, and exports supplemental data
- implement replay artifact packaging, manifest validation, sanitisation helpers, and case utilities with tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dd4af2d864832a96428c681cacd422