### PR TITLE
feat: expand packaging targets and harden container

### DIFF
--- a/.github/workflows/packaging-smoke.yml
+++ b/.github/workflows/packaging-smoke.yml
@@ -1,0 +1,100 @@
+name: packaging-smoke
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  deb:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Determine latest release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q '.tagName' || echo '')
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          if [ -z "$tag" ]; then
+            echo "No published releases found; skipping install"
+          fi
+
+      - name: Install Debian package
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+        if: steps.release.outputs.tag != ''
+        run: |
+          set -euo pipefail
+          asset="glyphctl_${TAG}_linux_amd64.deb"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p "$asset"
+          sudo dpkg -i "$asset"
+          glyphctl --version
+
+  rpm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq rpm
+
+      - name: Determine latest release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q '.tagName' || echo '')
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          if [ -z "$tag" ]; then
+            echo "No published releases found; skipping install"
+          fi
+
+      - name: Install RPM package
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+        if: steps.release.outputs.tag != ''
+        run: |
+          set -euo pipefail
+          asset="glyphctl_${TAG}_linux_amd64.rpm"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p "$asset"
+          sudo rpm -i --replacepkgs --nosignature "$asset"
+          glyphctl --version
+
+  scoop:
+    runs-on: windows-latest
+    steps:
+      - name: Determine manifest status
+        id: manifest
+        shell: pwsh
+        run: |
+          $manifest = Invoke-RestMethod "https://raw.githubusercontent.com/${{ github.repository }}/main/scoop/bucket/glyphctl.json"
+          if ($manifest.version -eq '0.0.0') {
+            "placeholder=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            Write-Host "Scoop manifest still uses placeholder version; skipping install"
+          } else {
+            "placeholder=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          }
+
+      - name: Install Scoop
+        if: steps.manifest.outputs.placeholder == 'false'
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+          iwr -useb get.scoop.sh | iex
+
+      - name: Add Glyph bucket and install glyphctl
+        if: steps.manifest.outputs.placeholder == 'false'
+        shell: pwsh
+        run: |
+          scoop bucket add glyph https://github.com/${{ github.repository }}
+          scoop install glyphctl
+          glyphctl --version

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -60,6 +60,12 @@ jobs:
           build-args: |
             VERSION=${{ github.ref_name }}
 
+      - name: Select primary tag
+        id: tag
+        run: |
+          primary=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
+          echo "ref=$primary" >>"$GITHUB_OUTPUT"
+
       - name: Upload image digest for provenance
         run: |
           echo "${{ steps.build.outputs.digest }}" >image-digest.txt
@@ -89,3 +95,20 @@ jobs:
               cosign sign "${tag}@${DIGEST}"
             fi
           done <<< "$tags"
+
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.22.0
+        with:
+          image-ref: ${{ steps.tag.outputs.ref }}
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Grype vulnerability scan
+        uses: anchore/grype-action@v0.9.1
+        with:
+          image: ${{ steps.tag.outputs.ref }}
+          fail-build: true
+          severity-cutoff: high

--- a/.github/workflows/scoop-release.yml
+++ b/.github/workflows/scoop-release.yml
@@ -1,0 +1,76 @@
+name: scoop-release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  update-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p "glyphctl_${TAG}_windows_amd64.zip" -D dist
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" -p "glyphctl_${TAG}_windows_arm64.zip" -D dist
+
+      - name: Update Scoop manifest
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          AMD64_HASH=$(sha256sum "dist/glyphctl_${TAG}_windows_amd64.zip" | awk '{print $1}')
+          ARM64_HASH=$(sha256sum "dist/glyphctl_${TAG}_windows_arm64.zip" | awk '{print $1}')
+          export AMD64_HASH ARM64_HASH
+          python <<'PY'
+import json
+import os
+from pathlib import Path
+
+tag = os.environ["TAG"]
+version = tag[1:] if tag.startswith("v") else tag
+amd64_hash = os.environ["AMD64_HASH"]
+arm64_hash = os.environ["ARM64_HASH"]
+manifest_path = Path("scoop/bucket/glyphctl.json")
+manifest = json.loads(manifest_path.read_text())
+manifest["version"] = version
+manifest["architecture"]["64bit"]["url"] = f"https://github.com/RowanDark/Glyph/releases/download/{tag}/glyphctl_{tag}_windows_amd64.zip"
+manifest["architecture"]["64bit"]["hash"] = f"sha256:{amd64_hash}"
+manifest["architecture"]["arm64"]["url"] = f"https://github.com/RowanDark/Glyph/releases/download/{tag}/glyphctl_{tag}_windows_arm64.zip"
+manifest["architecture"]["arm64"]["hash"] = f"sha256:{arm64_hash}"
+manifest["autoupdate"]["architecture"]["64bit"]["url"] = "https://github.com/RowanDark/Glyph/releases/download/v$version/glyphctl_v$version_windows_amd64.zip"
+manifest["autoupdate"]["architecture"]["arm64"]["url"] = "https://github.com/RowanDark/Glyph/releases/download/v$version/glyphctl_v$version_windows_arm64.zip"
+manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+PY
+
+      - name: Commit manifest
+        run: |
+          set -euo pipefail
+          if git diff --quiet scoop/bucket/glyphctl.json; then
+            echo "Manifest already up to date"
+            exit 0
+          fi
+          git add scoop/bucket/glyphctl.json
+          git commit -m "chore: update Scoop manifest for $TAG"
+          git push origin HEAD:main
+        env:
+          TAG: ${{ github.event.release.tag_name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,6 +73,23 @@ archives:
 checksum:
   name_template: "glyph_{{ .Version }}_checksums.txt"
 
+nfpms:
+  - id: glyphctl-linux-packages
+    package_name: glyphctl
+    builds:
+      - glyphctl
+    formats:
+      - deb
+      - rpm
+    maintainer: Rowan Dark <security@rowandark.dev>
+    description: Glyph automation toolkit command-line interface.
+    homepage: https://github.com/RowanDark/Glyph
+    license: Apache-2.0
+    bindir: /usr/local/bin
+    priority: optional
+    section: utils
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Arch }}"
+
 dockers:
   - id: glyphctl-image
     use: buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,14 @@ ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /out/glyphctl ./cmd/glyphctl
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12:nonroot
+
+WORKDIR /home/nonroot
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /out/glyphctl /usr/local/bin/glyphctl
+COPY --from=builder --chown=nonroot:nonroot --chmod=0555 /out/glyphctl /usr/local/bin/glyphctl
+
+USER nonroot:nonroot
 
 ENTRYPOINT ["/usr/local/bin/glyphctl"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -9,11 +9,53 @@ ranked findings and human-readable reports.
 
 ## Installation
 
+### macOS (Homebrew)
+
 macOS users can install the prebuilt `glyphctl` binary via Homebrew using the
 [RowanDark/homebrew-glyph tap](https://github.com/RowanDark/homebrew-glyph):
 
 ```bash
 brew install rowandark/glyph/glyph
+```
+
+### Linux (Debian/Ubuntu)
+
+Download the `.deb` package from the
+[GitHub Releases page](https://github.com/RowanDark/Glyph/releases) and install
+it with `dpkg`:
+
+```bash
+sudo dpkg -i glyphctl_<version>_linux_amd64.deb
+```
+
+Replace `<version>` with the release you want to install. The package installs
+`glyphctl` into `/usr/local/bin`.
+
+### Linux (Fedora/RHEL/OpenSUSE)
+
+RPM packages are published alongside each release. Install them with `rpm`:
+
+```bash
+sudo rpm -i glyphctl_<version>_linux_amd64.rpm
+```
+
+### Windows (Scoop)
+
+Add this repository as a Scoop bucket and install the manifest:
+
+```powershell
+scoop bucket add glyph https://github.com/RowanDark/Glyph
+scoop install glyphctl
+```
+
+### Container image
+
+A hardened container image is pushed to GitHub Container Registry with every
+release. Pull and run it with:
+
+```bash
+docker pull ghcr.io/rowandark/glyphctl:latest
+docker run --rm ghcr.io/rowandark/glyphctl:latest --version
 ```
 
 ## Quickstart

--- a/scoop/bucket/glyphctl.json
+++ b/scoop/bucket/glyphctl.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.0.0",
+  "description": "Glyph automation toolkit command-line interface.",
+  "homepage": "https://github.com/RowanDark/Glyph",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/RowanDark/Glyph/releases/download/v0.0.0/glyphctl_v0.0.0_windows_amd64.zip",
+      "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "arm64": {
+      "url": "https://github.com/RowanDark/Glyph/releases/download/v0.0.0/glyphctl_v0.0.0_windows_arm64.zip",
+      "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  "bin": [
+    "glyphctl.exe"
+  ],
+  "checkver": {
+    "github": "https://github.com/RowanDark/Glyph"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/RowanDark/Glyph/releases/download/v$version/glyphctl_v$version_windows_amd64.zip"
+      },
+      "arm64": {
+        "url": "https://github.com/RowanDark/Glyph/releases/download/v$version/glyphctl_v$version_windows_arm64.zip"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add NFPM packaging configuration so GoReleaser produces .deb and .rpm artifacts
- publish a Scoop manifest with automated updates and scheduled smoke tests for Linux and Windows installers
- harden the glyphctl container image and gate releases on Trivy and Grype vulnerability scans while documenting new install paths

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dfe6f58f98832aa0170d5c36decee8