### PR TITLE
Add mkdocs redirect maps for legacy documentation URLs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.5
+mkdocs-material
+mkdocs-redirects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,30 @@ theme:
 
 plugins:
   - search
-  - redirects
+  - redirects:
+      redirect_maps:
+        # Legacy single-page CLI docs
+        "cli.html": "cli/"
+        "CLI.html": "cli/"
+        "cli/index.html": "cli/"
+        "CLI/index.html": "cli/"
+        "docs/cli.html": "cli/"
+        "docs/CLI.html": "cli/"
+        "docs/cli/index.html": "cli/"
+        "docs/CLI/index.html": "cli/"
+        # Old quickstart locations (directory and capitalised variants)
+        "Quickstart/": "quickstart/"
+        "QuickStart/": "quickstart/"
+        "Quickstart.html": "quickstart/"
+        "QuickStart.html": "quickstart/"
+        "Quickstart/index.html": "quickstart/"
+        "QuickStart/index.html": "quickstart/"
+        "docs/Quickstart/": "quickstart/"
+        "docs/QuickStart/": "quickstart/"
+        "docs/Quickstart.html": "quickstart/"
+        "docs/QuickStart.html": "quickstart/"
+        "docs/Quickstart/index.html": "quickstart/"
+        "docs/QuickStart/index.html": "quickstart/"
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- configure mkdocs-redirects to point common legacy CLI and Quickstart URLs to their canonical locations
- document the documentation build dependencies, including mkdocs-redirects, in docs/requirements.txt

## Testing
- pip install -r docs/requirements.txt *(fails: proxy blocks access to PyPI)*

------
https://chatgpt.com/codex/tasks/task_e_68e102168520832a8e4185cc543ed3c1