### PR TITLE
Guard release workflows behind owner and secret checks

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -1,6 +1,11 @@
 name: Bump Homebrew Formula
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to bump (e.g. v1.2.3)"
+        required: true
   release:
     types: [published]
 
@@ -16,10 +21,10 @@ jobs:
         run: echo "Skipping Homebrew formula update: workflow only runs in the RowanDark repository."
 
   bump:
-    if: github.repository_owner == 'RowanDark'
+    if: github.repository_owner == 'RowanDark' && (github.event_name == 'workflow_dispatch' || github.event.release.tag_name != '')
     runs-on: ubuntu-latest
     env:
-      TAG_NAME: ${{ github.event.release.tag_name }}
+      TAG_NAME: ${{ github.event.release.tag_name || github.event.inputs.tag || '' }}
       TAP_REPO: RowanDark/homebrew-glyph
     outputs:
       should-run: ${{ steps.guard.outputs.should-run }}
@@ -37,7 +42,7 @@ jobs:
           fi
 
           if [ -z "${TAP_TOKEN}" ]; then
-            echo "::warning::Skipping Homebrew bump: HOMEBREW_TAP_TOKEN secret is not configured."
+            echo "Tap bump skipped: HOMEBREW_TAP_TOKEN missing."
             echo "should-run=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
@@ -78,7 +83,7 @@ jobs:
     if: github.repository_owner == 'RowanDark' && needs.bump.outputs.should-run == 'true'
     runs-on: macos-latest
     env:
-      TAG_NAME: ${{ github.event.release.tag_name }}
+      TAG_NAME: ${{ github.event.release.tag_name || github.event.inputs.tag || '' }}
     steps:
       - name: Brew install Glyph
         run: |

--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -87,12 +87,16 @@ jobs:
           output: dist/glyph-${{ steps.release.outputs.tag }}-sbom.spdx.json
 
       - name: Install cosign
+        if: ${{ secrets.COSIGN_PRIVATE_KEY != '' && secrets.COSIGN_PASSWORD != '' }}
         uses: sigstore/cosign-installer@v3.5.0
 
       - name: Sign release artifacts
+        if: ${{ secrets.COSIGN_PRIVATE_KEY != '' && secrets.COSIGN_PASSWORD != '' }}
         env:
           COSIGN_YES: "true"
           COSIGN_EXPERIMENTAL: "1"
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -102,9 +106,14 @@ jobs:
             esac
             base=$(basename "$artifact")
             cosign sign-blob "$artifact" \
+              --key env://COSIGN_PRIVATE_KEY \
               --output-signature "dist/${base}.sig" \
               --output-certificate "dist/${base}.pem"
           done
+
+      - name: Note skipped signing
+        if: ${{ !(secrets.COSIGN_PRIVATE_KEY != '' && secrets.COSIGN_PASSWORD != '') }}
+        run: echo "Signing skipped: missing COSIGN_* secrets."
 
       - name: Upload SBOM and signatures to release
         env:


### PR DESCRIPTION
## Summary
- guard the SLSA signing steps so they only run when Cosign secrets are present and emit a skip message otherwise
- require RowanDark ownership and allow manual triggers for the Homebrew bump workflow while keeping the tap update gated on secrets

## Testing
- not run (workflow changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ddcf963098832a86130d804b56bf85