### PR TITLE
Configure docs deployment via GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,23 +37,36 @@ jobs:
           python -m pip install --upgrade pip
           pip install mkdocs mkdocs-material mkdocs-redirects
 
-      - name: Configure Git user
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
       - name: Build documentation
         run: mkdocs build --strict
 
-      - name: Deploy documentation
-        run: mkdocs gh-deploy --force --clean --remote-name origin --remote-branch gh-pages
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   smoke:
-    needs: build
+    needs: deploy
     runs-on: ubuntu-latest
     steps:
       - name: Check published pages
+        env:
+          BASE_URL: ${{ needs.deploy.outputs.page_url }}
         run: |
+          url="${BASE_URL%/}"
           for p in "" "quickstart/" "cli/" "plugins/" "security/"; do
-            curl -fSL "https://rowandark.github.io/Glyph/${p}" >/dev/null
+            curl -fSL "${url}/${p}" >/dev/null
           done

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+glyph.rowandark.com


### PR DESCRIPTION
## Summary
- switch the docs workflow to the official GitHub Pages deployment pipeline
- publish the MkDocs build as a Pages artifact and reuse the deployed URL for smoke tests
- add a CNAME record so the site serves from glyph.rowandark.com

## Testing
- `mkdocs build --strict` *(fails: mkdocs not installed locally)*

------
https://chatgpt.com/codex/tasks/task_e_68e00e4b93b4832ab897d9d17e680008