### PR TITLE
Add optional HTTP/3 transport support

### DIFF
--- a/cmd/glyphd/main_test.go
+++ b/cmd/glyphd/main_test.go
@@ -33,7 +33,7 @@ func TestServeBootsAndShutsDown(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serve(ctx, lis, "test-token", coreLogger, busLogger, false, "")
+		errCh <- serve(ctx, lis, "test-token", coreLogger, busLogger, false, "", "auto")
 	}()
 
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/netgate/gate.go
+++ b/internal/netgate/gate.go
@@ -52,13 +52,17 @@ var (
 
 // TransportConfig controls the negotiated HTTP protocols available to clients.
 type TransportConfig struct {
-	EnableHTTP2 bool
-	EnableHTTP3 bool
+	EnableHTTP2  bool
+	EnableHTTP3  bool
+	RequireHTTP3 bool
 }
 
 var defaultTransportConfig = TransportConfig{EnableHTTP2: true, EnableHTTP3: true}
 
 func sanitizeTransportConfig(cfg TransportConfig) TransportConfig {
+	if cfg.RequireHTTP3 {
+		cfg.EnableHTTP3 = true
+	}
 	if !cfg.EnableHTTP2 && !cfg.EnableHTTP3 {
 		cfg.EnableHTTP2 = true
 	}

--- a/internal/netgate/gate_test.go
+++ b/internal/netgate/gate_test.go
@@ -462,6 +462,16 @@ func TestLayeredTransportShouldFallback(t *testing.T) {
 	}
 }
 
+func TestLayeredTransportRequireHTTP3DisablesFallback(t *testing.T) {
+	lt := &layeredTransport{requireHTTP3: true}
+	if lt.shouldFallback(errors.New("boom")) {
+		t.Fatal("fallback should be disabled when HTTP/3 is required")
+	}
+	if lt.shouldFallback(errHTTP3Unavailable) {
+		t.Fatal("requireHTTP3 should prevent fallback on availability errors")
+	}
+}
+
 func TestLayeredTransportRoundTripFallsBackToPrimary(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)

--- a/internal/netgate/transport_http3_quic.go
+++ b/internal/netgate/transport_http3_quic.go
@@ -1,0 +1,91 @@
+//go:build http3
+
+package netgate
+
+import (
+	"crypto/tls"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+
+	xhttp3 "golang.org/x/net/http3"
+)
+
+func (lt *layeredTransport) roundTripHTTP3(req *http.Request, addr string, cfg *tls.Config) (*http.Response, error) {
+	if req == nil {
+		return nil, errors.New("http3: request is nil")
+	}
+	_ = addr
+	tlsCfg := cfg
+	if tlsCfg != nil {
+		tlsCfg = tlsCfg.Clone()
+	} else {
+		tlsCfg = &tls.Config{}
+	}
+	ctx := req.Context()
+	cancel := func() {}
+	if lt.gate != nil {
+		var cancelFn func()
+		ctx, cancelFn = lt.gate.withTimeout(ctx)
+		cancel = cancelFn
+	}
+	defer cancel()
+
+	h3Req := req.WithContext(ctx)
+	rt := &xhttp3.RoundTripper{
+		TLSClientConfig: tlsCfg,
+	}
+	if lt.primary != nil {
+		rt.DisableCompression = lt.primary.DisableCompression
+	}
+
+	resp, err := rt.RoundTrip(h3Req)
+	if err != nil {
+		_ = rt.Close()
+		return nil, err
+	}
+	resp.Body = &http3Body{ReadCloser: resp.Body, closer: &onceCloser{fn: rt.Close}}
+	return resp, nil
+}
+
+type http3Body struct {
+	io.ReadCloser
+	closer io.Closer
+}
+
+func (b *http3Body) Close() error {
+	if b == nil {
+		return nil
+	}
+	var err error
+	if b.ReadCloser != nil {
+		err = b.ReadCloser.Close()
+	}
+	if b.closer != nil {
+		if cerr := b.closer.Close(); cerr != nil {
+			if err != nil {
+				err = errors.Join(err, cerr)
+			} else {
+				err = cerr
+			}
+		}
+	}
+	return err
+}
+
+type onceCloser struct {
+	once sync.Once
+	fn   func() error
+	err  error
+}
+
+func (c *onceCloser) Close() error {
+	if c == nil || c.fn == nil {
+		return nil
+	}
+	c.once.Do(func() {
+		c.err = c.fn()
+	})
+	return c.err
+}


### PR DESCRIPTION
## Summary
- add a `--http3` flag to glyphd for toggling HTTP/3 negotiation modes
- allow the gate transport to require HTTP/3 and disable fallback when requested
- implement a build-tagged HTTP/3 round tripper using golang.org/x/net/http3

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2a74d0924832a8d5a95dc78f8c6c3