### PR TITLE
Fix docs workflow deployment and README tap link

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,9 +55,9 @@ jobs:
             fi
             sleep 1
           done
-          for path in "" quickstart/ security/ plugins/; do
+          for path in "" quickstart/ cli/ plugins/ security/; do
             curl -fsS --retry 3 --retry-delay 1 --retry-connrefused "http://127.0.0.1:8000/${path}" >/dev/null
           done
 
       - name: Deploy documentation
-        run: mkdocs gh-deploy --force --clean
+        run: mkdocs gh-deploy --force --clean --remote-name origin --remote-branch gh-pages

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ranked findings and human-readable reports.
 ## Installation
 
 macOS users can install the prebuilt `glyphctl` binary via Homebrew using the
-[RowanDark/homebrew-glyph tap](https://github.com/RowanDark/homebrew-glyph):
+[RowanDark/homebrew-tap tap](https://github.com/RowanDark/homebrew-tap):
 
 ```bash
 brew install rowandark/glyph/glyph


### PR DESCRIPTION
## Summary
- update the docs workflow to smoke test the published quickstart/CLI/plugins pages and push to the gh-pages branch explicitly
- fix the README Homebrew tap link so it points at the consolidated tap repository

## Testing
- not run (network restrictions prevented installing mkdocs)


------
https://chatgpt.com/codex/tasks/task_e_68ddd10f5f80832a8edc79776f638ea8