### PR TITLE
Ensure browser resources are released when release option resolution fails

### DIFF
--- a/plugins/excavator/concurrency_manager.js
+++ b/plugins/excavator/concurrency_manager.js
@@ -44,11 +44,23 @@ function createConcurrencyManager(options = {}) {
     }
 
     if (!released) {
+      let releaseOptions;
+      let releaseOptionsError;
+
       try {
-        const releaseOptions = await resolveReleaseOptions(task, result, runError);
+        releaseOptions = await resolveReleaseOptions(task, result, runError);
+      } catch (error) {
+        releaseOptionsError = error;
+      }
+
+      try {
         await release(releaseOptions);
       } catch (error) {
         releaseError = error;
+      }
+
+      if (!releaseError && releaseOptionsError) {
+        releaseError = releaseOptionsError;
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure the concurrency manager releases browser resources even when resolving release options fails
- capture errors from release option resolution separately while still releasing the resource

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea331b0d8832a9300a534c22a713c