### PR TITLE
Automate post-SLSA signing and Homebrew smoke test

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -21,6 +21,8 @@ jobs:
     env:
       TAG_NAME: ${{ github.event.release.tag_name }}
       TAP_REPO: RowanDark/homebrew-glyph
+    outputs:
+      should-run: ${{ steps.guard.outputs.should-run }}
     steps:
       - name: Check release and secrets
         id: guard
@@ -50,8 +52,8 @@ jobs:
         if: steps.guard.outputs.should-run == 'true'
         env:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          run: |
-            git clone "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+        run: |
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
 
       - name: Update formula
         if: steps.guard.outputs.should-run == 'true'
@@ -70,4 +72,17 @@ jobs:
             git push origin HEAD
           else
             echo "Homebrew formula already up to date"
-          fi
+
+  smoke-test:
+    needs: bump
+    if: github.repository_owner == 'RowanDark' && needs.bump.outputs.should-run == 'true'
+    runs-on: macos-latest
+    env:
+      TAG_NAME: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Brew install Glyph
+        run: |
+          set -euo pipefail
+          brew update
+          brew install rowandark/glyph/glyph
+          glyph --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: write
   packages: write
-  id-token: write
 
 jobs:
   goreleaser:
@@ -49,37 +48,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v3.5.0
-
-      - name: Sign release artifacts
-        env:
-          COSIGN_YES: "true"
-          COSIGN_EXPERIMENTAL: "1"
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          for artifact in dist/*; do
-            case "$artifact" in
-              *.sig|*.pem|*.intoto.jsonl) continue ;;
-            esac
-            base=$(basename "$artifact")
-            cosign sign-blob "$artifact" \
-              --output-signature "dist/${base}.sig" \
-              --output-certificate "dist/${base}.pem"
-          done
-
-      - name: Upload signatures to release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          files=()
-          for f in dist/*.sig dist/*.pem; do
-            [ -e "$f" ] || continue
-            files+=("$f")
-          done
-          if [ ${#files[@]} -gt 0 ]; then
-            gh release upload "${GITHUB_REF_NAME}" "${files[@]}" --clobber
-          fi
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dist
+          path: dist/
+          if-no-files-found: error

--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -44,6 +44,88 @@ jobs:
         dist/*SHA256SUMS.txt.pem
       upload-assets: true
 
+  sign-and-sbom:
+    needs: release-provenance
+    if: github.repository_owner == 'RowanDark' && github.event.workflow_run.name == 'Release' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      RELEASE_RUN_ID: ${{ github.event.workflow_run.id }}
+    steps:
+      - name: Determine release tag
+        id: release
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+        run: |
+          set -euo pipefail
+          tag="${HEAD_BRANCH}"
+          if [ -z "${tag}" ] || [ "${tag}" = "null" ]; then
+            tag="${HEAD_SHA}"
+          fi
+          if [ -z "${tag}" ] || [ "${tag}" = "null" ]; then
+            tag="${DISPLAY_TITLE:-release}"
+            tag=${tag// /-}
+          fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ env.RELEASE_RUN_ID }}
+          name: release-dist
+          path: dist
+
+      - name: Generate release SBOM
+        uses: anchore/syft-action@v0.9.0
+        with:
+          path: dist
+          output: dist/glyph-${{ steps.release.outputs.tag }}-sbom.spdx.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Sign release artifacts
+        env:
+          COSIGN_YES: "true"
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for artifact in dist/*; do
+            case "$artifact" in
+              *.sig|*.pem|*.intoto.jsonl) continue ;;
+            esac
+            base=$(basename "$artifact")
+            cosign sign-blob "$artifact" \
+              --output-signature "dist/${base}.sig" \
+              --output-certificate "dist/${base}.pem"
+          done
+
+      - name: Upload SBOM and signatures to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=()
+          for pattern in dist/*.sig dist/*.pem dist/*-sbom.spdx.json; do
+            for f in $pattern; do
+              [ -e "$f" ] || continue
+              files+=("$f")
+            done
+          done
+          if [ ${#files[@]} -gt 0 ]; then
+            gh release upload "${TAG_NAME}" "${files[@]}" --clobber
+          else
+            echo "No files to upload"
+          fi
+
   container-provenance:
     if: github.repository_owner == 'RowanDark' && github.event.workflow_run.name == 'Release Container Image' && github.event.workflow_run.conclusion == 'success'
     permissions:


### PR DESCRIPTION
## Summary
- upload GoReleaser artifacts so the SLSA workflow can reuse them after the release job
- extend the SLSA workflow to generate SBOMs, sign release artifacts, and publish the results once provenance succeeds
- guard the Homebrew tap updater behind owner-only v* tags and add a macOS smoke test that installs the formula

## Testing
- not run (GitHub Actions workflow changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd6fe5be40832aa5ccfdaeb809e7b6