### PR TITLE
Add scope policy enforcer and summary

### DIFF
--- a/internal/scope/enforcer.go
+++ b/internal/scope/enforcer.go
@@ -1,0 +1,330 @@
+package scope
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// DecisionReason captures the outcome of a scope evaluation.
+type DecisionReason string
+
+const (
+	// DecisionAllowed indicates the candidate satisfied the policy allowlist.
+	DecisionAllowed DecisionReason = "allowed"
+	// DecisionNotAllowlisted indicates no allowlist entry matched the candidate.
+	DecisionNotAllowlisted DecisionReason = "not_allowlisted"
+	// DecisionDeniedByRule indicates an explicit deny rule matched the candidate.
+	DecisionDeniedByRule DecisionReason = "denied_by_rule"
+	// DecisionPrivateBlocked indicates private network access was blocked.
+	DecisionPrivateBlocked DecisionReason = "private_network_blocked"
+	// DecisionInvalidCandidate indicates the input URL was invalid.
+	DecisionInvalidCandidate DecisionReason = "invalid_candidate"
+)
+
+// Decision describes the result of evaluating a candidate against a policy.
+type Decision struct {
+	Allowed bool
+	Reason  DecisionReason
+	Rule    *Rule
+}
+
+// Enforcer evaluates URLs against a compiled scope policy.
+type Enforcer struct {
+	allowRules []*compiledRule
+	denyRules  []*compiledRule
+	allowEmpty bool
+	private    string
+}
+
+type compiledRule struct {
+	original Rule
+	match    func(*url.URL, string) bool
+}
+
+// Option customises enforcer behaviour.
+type Option func(*Enforcer)
+
+// WithAllowEmpty controls the behaviour when no allow rules are present. When
+// true, candidates are allowed unless denied by an explicit rule. The default
+// behaviour denies candidates when the allowlist is empty.
+func WithAllowEmpty(allow bool) Option {
+	return func(e *Enforcer) {
+		e.allowEmpty = allow
+	}
+}
+
+// Compile constructs a new Enforcer for the provided policy.
+func Compile(policy Policy, opts ...Option) (*Enforcer, error) {
+	policy.Normalise()
+
+	enforcer := &Enforcer{private: policy.PrivateNetworks}
+	for _, opt := range opts {
+		opt(enforcer)
+	}
+
+	for _, rule := range policy.Allow {
+		compiled, err := compileRule(rule)
+		if err != nil {
+			return nil, fmt.Errorf("compile allow rule %s %q: %w", rule.Type, rule.Value, err)
+		}
+		enforcer.allowRules = append(enforcer.allowRules, compiled)
+	}
+	for _, rule := range policy.Deny {
+		compiled, err := compileRule(rule)
+		if err != nil {
+			return nil, fmt.Errorf("compile deny rule %s %q: %w", rule.Type, rule.Value, err)
+		}
+		enforcer.denyRules = append(enforcer.denyRules, compiled)
+	}
+
+	return enforcer, nil
+}
+
+// Evaluate determines whether the provided URL is permitted by the policy.
+func (e *Enforcer) Evaluate(candidate string) Decision {
+	trimmed := strings.TrimSpace(candidate)
+	if trimmed == "" {
+		return Decision{Allowed: false, Reason: DecisionInvalidCandidate}
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return Decision{Allowed: false, Reason: DecisionInvalidCandidate}
+	}
+
+	serialised := parsed.String()
+
+	if e.private != PrivateNetworksAllow && isPrivateHost(parsed.Hostname()) {
+		return Decision{Allowed: false, Reason: DecisionPrivateBlocked}
+	}
+
+	for _, rule := range e.denyRules {
+		if rule.match(parsed, serialised) {
+			return Decision{Allowed: false, Reason: DecisionDeniedByRule, Rule: &rule.original}
+		}
+	}
+
+	if len(e.allowRules) == 0 {
+		if e.allowEmpty {
+			return Decision{Allowed: true, Reason: DecisionAllowed}
+		}
+		return Decision{Allowed: false, Reason: DecisionNotAllowlisted}
+	}
+
+	for _, rule := range e.allowRules {
+		if rule.match(parsed, serialised) {
+			return Decision{Allowed: true, Reason: DecisionAllowed, Rule: &rule.original}
+		}
+	}
+
+	return Decision{Allowed: false, Reason: DecisionNotAllowlisted}
+}
+
+func compileRule(rule Rule) (*compiledRule, error) {
+	switch rule.Type {
+	case RuleTypeDomain:
+		value := strings.ToLower(rule.Value)
+		return &compiledRule{
+			original: rule,
+			match: func(u *url.URL, _ string) bool {
+				return hostMatchesDomain(strings.ToLower(u.Hostname()), value)
+			},
+		}, nil
+	case RuleTypeWildcard:
+		regex, err := wildcardToRegexp(rule.Value)
+		if err != nil {
+			return nil, err
+		}
+		return &compiledRule{
+			original: rule,
+			match: func(u *url.URL, _ string) bool {
+				return regex.MatchString(strings.ToLower(u.Hostname()))
+			},
+		}, nil
+	case RuleTypeURL:
+		value := rule.Value
+		return &compiledRule{
+			original: rule,
+			match: func(_ *url.URL, serialised string) bool {
+				return serialised == value
+			},
+		}, nil
+	case RuleTypePrefix:
+		value := rule.Value
+		return &compiledRule{
+			original: rule,
+			match: func(_ *url.URL, serialised string) bool {
+				return strings.HasPrefix(serialised, value)
+			},
+		}, nil
+	case RuleTypePath:
+		needle := rule.Value
+		if !strings.HasPrefix(needle, "/") {
+			needle = "/" + needle
+		}
+		return &compiledRule{
+			original: Rule{Type: rule.Type, Value: needle, Notes: rule.Notes},
+			match: func(u *url.URL, _ string) bool {
+				return strings.HasPrefix(u.Path, needle)
+			},
+		}, nil
+	case RuleTypeCIDR:
+		prefix, err := parseCIDR(rule.Value)
+		if err != nil {
+			return nil, err
+		}
+		return &compiledRule{
+			original: rule,
+			match: func(u *url.URL, _ string) bool {
+				return cidrContains(prefix, u.Hostname())
+			},
+		}, nil
+	case RuleTypeIP:
+		target := strings.ToLower(rule.Value)
+		return &compiledRule{
+			original: rule,
+			match: func(u *url.URL, _ string) bool {
+				return strings.ToLower(u.Hostname()) == target
+			},
+		}, nil
+	case RuleTypePattern:
+		expr, err := regexp.Compile(rule.Value)
+		if err != nil {
+			return nil, err
+		}
+		return &compiledRule{
+			original: rule,
+			match: func(_ *url.URL, serialised string) bool {
+				return expr.MatchString(serialised)
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported rule type %q", rule.Type)
+	}
+}
+
+func wildcardToRegexp(pattern string) (*regexp.Regexp, error) {
+	trimmed := strings.TrimSpace(pattern)
+	if trimmed == "" {
+		return nil, errors.New("empty wildcard pattern")
+	}
+	escaped := regexp.QuoteMeta(trimmed)
+	regex := "^" + strings.ReplaceAll(escaped, "\\*", ".*") + "$"
+	return regexp.Compile(strings.ToLower(regex))
+}
+
+func hostMatchesDomain(host, domain string) bool {
+	if host == "" || domain == "" {
+		return false
+	}
+	if host == domain {
+		return true
+	}
+	return strings.HasSuffix(host, "."+domain)
+}
+
+func parseCIDR(value string) (netip.Prefix, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return netip.Prefix{}, errors.New("empty cidr")
+	}
+	prefix, err := netip.ParsePrefix(trimmed)
+	if err == nil {
+		return prefix, nil
+	}
+	// Attempt to unwrap IPv6 literals like [::1]/128
+	if strings.HasPrefix(trimmed, "[") && strings.Contains(trimmed, "]/") {
+		closing := strings.Index(trimmed, "]/")
+		if closing > 0 {
+			addr := trimmed[1:closing]
+			suffix := trimmed[closing+2:]
+			return netip.ParsePrefix(addr + "/" + suffix)
+		}
+	}
+	return netip.Prefix{}, err
+}
+
+func cidrContains(prefix netip.Prefix, host string) bool {
+	addr, ok := parseHostAddr(host)
+	if !ok {
+		return false
+	}
+	return prefix.Contains(addr)
+}
+
+func parseHostAddr(host string) (netip.Addr, bool) {
+	trimmed := strings.TrimSpace(host)
+	if trimmed == "" {
+		return netip.Addr{}, false
+	}
+	if strings.EqualFold(trimmed, "localhost") {
+		return netip.AddrFrom4([4]byte{127, 0, 0, 1}), true
+	}
+	unwrapped := trimmed
+	if strings.HasPrefix(unwrapped, "[") && strings.HasSuffix(unwrapped, "]") {
+		unwrapped = unwrapped[1 : len(unwrapped)-1]
+	}
+	addr, err := netip.ParseAddr(unwrapped)
+	if err != nil && strings.HasPrefix(strings.ToLower(unwrapped), "::ffff:") {
+		mapped := unwrapped[7:]
+		if parsed, err := netip.ParseAddr(mapped); err == nil {
+			addr = parsed
+		}
+	}
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr, true
+}
+
+func isPrivateHost(host string) bool {
+	addr, ok := parseHostAddr(host)
+	if !ok {
+		return false
+	}
+	if addr.IsLoopback() || addr.IsPrivate() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsUnspecified() {
+		return true
+	}
+	return false
+}
+
+// Summary captures a human-readable view of the policy contents.
+type Summary struct {
+	Allow           map[string][]string
+	Deny            map[string][]string
+	PrivateNetworks string
+	PIIMode         string
+}
+
+// Summarize groups policy rules by type for presentation.
+func Summarize(policy Policy) Summary {
+	policy.Normalise()
+	summary := Summary{
+		Allow:           make(map[string][]string),
+		Deny:            make(map[string][]string),
+		PrivateNetworks: policy.PrivateNetworks,
+		PIIMode:         policy.PIIMode,
+	}
+
+	for _, rule := range policy.Allow {
+		summary.Allow[rule.Type] = append(summary.Allow[rule.Type], rule.Value)
+	}
+	for _, rule := range policy.Deny {
+		summary.Deny[rule.Type] = append(summary.Deny[rule.Type], rule.Value)
+	}
+
+	for _, bucket := range []map[string][]string{summary.Allow, summary.Deny} {
+		for key, values := range bucket {
+			clone := append([]string(nil), values...)
+			sort.Strings(clone)
+			bucket[key] = clone
+		}
+	}
+
+	return summary
+}

--- a/internal/scope/enforcer_test.go
+++ b/internal/scope/enforcer_test.go
@@ -1,0 +1,98 @@
+package scope
+
+import "testing"
+
+func TestCompileAndEvaluate(t *testing.T) {
+	text := `### Program Scope
+
+Eligible targets:
+- app.acme.test
+- https://portal.acme.test/login
+- *.acme.org/api
+
+Out of scope targets:
+- admin.acme.test
+- api.acme.net/internal
+- 192.168.0.0/16
+
+Private subnets are out of scope.`
+
+	derived := ParsePolicyFromText(text)
+	manual := Policy{Version: 1, PrivateNetworks: PrivateNetworksBlock}
+	manual.Allow = []Rule{
+		{Type: RuleTypeDomain, Value: "app.acme.test"},
+		{Type: RuleTypePrefix, Value: "https://portal.acme.test/login"},
+		{Type: RuleTypeWildcard, Value: "*.acme.org"},
+		{Type: RuleTypePath, Value: "/api"},
+	}
+	manual.Deny = []Rule{
+		{Type: RuleTypeDomain, Value: "admin.acme.test"},
+		{Type: RuleTypeDomain, Value: "api.acme.net"},
+		{Type: RuleTypePath, Value: "/internal"},
+		{Type: RuleTypeCIDR, Value: "192.168.0.0/16"},
+	}
+
+	derived.Normalise()
+	manual.Normalise()
+
+	derivedEnforcer, err := Compile(derived)
+	if err != nil {
+		t.Fatalf("compile derived policy: %v", err)
+	}
+	manualEnforcer, err := Compile(manual)
+	if err != nil {
+		t.Fatalf("compile manual policy: %v", err)
+	}
+
+	cases := map[string]DecisionReason{
+		"https://app.acme.test/dashboard":      DecisionAllowed,
+		"https://portal.acme.test/login":       DecisionAllowed,
+		"https://portal.acme.test/login/reset": DecisionAllowed,
+		"https://portal.acme.test/logout":      DecisionNotAllowlisted,
+		"https://admin.acme.test/":             DecisionDeniedByRule,
+		"https://api.acme.net/internal/status": DecisionDeniedByRule,
+		"https://api.acme.org/api/list":        DecisionAllowed,
+		"https://api.acme.org/health":          DecisionAllowed,
+		"https://public.acme.net":              DecisionNotAllowlisted,
+		"http://192.168.1.10/status":           DecisionPrivateBlocked,
+		"https://10.0.0.5":                     DecisionPrivateBlocked,
+		"https://[::1]/":                       DecisionPrivateBlocked,
+		"":                                     DecisionInvalidCandidate,
+		"not a url":                            DecisionInvalidCandidate,
+	}
+
+	for candidate, expected := range cases {
+		d := derivedEnforcer.Evaluate(candidate)
+		m := manualEnforcer.Evaluate(candidate)
+		if d.Reason != m.Reason {
+			t.Errorf("decision mismatch for %q: derived=%s manual=%s", candidate, d.Reason, m.Reason)
+		}
+		if d.Reason != expected {
+			t.Errorf("unexpected derived decision for %q: got %s want %s", candidate, d.Reason, expected)
+		}
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	policy := Policy{
+		Allow: []Rule{
+			{Type: RuleTypeDomain, Value: "app.test"},
+			{Type: RuleTypeDomain, Value: "api.test"},
+		},
+		Deny: []Rule{{Type: RuleTypeCIDR, Value: "10.0.0.0/8"}},
+	}
+	policy.Normalise()
+	summary := Summarize(policy)
+
+	if summary.PrivateNetworks != PrivateNetworksUnspecified {
+		t.Fatalf("unexpected private network mode: %s", summary.PrivateNetworks)
+	}
+	allowDomains := summary.Allow[RuleTypeDomain]
+	if len(allowDomains) != 2 || allowDomains[0] != "api.test" || allowDomains[1] != "app.test" {
+		t.Fatalf("unexpected allow domain summary: %#v", allowDomains)
+	}
+	denyCIDR := summary.Deny[RuleTypeCIDR]
+	if len(denyCIDR) != 1 || denyCIDR[0] != "10.0.0.0/8" {
+		t.Fatalf("unexpected deny cidr summary: %#v", denyCIDR)
+	}
+}

--- a/internal/scope/parser.go
+++ b/internal/scope/parser.go
@@ -77,16 +77,16 @@ func detectHeading(lower, original string) (section, string) {
 	allowKeywords := []string{"in scope", "scope includes", "eligible", "targets", "permitted"}
 	denyKeywords := []string{"out of scope", "not in scope", "excluded", "forbidden", "prohibited"}
 
-	for _, kw := range allowKeywords {
-		if strings.Contains(lower, kw) {
-			remainder := extractRemainder(original, kw)
-			return sectionAllow, remainder
-		}
-	}
 	for _, kw := range denyKeywords {
 		if strings.Contains(lower, kw) {
 			remainder := extractRemainder(original, kw)
 			return sectionDeny, remainder
+		}
+	}
+	for _, kw := range allowKeywords {
+		if strings.Contains(lower, kw) {
+			remainder := extractRemainder(original, kw)
+			return sectionAllow, remainder
 		}
 	}
 	return sectionUnknown, ""
@@ -143,12 +143,17 @@ func extractRules(line string) []Rule {
 		addRule(Rule{Type: RuleTypeIP, Value: match})
 	}
 
+	cleanedLower := strings.ToLower(cleaned)
+
 	for _, match := range domainPattern.FindAllString(cleaned, -1) {
 		token := strings.ToLower(cleanToken(match))
 		if strings.Contains(token, "@") {
 			continue
 		}
 		if ipPattern.MatchString(token) {
+			continue
+		}
+		if strings.Contains(cleanedLower, "://"+token) {
 			continue
 		}
 		if strings.Contains(token, "*") {


### PR DESCRIPTION
## Summary
- add a glyphctl scope derive summary that surfaces detected allow/deny rules and network posture before writing scope.yaml
- implement a central scope enforcer capable of compiling policies, evaluating URLs, and producing grouped summaries for reuse across plugins
- harden the scope parser to prioritise deny headings and avoid emitting duplicate domain rules from full URLs
- add targeted tests to ensure compiled policies match manual allowlists and that summaries remain sorted

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68debc1359b0832aaec4b1d345a49220