### PR TITLE
Update Homebrew tap automation

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -67,16 +67,41 @@ jobs:
 
       - name: Commit and push changes
         if: steps.guard.outputs.should-run == 'true'
+        id: commit
         run: |
+          set -euo pipefail
           cd tap
           if git status --porcelain | grep . >/dev/null 2>&1; then
             git config user.name "glyph-bot"
             git config user.email "glyph-bot@users.noreply.github.com"
+            branch="bump/glyph-${TAG_NAME}"
+            git checkout -b "${branch}"
             git add Formula/glyph.rb
             git commit -m "Bump glyph to ${TAG_NAME}"
-            git push origin HEAD
+            git push --force --set-upstream origin "${branch}"
+            echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
           else
             echo "Homebrew formula already up to date"
+            echo "branch=" >> "${GITHUB_OUTPUT}"
+
+      - name: Open pull request
+        if: steps.guard.outputs.should-run == 'true' && steps.commit.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd tap
+          branch="${{ steps.commit.outputs.branch }}"
+          if gh pr view "${branch}" --repo "${TAP_REPO}" >/dev/null 2>&1; then
+            echo "Pull request for ${branch} already exists"
+          else
+            gh pr create \
+              --repo "${TAP_REPO}" \
+              --head "${branch}" \
+              --base main \
+              --title "Bump glyph to ${TAG_NAME}" \
+              --body "Automated update for Glyph ${TAG_NAME}."
+          fi
 
   smoke-test:
     needs: bump
@@ -89,5 +114,6 @@ jobs:
         run: |
           set -euo pipefail
           brew update
-          brew install rowandark/glyph/glyph
-          glyph --version
+          brew tap rowandark/glyph
+          brew install glyph
+          glyphctl --version

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ranked findings and human-readable reports.
 ## Installation
 
 macOS users can install the prebuilt `glyphctl` binary via Homebrew using the
-[RowanDark/homebrew-tap tap](https://github.com/RowanDark/homebrew-tap):
+[RowanDark/homebrew-glyph tap](https://github.com/RowanDark/homebrew-glyph):
 
 ```bash
 brew install rowandark/glyph/glyph

--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -60,7 +60,10 @@ you debug the plugin in real time.
 2. Run `make test` and `glyphctl demo` to ensure critical paths pass.
 3. Execute `scripts/build_release.sh` to produce signed archives and checksums.
 4. Follow the prompts in `scripts/update_homebrew_formula.sh` if the Homebrew tap
-   needs a new version.
+   needs a new version. The script keeps the
+   [`RowanDark/homebrew-glyph`](https://github.com/RowanDark/homebrew-glyph)
+   formula in sync and the `bump-homebrew` workflow opens a pull request with the
+   changes.
 5. Push a Git tag (for example `v1.2.3`) to trigger the release workflows and publish
    versioned documentation.
 

--- a/scripts/update_homebrew_formula.sh
+++ b/scripts/update_homebrew_formula.sh
@@ -40,6 +40,7 @@ class Glyph < Formula
   desc "Automation toolkit for orchestrating red-team and detection workflows"
   homepage "https://github.com/${RELEASE_OWNER}/${RELEASE_REPO}"
   version "${VERSION}"
+  license "Apache-2.0"
 
   on_macos do
     on_arm do
@@ -61,7 +62,7 @@ class Glyph < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/glyphctl version")
+    assert_match version.to_s, shell_output("#{bin}/glyphctl --version")
   end
 end
 FORMULA


### PR DESCRIPTION
## Summary
- point the README and developer docs at the dedicated `RowanDark/homebrew-glyph` tap
- teach the Homebrew bump script to record the formula license and align the smoke test command
- extend the bump workflow to push a branch, open a PR against the tap, and exercise the new installation flow

## Testing
- `bash -n scripts/update_homebrew_formula.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ddd2667a84832a989469b8b9655c6f