### PR TITLE
Add explicit anchors to docs for stable deep links

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -4,7 +4,7 @@ Glyph reads configuration from a single resolved source that combines defaults,
 optional configuration files, and environment variable overrides. This keeps the
 platform easy to tune locally and in production deployments.
 
-## Resolution order
+## Resolution order {#resolution-order}
 
 1. Built-in defaults.
 2. `~/.glyph/config.toml` (optional).
@@ -15,7 +15,7 @@ Each subsequent source overrides values defined in the previous ones. Local
 project configuration therefore beats the user-level TOML file, and environment
 variables have the final say.
 
-## Supported fields
+## Supported fields {#supported-fields}
 
 ```yaml
 server_addr: 127.0.0.1:50051
@@ -32,7 +32,7 @@ proxy:
 
 The TOML representation uses matching keys and section names.
 
-## Environment overrides
+## Environment overrides {#environment-overrides}
 
 The loader accepts the following variables:
 
@@ -51,7 +51,7 @@ The loader accepts the following variables:
 All variables accept whitespace-trimmed values. Boolean variables treat `1`,
 `true`, `yes`, and `on` as true, and `0`, `false`, `no`, and `off` as false.
 
-## Inspecting the resolved configuration
+## Inspecting the resolved configuration {#inspect-the-resolved-configuration}
 
 Run the following command to print the merged configuration as seen by
 `glyphctl`:

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -5,7 +5,7 @@ launch plugins, inspect findings, and generate analyst-facing reports. This page
 summarises the most common workflows; run `glyphctl --help` to explore every
 subcommand.
 
-## Try the demo pipeline
+## Try the demo pipeline {#try-the-demo-pipeline}
 
 Generate a full set of demo artifacts—target traffic, ranked findings, and a
 shareable HTML report—with a single command:
@@ -19,7 +19,7 @@ JSONL outputs under `out/demo/`, and renders `out/demo/report.html`. The output 
 safe to share with stakeholders and mirrors the examples under
 [`examples/quickstart/`]({{ config.repo_url }}/tree/main/examples/quickstart).
 
-## Inspect configuration
+## Inspect configuration {#inspect-configuration}
 
 Print the resolved runtime configuration to confirm the active server address,
 authentication token, and output directory:
@@ -31,7 +31,7 @@ glyphctl config print
 See the [configuration reference](configuration.md) for the full resolution order and
 overridable fields.
 
-## Run plugins locally
+## Run plugins locally {#run-plugins-locally}
 
 Use the `plugin run` command to execute a bundled plugin against a running `glyphd`
 instance. The example below runs the `emit-on-start` sample for three seconds against
@@ -48,7 +48,7 @@ glyphctl plugin run \
 Add `--sample` to target the fixture binaries under `plugins/samples/`, or provide a
 `--path` to an arbitrary plugin executable.
 
-## Validate findings
+## Validate findings {#validate-findings}
 
 Glyph emits findings as JSON Lines (JSONL) records that conform to
 [`specs/finding.md`]({{ config.repo_url }}/blob/main/specs/finding.md). Lint generated output before shipping it
@@ -60,7 +60,7 @@ glyphctl findings validate --input out/findings.jsonl
 
 The validator reports schema violations and highlights the offending record numbers.
 
-## Generate reports
+## Generate reports {#generate-reports}
 
 Turn validated findings into Markdown or HTML reports for analysts:
 

--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -3,7 +3,7 @@
 This guide helps contributors set up a development environment, iterate on new
 features, and ship releases with confidence.
 
-## Prerequisites
+## Prerequisites {#prerequisites}
 
 Glyph is written in Go with supporting tooling in Node.js and Python. Install the
 following before hacking on the repository:
@@ -16,7 +16,7 @@ following before hacking on the repository:
 Clone the repository and run `make deps` to download Go modules and Playwright
 browsers used by the integration tests.
 
-## Build and test
+## Build and test {#build-and-test}
 
 The [`Makefile`]({{ config.repo_url }}/blob/main/Makefile) contains convenience targets for the most common
 developer workflows:
@@ -36,7 +36,7 @@ You can also build the CLI manually with `go build ./cmd/glyphctl`. Tests that r
 Playwright or other external services automatically skip themselves when the
 prerequisites are missing, keeping `make test` fast on constrained environments.
 
-## Plugin development loop
+## Plugin development loop {#plugin-development-loop}
 
 Use `make new-plugin name=<id>` to scaffold a new plugin under `plugins/<id>/`. The
 scaffolding includes a manifest, Go stubs, and a sample test harness wired to the
@@ -54,7 +54,7 @@ glyphctl plugin run --path ./plugins/<id>/<id> --duration 30s
 The CLI connects to `glyphd`, streams findings back to `out/findings.jsonl`, and lets
 you debug the plugin in real time.
 
-## Release checklist
+## Release checklist {#release-checklist}
 
 1. Update [`CHANGELOG.md`]({{ config.repo_url }}/blob/main/CHANGELOG.md) with user-facing notes.
 2. Run `make test` and `glyphctl demo` to ensure critical paths pass.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,6 @@ Use the navigation sidebar to explore:
 - **Security** – review Glyph's threat model, provenance guarantees, and vulnerability
   reporting process.
 
-If you are just getting started, the [Quickstart](quickstart.md) walkthrough is the best
+If you are just getting started, the [Quickstart](quickstart.md#getting-started) walkthrough is the best
 place to see the platform in action before diving deeper into configuration or plugin
 development.

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -5,7 +5,7 @@ provided in [`sdk/plugin-sdk`]({{ config.repo_url }}/tree/main/sdk/plugin-sdk). 
 lifecycle hooks exposed by the runtime, the capabilities that can be requested in a
 manifest, and the rules for emitting JSONL findings safely.
 
-## Plugin Roster
+## Plugin Roster {#plugin-roster}
 
 The following plugins form the foundation of the Glyph platform. Each directory
 under `plugins/` contains a manifest, implementation, documentation, and test
@@ -25,7 +25,7 @@ fixtures to accelerate future development.
 | `cryptographer` | CyberChef-inspired utility UI for transforming payloads during investigations. |
 | `example-hello` | Minimal starter plugin that emits a greeting finding during startup. |
 
-## Getting started
+## Getting started {#getting-started}
 
 1. Scaffold a new plugin with `glyph-plugin init`. The CLI generates Node and
    Go projects that already depend on the broker helpers, capability macros, and
@@ -42,21 +42,21 @@ fixtures to accelerate future development.
    in-memory broker exposed by [`sdk/plugin-sdk`]({{ config.repo_url }}/tree/main/sdk/plugin-sdk)
    so findings can be asserted without a full Glyph deployment.
 
-## Lifecycle hooks
+## Lifecycle hooks {#lifecycle-hooks}
 
 Plugins implement behaviour by registering callbacks in `pluginsdk.Hooks` before
 calling `pluginsdk.Run` or `pluginsdk.Serve`. The SDK manages the connection to
 `glyphd`, performs capability enforcement, and invokes hooks on the same goroutine
 that receives events.
 
-### `OnStart(*pluginsdk.Context) error`
+### `OnStart(*pluginsdk.Context) error` {#onstart}
 
 Invoked once after the plugin authenticates with `glyphd`. Use the hook for
 lightweight initialisation, emitting startup findings, and launching background
 goroutines scoped to the supplied context. Returning an error terminates the
 plugin immediately.
 
-### `OnHTTPPassive(*pluginsdk.Context, pluginsdk.HTTPPassiveEvent) error`
+### `OnHTTPPassive(*pluginsdk.Context, pluginsdk.HTTPPassiveEvent) error` {#onhttppassive}
 
 Triggered for every passive HTTP response streamed to the plugin when
 `CAP_HTTP_PASSIVE` is granted. The hook is ideal for analytics that react to
@@ -67,7 +67,7 @@ The SDK automatically wires graceful shutdown through `pluginsdk.Run`, cancellin
 the context when the process receives `SIGINT` or `SIGTERM`. Long-running work
 should honour `ctx.Context().Done()` to exit promptly.
 
-## Capabilities
+## Capabilities {#capabilities}
 
 Capabilities gate access to host features. Declare them in `manifest.json` under
 `capabilities`, and ensure the same set is configured in `pluginsdk.Config` so the
@@ -89,7 +89,7 @@ missing or the plugin requests undeclared privileges.
 Only request capabilities the plugin actively needs. The manifest validator under
 `hack/validate_manifests.sh` enforces the whitelist above.
 
-## Emitting findings
+## Emitting findings {#emitting-findings}
 
 Findings are serialised to `findings.jsonl` using the schema defined in
 `plugins/findings.schema.json`. The SDK handles common safety checks when calling
@@ -109,7 +109,7 @@ schema described in [`specs/finding.md`]({{ config.repo_url }}/blob/main/specs/f
 `go run ./cmd/glyphctl findings validate --input <path>` to verify JSONL output
 before distribution.
 
-## Performance and safety guidelines
+## Performance and safety guidelines {#performance-and-safety-guidelines}
 
 - **Respect backpressure**: Hooks run on the gRPC receive loop. Avoid blocking
   operations inside handlers. Offload expensive work to goroutines and use the

--- a/docs/plugins/safe-starter-go.md
+++ b/docs/plugins/safe-starter-go.md
@@ -5,7 +5,7 @@ safe defaults: capability macros, broker clients, and CI-friendly tooling. This
 page walks through the generated layout and shows how to adapt it for your own
 integrations.
 
-## Generate a project
+## Generate a project {#generate-a-project}
 
 ```bash
 go run ./cmd/glyph-plugin init \
@@ -29,7 +29,7 @@ You can inspect the repository copy under
 [`examples/plugin-safe-go/`]({{ config.repo_url }}/tree/main/examples/plugin-safe-go) for a ready-made
 reference implementation.
 
-## Capability macros
+## Capability macros {#capability-macros}
 
 `internal/plugin/capabilities.go` centralises the manifest declaration:
 
@@ -50,7 +50,7 @@ Toggling a macro updates `pluginsdk.Config.Capabilities`, the generated
 filesystem, network, and secret access on the macros so the linter can verify
 that capabilities are either declared or safely ignored.
 
-## Tests and linting
+## Tests and linting {#tests-and-linting}
 
 Run the scaffolded targets from the plugin directory:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ It spins up a local demo target, scans the page with Seer, ranks the resulting
 findings, and renders a polished HTML report. Everything runs on localhost and
 falls back to bundled fixtures when external network access is restricted.
 
-## Prerequisites
+## Prerequisites {#prerequisites}
 
 * Go 1.21+ (for `go run ./cmd/glyphctl demo`) or a downloaded `glyphctl` binary
 * Git (to clone this repository)
@@ -15,7 +15,8 @@ external services are required—if Glyph cannot reach `example.com` the demo
 feeds Seer a synthetic response that mirrors the HTML shipped in
 `examples/quickstart/demo-response.html`.
 
-## Run the pipeline
+<div id="run-the-pipeline"></div>
+## Getting started {#getting-started}
 
 ```bash
 glyphctl demo
@@ -39,7 +40,7 @@ snippets. The JSONL artifacts under `out/demo/` and the reference copies in
 [`examples/quickstart/`]({{ config.repo_url }}/tree/main/examples/quickstart)
 are handy when writing tests or inspecting the data Seer emits.
 
-## Inspecting the run
+## Inspecting the run {#inspecting-the-run}
 
 Useful files after the demo completes:
 
@@ -54,7 +55,7 @@ The [`examples/quickstart/` directory]({{ config.repo_url }}/tree/main/examples/
 mirrors the expected outputs so you can diff future runs or plug sample data into
 other tools without re-running the pipeline.
 
-## Cleaning up
+## Cleaning up {#cleaning-up}
 
 Remove the generated artifacts with:
 

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -4,14 +4,14 @@ Glyph's security model balances powerful automation with strict guardrails that 
 operators in control. This section consolidates resources for security reviewers and
 incident responders.
 
-## Vulnerability reporting
+## Vulnerability reporting {#vulnerability-reporting}
 
 Please follow the process documented in [SECURITY.md]({{ config.repo_url }}/blob/main/SECURITY.md) when reporting
 vulnerabilities. The security team monitors the disclosed channels and coordinates
 fixes as quickly as possible. Include reproduction steps, impacted versions, and any
 supporting artifacts.
 
-## Threat model and provenance
+## Threat model and provenance {#threat-model-and-provenance}
 
 The [threat model](threat-model.md) explains how Glyph isolates untrusted plugins,
 limits network access, and captures audit trails for every run. Combine it with the
@@ -19,7 +19,7 @@ limits network access, and captures audit trails for every run. Combine it with 
 guides to verify that downloaded binaries and containers were produced by the
 official CI pipelines and signed by trusted automation.
 
-## Hardening checklist
+## Hardening checklist {#hardening-checklist}
 
 - Disable the proxy (`proxy.enable: false`) unless you need active interception.
 - Grant plugins only the capabilities listed in their manifests.

--- a/docs/security/provenance.md
+++ b/docs/security/provenance.md
@@ -13,7 +13,7 @@ signer/builder principle: when you trust the GitHub Actions workflow that the
 project maintains, you can validate that a release artifact originated from
 that workflow and was not tampered with after it was built.
 
-## Release binaries
+## Release binaries {#release-binaries}
 
 Every release attaches a provenance file alongside the tarballs and checksum
 files (for example, `glyph-v1.2.3-binaries.intoto.jsonl`). To verify a release:
@@ -38,7 +38,7 @@ files (for example, `glyph-v1.2.3-binaries.intoto.jsonl`). To verify a release:
    verification proves the archive was produced by the tagged commit through
    Glyph's release workflow.
 
-## Container image
+## Container image {#container-image}
 
 The container image published to `ghcr.io/rowandark/glyphctl` also carries a SLSA
 provenance statement. After pulling the image digest you wish to verify, run:

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -4,7 +4,7 @@ Glyph's CI pipelines enforce dependency hygiene, generate a software bill of
 materials (SBOM), and sign every published artifact. This page documents the
 controls and the steps operators can take to validate them independently.
 
-## Dependency policy
+## Dependency policy {#dependency-policy}
 
 - The `Dependency Review` GitHub Action blocks pull requests that introduce new
   transitive risks with a severity of **high** or **critical**.
@@ -18,7 +18,7 @@ If you maintain a plugin, run `npm audit --omit=dev --audit-level=high` locally
 before submitting patches. CI fails if the audit reports a high or critical
 vulnerability.
 
-## SBOM generation
+## SBOM generation {#sbom-generation}
 
 Syft generates SPDX SBOMs for both the repository and the plugin tree on every
 push and pull request. The artifacts are uploaded as `glyph-sboms` and contain:
@@ -29,7 +29,7 @@ push and pull request. The artifacts are uploaded as `glyph-sboms` and contain:
 Download the SBOMs from the workflow run summary to integrate with your own
 inventory or vulnerability scanners.
 
-## Release signing & provenance
+## Release signing & provenance {#release-signing-and-provenance}
 
 Tagged releases trigger the `Release` workflow, which now performs the
 following:
@@ -71,7 +71,7 @@ slsa-verifier verify-artifact \
 Successful verification proves the archive was produced by the trusted release
 workflow and signed with Sigstore.
 
-## Plugin signature verification
+## Plugin signature verification {#plugin-signature-verification}
 
 The `glyphctl plugin run` command now validates detached signatures before a
 plugin is compiled or executed. Each official plugin ships with:
@@ -94,7 +94,7 @@ You can rotate the signing key by updating the public key, regenerating the
 signatures, and adjusting the manifests. Glyph refuses to run a plugin when the
 signature is missing or invalid.
 
-## Trust chain summary
+## Trust chain summary {#trust-chain-summary}
 
 1. Dependency diffs and `npm audit` prevent risky packages from entering the
    tree.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -4,7 +4,7 @@ Glyph runs untrusted analysis plugins while aggregating findings into signed,
 reproducible reports. This document captures the security goals, assumptions, and
 controls that underpin the default deployment model.
 
-## Goals and assumptions
+## Goals and assumptions {#goals-and-assumptions}
 
 - Keep the Glyph daemon (`glyphd`) and control surface (`glyphctl`) resilient to
   compromised plugins.
@@ -14,7 +14,7 @@ controls that underpin the default deployment model.
 - Assume attackers can supply arbitrary plugin binaries and task inputs but do not
   control the host operating system.
 
-## Plugin isolation and resource limits
+## Plugin isolation and resource limits {#plugin-isolation-and-resource-limits}
 
 Plugins execute in dedicated subprocesses with strict resource limits. Each run is
 assigned a temporary working directory and constrained environment variables so writes
@@ -28,7 +28,7 @@ The supervisor captures termination reasons and emits structured metadata such a
 task ID, CPU/heap usage, and configured timeouts. Operations teams can trace why a
 plugin stopped and correlate the event with downstream automation.
 
-## Network posture
+## Network posture {#network-posture}
 
 Glyph starts in a "no network" posture. The built-in configuration keeps
 `proxy.enable` set to `false`, leaving Glyph without outbound network access unless
@@ -40,7 +40,7 @@ Capabilities declared in a plugin's manifest (for example `CAP_HTTP_ACTIVE` or
 `CAP_WS`) gate access to outbound helpers exposed by the host. A plugin without the
 relevant capability cannot reach the network layer at all.
 
-## Finding provenance
+## Finding provenance {#finding-provenance}
 
 Every release artifact ships with SLSA v3 provenance that can be verified using
 `slsa-verifier`, as described in [Build Provenance](provenance.md). Glyph's supervisors
@@ -49,7 +49,7 @@ configuration fingerprints, and hashes of harvested evidence. This metadata allo
 downstream systems to prove which signed binary generated a finding and to trace it
 back to the exact task invocation.
 
-## Reproducing reports from artifacts
+## Reproducing reports from artifacts {#reproducing-reports-from-artifacts}
 
 The default workflow stores logs and JSONL transcripts for each run under the `out/`
 directory. To reproduce a report without executing untrusted plugins:


### PR DESCRIPTION
## Summary
- add explicit fragment identifiers to Quickstart, CLI, developer, plugin, and security docs so deep links stay stable
- link the homepage Quickstart reference directly to the new getting-started anchor and keep the legacy run-the-pipeline id for compatibility

## Testing
- mkdocs build --strict *(fails: mkdocs is unavailable in the sandbox and pip installs are blocked by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e103e74da4832abaa7de284348b194