### PR TITLE
Add TLS metadata and deterministic normalization to replay manifests

### DIFF
--- a/internal/replay/artifact.go
+++ b/internal/replay/artifact.go
@@ -78,6 +78,8 @@ func CreateArtifact(path string, manifest Manifest, files map[string][]byte) err
 			return fmt.Errorf("normalise robots[%d] body file: %w", i, err)
 		}
 	}
+	manifest.Normalize()
+
 	if err := manifest.Validate(); err != nil {
 		return err
 	}

--- a/internal/replay/artifact_test.go
+++ b/internal/replay/artifact_test.go
@@ -28,6 +28,14 @@ func TestCreateAndExtractArtifact(t *testing.T) {
 			Headers:    map[string][]string{"Content-Type": {"text/html"}},
 			BodyFile:   "responses/example.html",
 		}},
+		DNS: []DNSRecord{
+			{Host: "Example.com", Addresses: []string{"2.2.2.2", "1.1.1.1", "1.1.1.1"}},
+			{Host: "api.example.com", Addresses: []string{"3.3.3.3"}},
+		},
+		TLS: []TLSRecord{
+			{Host: "api.example.com", JA3: "api-ja3", JA3Hash: "api-hash", NegotiatedALPN: "h2", OfferedALPN: []string{"http/1.1", "h2"}},
+			{Host: "example.com", JA3: "root-ja3", JA3Hash: "root-hash", NegotiatedALPN: "http/1.1", OfferedALPN: []string{"http/1.1", "spdy/3"}},
+		},
 	}
 
 	files := map[string][]byte{
@@ -53,6 +61,36 @@ func TestCreateAndExtractArtifact(t *testing.T) {
 		t.Fatalf("unexpected findings file: %s", gotManifest.FindingsFile)
 	}
 
+	if len(gotManifest.DNS) != 2 {
+		t.Fatalf("expected 2 DNS records, got %d", len(gotManifest.DNS))
+	}
+	if gotManifest.DNS[0].Host != "api.example.com" {
+		t.Fatalf("dns records not normalised: %#v", gotManifest.DNS)
+	}
+	if len(gotManifest.DNS[0].Addresses) != 1 || gotManifest.DNS[0].Addresses[0] != "3.3.3.3" {
+		t.Fatalf("dns addresses not normalised: %#v", gotManifest.DNS[0])
+	}
+	if gotManifest.DNS[1].Host != "example.com" {
+		t.Fatalf("dns host normalisation failed: %#v", gotManifest.DNS[1])
+	}
+	expectedAddrs := []string{"1.1.1.1", "2.2.2.2"}
+	if !equalStrings(gotManifest.DNS[1].Addresses, expectedAddrs) {
+		t.Fatalf("dns address ordering unexpected: %v", gotManifest.DNS[1].Addresses)
+	}
+
+	if len(gotManifest.TLS) != 2 {
+		t.Fatalf("expected 2 TLS records, got %d", len(gotManifest.TLS))
+	}
+	if gotManifest.TLS[0].Host != "api.example.com" || gotManifest.TLS[0].NegotiatedALPN != "h2" {
+		t.Fatalf("tls normalisation failed: %#v", gotManifest.TLS[0])
+	}
+	if !equalStrings(gotManifest.TLS[0].OfferedALPN, []string{"h2", "http/1.1"}) {
+		t.Fatalf("tls offered ALPN normalisation failed: %v", gotManifest.TLS[0].OfferedALPN)
+	}
+	if gotManifest.TLS[1].Host != "example.com" || gotManifest.TLS[1].NegotiatedALPN != "http/1.1" {
+		t.Fatalf("tls ordering unexpected: %#v", gotManifest.TLS[1])
+	}
+
 	// Ensure files were extracted to the expected locations.
 	data, err := os.ReadFile(filepath.Join(extractedDir, "files", "responses", "example.html"))
 	if err != nil {
@@ -71,4 +109,16 @@ func TestCreateAndExtractArtifact(t *testing.T) {
 	if err := json.Unmarshal(enc, &decoded); err != nil {
 		t.Fatalf("unmarshal manifest: %v", err)
 	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- capture TLS handshake metadata in replay manifests and bump the schema to version 1.1
- normalize DNS, TLS, and other manifest collections before packaging to keep replay artefacts stable
- extend the artefact round-trip test to cover DNS/TLS persistence and ordering guarantees

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68df3e8ebbb4832aa2fb67957120697c