### PR TITLE
Add cross-asset correlation and outcome graph to case builder

### DIFF
--- a/internal/cases/case.go
+++ b/internal/cases/case.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CaseSchemaVersion captures the version of the Case JSON structure emitted by the builder.
-const CaseSchemaVersion = "1.0"
+const CaseSchemaVersion = "1.1"
 
 // Case represents a deduplicated issue that merges evidence from multiple plugins.
 type Case struct {
@@ -26,6 +26,7 @@ type Case struct {
 	Sources       []SourceFinding    `json:"sources"`
 	GeneratedAt   findings.Timestamp `json:"generated_at"`
 	Labels        map[string]string  `json:"labels,omitempty"`
+	Graph         ExploitGraph       `json:"graph"`
 }
 
 // Asset describes the affected resource in a normalised form.
@@ -54,6 +55,12 @@ type EvidenceItem struct {
 type ProofOfConcept struct {
 	Summary string   `json:"summary,omitempty"`
 	Steps   []string `json:"steps"`
+}
+
+// ExploitGraph captures a deterministic state machine illustrating the exploit path.
+type ExploitGraph struct {
+	DOT     string `json:"dot"`
+	Mermaid string `json:"mermaid"`
 }
 
 // Risk captures the severity and supporting rationale for the case.
@@ -94,6 +101,7 @@ func (c Case) Clone() Case {
 			clone.Labels[k] = v
 		}
 	}
+	clone.Graph = c.Graph
 	return clone
 }
 

--- a/internal/cases/correlate.go
+++ b/internal/cases/correlate.go
@@ -1,0 +1,234 @@
+package cases
+
+import (
+	"net"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+func (b *Builder) clusterFindings(fs []findings.Finding) [][]findings.Finding {
+	if len(fs) == 0 {
+		return nil
+	}
+	uf := newUnionFind(len(fs))
+	indexByKey := make(map[string]int)
+	for i, f := range fs {
+		keys := b.correlationKeys(f)
+		if len(keys) == 0 {
+			keys = []string{strings.ToLower(strings.TrimSpace(b.groupKey(f)))}
+		}
+		for _, key := range keys {
+			if key == "" {
+				continue
+			}
+			if prev, ok := indexByKey[key]; ok {
+				uf.union(i, prev)
+			} else {
+				indexByKey[key] = i
+			}
+		}
+	}
+
+	grouped := make(map[int][]findings.Finding)
+	for i, f := range fs {
+		root := uf.find(i)
+		grouped[root] = append(grouped[root], f)
+	}
+
+	out := make([][]findings.Finding, 0, len(grouped))
+	for _, group := range grouped {
+		out = append(out, group)
+	}
+	return out
+}
+
+func (b *Builder) componentOrderKey(fs []findings.Finding) string {
+	if len(fs) == 0 {
+		return ""
+	}
+	keys := make([]string, len(fs))
+	for i, f := range fs {
+		keys[i] = strings.ToLower(strings.TrimSpace(b.groupKey(f)))
+	}
+	sort.Strings(keys)
+	return keys[0]
+}
+
+func (b *Builder) correlationKeys(f findings.Finding) []string {
+	seen := make(map[string]struct{})
+	add := func(prefix, raw string) {
+		raw = strings.TrimSpace(strings.ToLower(raw))
+		if raw == "" {
+			return
+		}
+		key := prefix + raw
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+	}
+
+	primary := strings.ToLower(strings.TrimSpace(b.groupKey(f)))
+	if primary != "" {
+		add("primary:", primary)
+	}
+
+	if explicit := strings.TrimSpace(f.Metadata["case_key"]); explicit != "" {
+		add("case:", explicit)
+	}
+
+	if host := canonicalTarget(f.Target); host != "" {
+		add("host:", host)
+		if domain := registrableDomain(host); domain != "" {
+			add("domain:", domain)
+		}
+	}
+
+	asset := normaliseAsset(f)
+	if asset.Identifier != "" {
+		add("asset:", asset.Kind+"|"+strings.ToLower(asset.Identifier))
+	}
+
+	for k, v := range f.Metadata {
+		key := strings.ToLower(strings.TrimSpace(k))
+		value := strings.TrimSpace(v)
+		switch {
+		case key == "case_key" || strings.HasPrefix(key, "label:"):
+			continue
+		case key == "cookie_domain" || key == "cookie_domains":
+			for _, token := range splitCorrelationValues(value) {
+				token = strings.TrimPrefix(token, ".")
+				add("domain:", token)
+			}
+		case strings.HasPrefix(key, "cookie:"):
+			for _, token := range splitCorrelationValues(value) {
+				token = strings.TrimPrefix(token, ".")
+				add("domain:", token)
+			}
+		case key == "redirect_chain" || key == "redirects":
+			for _, token := range splitCorrelationValues(value) {
+				if strings.HasPrefix(token, "http://") || strings.HasPrefix(token, "https://") {
+					if u, err := url.Parse(token); err == nil && u.Host != "" {
+						host := strings.ToLower(u.Host)
+						if h, _, err := net.SplitHostPort(host); err == nil && h != "" {
+							host = h
+						}
+						add("host:", host)
+						if domain := registrableDomain(host); domain != "" {
+							add("domain:", domain)
+						}
+					}
+				} else {
+					add("host:", token)
+				}
+			}
+		case strings.HasPrefix(key, "param:"):
+			name := strings.TrimPrefix(key, "param:")
+			if name == "" {
+				continue
+			}
+			add("param:", name+"="+strings.ToLower(value))
+		case key == "shared_param" || key == "shared_params":
+			for _, token := range splitCorrelationValues(value) {
+				parts := strings.SplitN(token, "=", 2)
+				if len(parts) == 2 {
+					add("param:", strings.ToLower(strings.TrimSpace(parts[0]))+"="+strings.ToLower(strings.TrimSpace(parts[1])))
+				}
+			}
+		case strings.HasPrefix(key, "correlate:"):
+			label := strings.TrimPrefix(key, "correlate:")
+			for _, token := range splitCorrelationValues(value) {
+				add(label+":", token)
+			}
+		}
+	}
+
+	if len(seen) == 0 {
+		add("fallback:", primary)
+	}
+
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func splitCorrelationValues(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	replacer := strings.NewReplacer("->", " ", ",", " ", ";", " ", "|", " ", "\n", " ", "\t", " ")
+	normalized := replacer.Replace(raw)
+	fields := strings.Fields(normalized)
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.TrimSpace(strings.ToLower(strings.TrimPrefix(f, ".")))
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func registrableDomain(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return ""
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return host
+	}
+	if strings.HasSuffix(host, ".") {
+		host = strings.TrimSuffix(host, ".")
+	}
+	parts := strings.Split(host, ".")
+	if len(parts) < 2 {
+		return host
+	}
+	last := parts[len(parts)-1]
+	secondLast := parts[len(parts)-2]
+	return secondLast + "." + last
+}
+
+type unionFind struct {
+	parent []int
+	rank   []int
+}
+
+func newUnionFind(n int) *unionFind {
+	parent := make([]int, n)
+	rank := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+	return &unionFind{parent: parent, rank: rank}
+}
+
+func (u *unionFind) find(x int) int {
+	if u.parent[x] != x {
+		u.parent[x] = u.find(u.parent[x])
+	}
+	return u.parent[x]
+}
+
+func (u *unionFind) union(a, b int) {
+	ra := u.find(a)
+	rb := u.find(b)
+	if ra == rb {
+		return
+	}
+	if u.rank[ra] < u.rank[rb] {
+		u.parent[ra] = rb
+	} else if u.rank[rb] < u.rank[ra] {
+		u.parent[rb] = ra
+	} else {
+		u.parent[rb] = ra
+		u.rank[ra]++
+	}
+}

--- a/internal/cases/graph.go
+++ b/internal/cases/graph.go
@@ -1,0 +1,65 @@
+package cases
+
+import (
+	"fmt"
+	"strings"
+)
+
+func buildExploitGraph(c Case, summary SummaryOutput) ExploitGraph {
+	preconditions := fmt.Sprintf("Asset: %s", safeGraphText(c.Asset.Identifier))
+	if c.Vector.Kind != "" {
+		vector := c.Vector.Kind
+		if c.Vector.Value != "" {
+			vector = fmt.Sprintf("%s (%s)", vector, c.Vector.Value)
+		}
+		preconditions = preconditions + "\\nVector: " + safeGraphText(vector)
+	}
+
+	action := "Follow synthesised reproduction"
+	if len(summary.ReproductionSteps) > 0 {
+		action = summary.ReproductionSteps[0]
+	} else if summary.ProofSummary != "" {
+		action = summary.ProofSummary
+	}
+
+	post := fmt.Sprintf("Impact: %s", strings.ToUpper(string(summary.RiskSeverity)))
+	if summary.RiskRationale != "" {
+		post = post + "\\n" + summary.RiskRationale
+	}
+
+	dot := fmt.Sprintf(`digraph ExploitPath {
+    rankdir=LR;
+    node [shape=box];
+    pre [label="%s"];
+    act [label="%s"];
+    post [label="%s"];
+    pre -> act -> post;
+}`, escapeDOT(preconditions), escapeDOT(action), escapeDOT(post))
+
+	mermaid := fmt.Sprintf(`graph TD
+    pre["%s"] --> act["%s"] --> post["%s"]
+`, escapeMermaid(preconditions), escapeMermaid(action), escapeMermaid(post))
+
+	return ExploitGraph{DOT: dot, Mermaid: mermaid}
+}
+
+func safeGraphText(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "unspecified"
+	}
+	return s
+}
+
+func escapeDOT(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	return s
+}
+
+func escapeMermaid(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	s = strings.ReplaceAll(s, "\n", "<br/>")
+	return s
+}

--- a/internal/cases/testdata/golden_case.json
+++ b/internal/cases/testdata/golden_case.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "id": "TFYQRWYLW5TXVDTX7357DBU4BT",
   "asset": {
     "kind": "web",
@@ -53,5 +53,9 @@
       "target": "https://corp.example.com"
     }
   ],
-  "generated_at": "2023-11-14T23:03:20Z"
+  "generated_at": "2023-11-14T23:03:20Z",
+  "graph": {
+    "dot": "digraph ExploitPath {\n    rankdir=LR;\n    node [shape=box];\n    pre [label=\"Asset: corp.example.com\\\\nVector: source_code\"];\n    act [label=\"Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\nAsset: corp.example.com (web)\nAttack vector: source_code\nEvidence:\n- Plugin=excavator Severity=MED Message=Public log leak\n- Plugin=seer Severity=LOW Message=Email address found\nProvide a concise narrative and highlight overlapping evidence.\"];\n    post [label=\"Impact: MED\\\\nHighest severity reported by contributing plugins: MED\"];\n    pre -\u003e act -\u003e post;\n}",
+    "mermaid": "graph TD\n    pre[\"Asset: corp.example.com\\\\nVector: source_code\"] --\u003e act[\"Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\u003cbr/\u003eAsset: corp.example.com (web)\u003cbr/\u003eAttack vector: source_code\u003cbr/\u003eEvidence:\u003cbr/\u003e- Plugin=excavator Severity=MED Message=Public log leak\u003cbr/\u003e- Plugin=seer Severity=LOW Message=Email address found\u003cbr/\u003eProvide a concise narrative and highlight overlapping evidence.\"] --\u003e post[\"Impact: MED\\\\nHighest severity reported by contributing plugins: MED\"]\n"
+  }
 }

--- a/internal/cases/testdata/multi_host_case.json
+++ b/internal/cases/testdata/multi_host_case.json
@@ -1,0 +1,82 @@
+{
+  "version": "1.1",
+  "id": "R6PZLFDP2I3ZMVL77GNI2FQT4U",
+  "asset": {
+    "kind": "web",
+    "identifier": "c.internal",
+    "details": "https://c.internal/metadata"
+  },
+  "vector": {
+    "kind": "http_proxy"
+  },
+  "summary": "3 plugin signal(s) indicate an issue affecting c.internal (https://c.internal/metadata).\n\nKey evidence:\n- [Galdr] Open redirect observed (MED)\n- [Proxy] Captured authenticated flow (HIGH)\n- [Seer] Server-side request forgery (CRIT)",
+  "evidence": [
+    {
+      "plugin": "galdr",
+      "type": "galdr.redirect",
+      "message": "Open redirect observed",
+      "metadata": {
+        "redirect_chain": "https://auth.example/login -\u003e https://app.example/dashboard -\u003e https://c.internal/metadata?token=abc123"
+      }
+    },
+    {
+      "plugin": "proxy",
+      "type": "proxy.session",
+      "message": "Captured authenticated flow",
+      "metadata": {
+        "cookie_domain": ".example.com",
+        "param:token": "abc123"
+      }
+    },
+    {
+      "plugin": "seer",
+      "type": "seer.ssrf",
+      "message": "Server-side request forgery",
+      "metadata": {
+        "shared_param": "token=abc123"
+      }
+    }
+  ],
+  "proof": {
+    "summary": "Reproduce the issue on c.internal by following 2 synthesised steps.",
+    "steps": [
+      "Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\nAsset: c.internal (web)\nAttack vector: http_proxy\nEvidence:\n- Plugin=galdr Severity=MED Message=Open redirect observed\n- Plugin=proxy Severity=HIGH Message=Captured authenticated flow\n- Plugin=seer Severity=CRIT Message=Server-side request forgery\nProvide a concise narrative and highlight overlapping evidence.",
+      "Execute reproduction instructions synthesised from prompt: Synthesize deterministic reproduction steps for asset c.internal (web).\nUse at most 4 steps. Incorporate plugin observations:\n- Galdr observed: Open redirect observed\n- Proxy observed: Captured authenticated flow\n- Seer observed: Server-side request forgery\nReturn concise imperative steps."
+    ]
+  },
+  "risk": {
+    "severity": "crit",
+    "score": 9.5,
+    "rationale": "Highest severity reported by contributing plugins: CRIT"
+  },
+  "confidence": 0.75,
+  "confidence_log": "3 plugin(s), 3 finding(s)",
+  "sources": [
+    {
+      "id": "01J123ABCEXAMPLE0000000002",
+      "plugin": "galdr",
+      "type": "galdr.redirect",
+      "severity": "med",
+      "target": "https://app.example/start"
+    },
+    {
+      "id": "01J123ABCEXAMPLE0000000001",
+      "plugin": "proxy",
+      "type": "proxy.session",
+      "severity": "high",
+      "target": "https://auth.example/login"
+    },
+    {
+      "id": "01J123ABCEXAMPLE0000000003",
+      "plugin": "seer",
+      "type": "seer.ssrf",
+      "severity": "crit",
+      "target": "https://c.internal/metadata"
+    }
+  ],
+  "generated_at": "2023-11-15T03:46:40Z",
+  "graph": {
+    "dot": "digraph ExploitPath {\n    rankdir=LR;\n    node [shape=box];\n    pre [label=\"Asset: c.internal\\\\nVector: http_proxy\"];\n    act [label=\"Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\nAsset: c.internal (web)\nAttack vector: http_proxy\nEvidence:\n- Plugin=galdr Severity=MED Message=Open redirect observed\n- Plugin=proxy Severity=HIGH Message=Captured authenticated flow\n- Plugin=seer Severity=CRIT Message=Server-side request forgery\nProvide a concise narrative and highlight overlapping evidence.\"];\n    post [label=\"Impact: CRIT\\\\nHighest severity reported by contributing plugins: CRIT\"];\n    pre -\u003e act -\u003e post;\n}",
+    "mermaid": "graph TD\n    pre[\"Asset: c.internal\\\\nVector: http_proxy\"] --\u003e act[\"Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\u003cbr/\u003eAsset: c.internal (web)\u003cbr/\u003eAttack vector: http_proxy\u003cbr/\u003eEvidence:\u003cbr/\u003e- Plugin=galdr Severity=MED Message=Open redirect observed\u003cbr/\u003e- Plugin=proxy Severity=HIGH Message=Captured authenticated flow\u003cbr/\u003e- Plugin=seer Severity=CRIT Message=Server-side request forgery\u003cbr/\u003eProvide a concise narrative and highlight overlapping evidence.\"] --\u003e post[\"Impact: CRIT\\\\nHighest severity reported by contributing plugins: CRIT\"]\n"
+  }
+}

--- a/internal/cases/testdata/multi_host_findings.json
+++ b/internal/cases/testdata/multi_host_findings.json
@@ -1,0 +1,42 @@
+[
+  {
+    "version": "0.2",
+    "id": "01J123ABCEXAMPLE0000000001",
+    "plugin": "proxy",
+    "type": "proxy.session",
+    "message": "Captured authenticated flow",
+    "target": "https://auth.example/login",
+    "severity": "high",
+    "ts": "2024-04-10T12:00:00Z",
+    "meta": {
+      "cookie_domain": ".example.com",
+      "param:token": "abc123"
+    }
+  },
+  {
+    "version": "0.2",
+    "id": "01J123ABCEXAMPLE0000000002",
+    "plugin": "galdr",
+    "type": "galdr.redirect",
+    "message": "Open redirect observed",
+    "target": "https://app.example/start",
+    "severity": "med",
+    "ts": "2024-04-10T12:05:00Z",
+    "meta": {
+      "redirect_chain": "https://auth.example/login -> https://app.example/dashboard -> https://c.internal/metadata?token=abc123"
+    }
+  },
+  {
+    "version": "0.2",
+    "id": "01J123ABCEXAMPLE0000000003",
+    "plugin": "seer",
+    "type": "seer.ssrf",
+    "message": "Server-side request forgery",
+    "target": "https://c.internal/metadata",
+    "severity": "crit",
+    "ts": "2024-04-10T12:10:00Z",
+    "meta": {
+      "shared_param": "token=abc123"
+    }
+  }
+]

--- a/internal/cases/testdata/sample_web_service_case.json
+++ b/internal/cases/testdata/sample_web_service_case.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "id": "TZLB22243HGZ7RJDGEQY5WLMMZ",
   "asset": {
     "kind": "web",
@@ -89,5 +89,9 @@
       "target": "https://app.example/login/static/app.js"
     }
   ],
-  "generated_at": "2023-11-15T00:43:20Z"
+  "generated_at": "2023-11-15T00:43:20Z",
+  "graph": {
+    "dot": "digraph ExploitPath {\n    rankdir=LR;\n    node [shape=box];\n    pre [label=\"Asset: app.example\\\\nVector: web (login)\"];\n    act [label=\"Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\nAsset: app.example (web)\nAttack vector: web (login)\nEvidence:\n- Plugin=excavator Severity=MED Message=Backup archive exposed\n- Plugin=galdr Severity=LOW Message=Response discloses login banner\n- Plugin=seer Severity=HIGH Message=Hardcoded API key leaked\nProvide a concise narrative and highlight overlapping evidence.\"];\n    post [label=\"Impact: HIGH\\\\nHighest severity reported by contributing plugins: HIGH\"];\n    pre -\u003e act -\u003e post;\n}",
+    "mermaid": "graph TD\n    pre[\"Asset: app.example\\\\nVector: web (login)\"] --\u003e act[\"Review plugin evidence: You are an AI security analyst. Summarise why the following signals combine into a single case.\u003cbr/\u003eAsset: app.example (web)\u003cbr/\u003eAttack vector: web (login)\u003cbr/\u003eEvidence:\u003cbr/\u003e- Plugin=excavator Severity=MED Message=Backup archive exposed\u003cbr/\u003e- Plugin=galdr Severity=LOW Message=Response discloses login banner\u003cbr/\u003e- Plugin=seer Severity=HIGH Message=Hardcoded API key leaked\u003cbr/\u003eProvide a concise narrative and highlight overlapping evidence.\"] --\u003e post[\"Impact: HIGH\\\\nHighest severity reported by contributing plugins: HIGH\"]\n"
+  }
 }


### PR DESCRIPTION
## Summary
- expand case grouping with correlation keys for cookies, redirects, shared parameters, and registrable domains
- attach exploit path graphs to cases and bump the schema version to 1.1
- stabilise summary cache hashing and add multi-host golden coverage

## Testing
- `go test ./internal/cases`
- `go test ./...` *(fails: runtime pthread_create limit while running plugin runner tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df214533a8832aaf37284335e62ff8