### PR TITLE
Add Excavator concurrency manager with rate-limited scheduling

### DIFF
--- a/plugins/excavator/concurrency_manager.js
+++ b/plugins/excavator/concurrency_manager.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const { createRateLimitedQueue } = require('./queue_manager');
+const { createBrowserPool } = require('./browser_pool');
+
+function createConcurrencyManager(options = {}) {
+  const {
+    rateLimiter = {
+      perHost: { tokens: 1, intervalMs: 1000, burst: 1 },
+      globalLimit: 1,
+    },
+    browserPool: browserPoolOptions = {},
+  } = options;
+
+  const queue = createRateLimitedQueue(rateLimiter);
+  const pool = createBrowserPool(browserPoolOptions);
+
+  let closing = false;
+  let closed = false;
+
+  async function runWithBrowser(task) {
+    const resource = await pool.acquire();
+    let released = false;
+    let result;
+    let runError;
+    let releaseError;
+
+    const release = async (releaseOptions) => {
+      if (released) {
+        return;
+      }
+      released = true;
+      await resource.release(releaseOptions);
+    };
+
+    try {
+      result = await task.execute({
+        context: resource.context,
+        fingerprint: resource.fingerprint,
+        release,
+      });
+    } catch (error) {
+      runError = error;
+    }
+
+    if (!released) {
+      try {
+        const releaseOptions = await resolveReleaseOptions(task, result, runError);
+        await release(releaseOptions);
+      } catch (error) {
+        releaseError = error;
+      }
+    }
+
+    if (runError) {
+      throw runError;
+    }
+    if (releaseError) {
+      throw releaseError;
+    }
+    return result;
+  }
+
+  function schedule(task) {
+    if (closing || closed) {
+      return Promise.reject(new Error('concurrency manager is closed'));
+    }
+    validateTask(task);
+
+    return queue.enqueue({
+      host: task.host,
+      url: task.url,
+      run: () => runWithBrowser(task),
+    });
+  }
+
+  async function close() {
+    if (closed) {
+      return;
+    }
+    closing = true;
+
+    let queueError = null;
+    try {
+      await queue.close();
+    } catch (error) {
+      queueError = error;
+    }
+
+    let poolError = null;
+    try {
+      await pool.close();
+    } catch (error) {
+      poolError = error;
+    }
+
+    closed = true;
+    closing = false;
+
+    if (queueError) {
+      throw queueError;
+    }
+    if (poolError) {
+      throw poolError;
+    }
+  }
+
+  function getTelemetry() {
+    return queue.getTelemetry();
+  }
+
+  return {
+    schedule,
+    close,
+    getTelemetry,
+  };
+}
+
+function validateTask(task) {
+  if (!task || typeof task !== 'object') {
+    throw new Error('task must be an object');
+  }
+  if (typeof task.execute !== 'function') {
+    throw new Error('task.execute must be a function');
+  }
+
+  const hasHost = typeof task.host === 'string' && task.host.trim() !== '';
+  const hasUrl = typeof task.url === 'string' && task.url.trim() !== '';
+
+  if (!hasHost && !hasUrl) {
+    throw new Error('task.url or task.host must be provided');
+  }
+}
+
+async function resolveReleaseOptions(task, result, error) {
+  const { releaseOptions } = task;
+
+  if (typeof releaseOptions === 'function') {
+    return releaseOptions({ result, error });
+  }
+
+  return releaseOptions;
+}
+
+module.exports = { createConcurrencyManager };

--- a/plugins/excavator/tests/concurrency_manager.test.js
+++ b/plugins/excavator/tests/concurrency_manager.test.js
@@ -1,0 +1,122 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createConcurrencyManager } = require('../concurrency_manager');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('serialises tasks per host and reuses browser contexts', async () => {
+  const contexts = [];
+  const resets = [];
+  const manager = createConcurrencyManager({
+    rateLimiter: {
+      perHost: { tokens: 1, intervalMs: 30, burst: 1 },
+      globalLimit: 1,
+    },
+    browserPool: {
+      size: 1,
+      warmup: false,
+      createContext: async () => {
+        const context = { id: contexts.length + 1 };
+        contexts.push(context);
+        return context;
+      },
+      resetContext: async (context) => {
+        resets.push(context.id);
+      },
+    },
+  });
+
+  const starts = [];
+
+  const jobs = Array.from({ length: 3 }, (_, index) =>
+    manager.schedule({
+      url: `https://crawl.test/${index}`,
+      execute: async ({ context }) => {
+        starts.push({ index, context: context.id });
+        await sleep(20);
+        return { status: 200 };
+      },
+      releaseOptions: { reason: 'success' },
+    })
+  );
+
+  await Promise.all(jobs);
+  await manager.close();
+
+  assert.deepStrictEqual(
+    starts.map((entry) => entry.index),
+    [0, 1, 2]
+  );
+  assert.ok(starts.every((entry) => entry.context === 1));
+  assert.equal(contexts.length, 1);
+  assert.deepStrictEqual(resets, [1, 1, 1]);
+});
+
+test('tracks telemetry, handles errors, and supports manual release', async () => {
+  const snapshots = [];
+  const releases = [];
+  const manager = createConcurrencyManager({
+    rateLimiter: {
+      perHost: { tokens: 1, intervalMs: 20, burst: 1 },
+      globalLimit: 1,
+      onTelemetry: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    },
+    browserPool: {
+      size: 1,
+      warmup: false,
+      createContext: async () => ({ id: 'alpha' }),
+      resetContext: async (_context, options) => {
+        releases.push(options);
+      },
+    },
+  });
+
+  await manager.schedule({
+    url: 'https://telemetry.test/ok',
+    execute: async () => {
+      await sleep(10);
+      return { status: 200 };
+    },
+    releaseOptions: { label: 'ok' },
+  });
+
+  await manager.schedule({
+    url: 'https://telemetry.test/429',
+    execute: async () => {
+      await sleep(10);
+      return { status: 429 };
+    },
+  });
+
+  await assert.rejects(
+    manager.schedule({
+      url: 'https://telemetry.test/503',
+      execute: async ({ release }) => {
+        await sleep(5);
+        await release({ label: 'manual' });
+        const error = new Error('server error');
+        error.status = 503;
+        throw error;
+      },
+      releaseOptions: { label: 'error' },
+    })
+  );
+
+  const telemetry = manager.getTelemetry();
+  await manager.close();
+
+  assert.ok(snapshots.length > 0);
+  assert.equal(telemetry.status429, 1);
+  assert.equal(telemetry.status5xx, 1);
+  assert.ok(telemetry.waitCount >= 1);
+  assert.ok(telemetry.avgWaitMs >= 0);
+
+  assert.equal(releases.length, 3);
+  assert.deepStrictEqual(releases[0], { label: 'ok' });
+  assert.equal(releases[1], undefined);
+  assert.deepStrictEqual(releases[2], { label: 'manual' });
+});


### PR DESCRIPTION
## Summary
- add an Excavator concurrency manager that layers the per-host token bucket queue on top of the Playwright browser pool
- ensure tasks auto-release contexts, support optional release hooks, and expose queue telemetry for wait times and throttling
- cover the new manager with node:test suites for sequential host execution, telemetry, and error handling

## Testing
- npm --prefix plugins/excavator test

------
https://chatgpt.com/codex/tasks/task_e_68ddf0734664832ab9da186cbe37a535