### PR TITLE
Harden netgate against local and restricted targets

### DIFF
--- a/internal/netgate/gate_test.go
+++ b/internal/netgate/gate_test.go
@@ -1,11 +1,12 @@
 package netgate
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -14,45 +15,22 @@ func TestGateDeniesMissingCapability(t *testing.T) {
 	gate := New(nil)
 	gate.Register("plugin", nil)
 
-	if _, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "127.0.0.1:1"); err == nil {
+	if _, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "198.51.100.1:1"); err == nil {
 		t.Fatal("expected dial to be denied without capability")
 	}
 }
 
 func TestGateAllowsWithCapability(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer func() {
-		_ = ln.Close()
-	}()
-
-	gate := New(&net.Dialer{Timeout: 100 * time.Millisecond})
+	gate := New(dummyDialer{}, WithTimeout(100*time.Millisecond))
 	gate.Register("plugin", []string{capHTTPActive})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	done := make(chan struct{})
-	go func() {
-		conn, err := ln.Accept()
-		if err == nil {
-			_ = conn.Close()
-		}
-		close(done)
-	}()
-
-	conn, err := gate.DialContext(ctx, "plugin", capHTTPActive, "tcp", ln.Addr().String())
+	conn, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "198.51.100.10:443")
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	func() {
-		if err := conn.Close(); err != nil {
-			t.Fatalf("close connection: %v", err)
-		}
-	}()
-	<-done
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close connection: %v", err)
+	}
 }
 
 func TestGateHTTPClientRequiresCapability(t *testing.T) {
@@ -64,13 +42,26 @@ func TestGateHTTPClientRequiresCapability(t *testing.T) {
 	}
 }
 
-func TestGateHTTPClientPerformsRequests(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+func TestGateDialBlocksRawNetwork(t *testing.T) {
+	gate := New(dummyDialer{})
+	gate.Register("plugin", []string{capHTTPActive})
 
-	gate := New(nil, WithRequestBudget(2))
+	if _, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "ip4:1", "198.51.100.1:80"); err == nil {
+		t.Fatal("expected raw network to be blocked")
+	}
+}
+
+func TestGateDialBlocksLoopback(t *testing.T) {
+	gate := New(dummyDialer{})
+	gate.Register("plugin", []string{capHTTPActive})
+
+	if _, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "127.0.0.1:80"); err == nil {
+		t.Fatal("expected loopback dial to be blocked")
+	}
+}
+
+func TestGateHTTPClientPerformsRequests(t *testing.T) {
+	gate := New(httpPipeDialer{response: "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"}, WithRequestBudget(2))
 	gate.Register("plugin", []string{capHTTPActive})
 
 	client, err := gate.HTTPClient("plugin", capHTTPActive)
@@ -78,7 +69,7 @@ func TestGateHTTPClientPerformsRequests(t *testing.T) {
 		t.Fatalf("http client: %v", err)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/resource", nil)
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
@@ -91,13 +82,85 @@ func TestGateHTTPClientPerformsRequests(t *testing.T) {
 	}
 }
 
+func TestGateHTTPClientBlocksLoopback(t *testing.T) {
+	gate := New(httpPipeDialer{})
+	gate.Register("plugin", []string{capHTTPActive})
+
+	client, err := gate.HTTPClient("plugin", capHTTPActive)
+	if err != nil {
+		t.Fatalf("http client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("expected loopback request to be denied")
+	}
+}
+
+func TestGateHTTPClientBlocksPrivate(t *testing.T) {
+	gate := New(httpPipeDialer{})
+	gate.Register("plugin", []string{capHTTPActive})
+
+	client, err := gate.HTTPClient("plugin", capHTTPActive)
+	if err != nil {
+		t.Fatalf("http client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://10.0.0.5/resource", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("expected private range to be denied")
+	}
+}
+
+func TestGateHTTPClientBlocksFileScheme(t *testing.T) {
+	gate := New(httpPipeDialer{})
+	gate.Register("plugin", []string{capHTTPActive})
+
+	client, err := gate.HTTPClient("plugin", capHTTPActive)
+	if err != nil {
+		t.Fatalf("http client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "file:///etc/passwd", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("expected file scheme to be denied")
+	}
+}
+
+func TestGateHTTPClientBlocksDataScheme(t *testing.T) {
+	gate := New(httpPipeDialer{})
+	gate.Register("plugin", []string{capHTTPActive})
+
+	client, err := gate.HTTPClient("plugin", capHTTPActive)
+	if err != nil {
+		t.Fatalf("http client: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "data:text/plain;base64,SGVsbG8=", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("expected data scheme to be denied")
+	}
+}
+
 func TestGateTimeoutEnforced(t *testing.T) {
 	slow := slowDialer{delay: 200 * time.Millisecond}
 	gate := New(slow, WithTimeout(50*time.Millisecond))
 	gate.Register("plugin", []string{capHTTPActive})
 
 	start := time.Now()
-	_, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "127.0.0.1:1")
+	_, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "198.51.100.2:1")
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -113,7 +176,7 @@ func TestGateBudgetExhaustion(t *testing.T) {
 	gate := New(dummyDialer{}, WithRequestBudget(1))
 	gate.Register("plugin", []string{capHTTPActive})
 
-	conn, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "127.0.0.1:1")
+	conn, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "198.51.100.3:1")
 	if err != nil {
 		t.Fatalf("unexpected error on first dial: %v", err)
 	}
@@ -121,7 +184,7 @@ func TestGateBudgetExhaustion(t *testing.T) {
 		t.Fatalf("close connection: %v", err)
 	}
 
-	if _, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "127.0.0.1:1"); err == nil {
+	if _, err := gate.DialContext(context.Background(), "plugin", capHTTPActive, "tcp", "198.51.100.3:1"); err == nil {
 		t.Fatal("expected error once budget exhausted")
 	}
 }
@@ -149,6 +212,35 @@ func (dummyDialer) DialContext(ctx context.Context, network, address string) (ne
 		case <-time.After(10 * time.Millisecond):
 		}
 		_ = c2.Close()
+	}()
+	return c1, nil
+}
+
+type httpPipeDialer struct {
+	response string
+}
+
+func (d httpPipeDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	c1, c2 := net.Pipe()
+	go func() {
+		defer c2.Close()
+		buf := make([]byte, 0, 512)
+		tmp := make([]byte, 256)
+		for {
+			n, err := c2.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+				if bytes.Contains(buf, []byte("\r\n\r\n")) {
+					break
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+		if _, err := io.WriteString(c2, d.response); err != nil {
+			return
+		}
 	}()
 	return c1, nil
 }


### PR DESCRIPTION
## Summary
- validate netgate dial requests to block raw sockets and local addresses
- enforce HTTP scheme and deny loopback, private and non-http schemes before dispatch
- extend gate tests to cover denial cases and pipe-based success flow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ddc2c1141c832a850b46ef86829e68