### PR TITLE
Harden container image and runtime guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,38 @@ jobs:
         with:
           version: v2.1.6
           args: --out-format=github-actions ./...
+
+  container-scan:
+    name: Container security scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: glyphctl:ci
+
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.22.0
+        with:
+          image-ref: glyphctl:ci
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Grype vulnerability scan
+        uses: anchore/grype-action@v0.9.1
+        with:
+          image: glyphctl:ci
+          fail-build: true
+          severity-cutoff: high

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ WORKDIR /src
 
 RUN apk add --no-cache git ca-certificates
 
+# Pre-create the directories that are bind mounted in the runtime image so they can
+# be copied with the desired ownership/permissions without running commands in the
+# distroless stage.
+RUN install -d -m 0755 /out \
+    && install -d -m 0700 /home/nonroot \
+    && install -d -m 0700 /home/nonroot/.glyph \
+    && install -d -m 0700 /home/nonroot/.cache
+
 COPY go.mod go.sum ./
 RUN go mod download
 
@@ -20,10 +28,18 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
 
 FROM gcr.io/distroless/static-debian12:nonroot
 
+ENV HOME=/home/nonroot \
+    XDG_CONFIG_HOME=/home/nonroot/.glyph \
+    XDG_CACHE_HOME=/home/nonroot/.cache
+
 WORKDIR /home/nonroot
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder --chown=nonroot:nonroot --chmod=0555 /out/glyphctl /usr/local/bin/glyphctl
+COPY --from=builder --chown=nonroot:nonroot --chmod=0700 /home/nonroot/.glyph /home/nonroot/.glyph
+COPY --from=builder --chown=nonroot:nonroot --chmod=0700 /home/nonroot/.cache /home/nonroot/.cache
+
+VOLUME ["/home/nonroot/.glyph", "/home/nonroot/.cache", "/out"]
 
 USER nonroot:nonroot
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,29 @@ scoop install glyphctl
 ### Container image
 
 A hardened container image is pushed to GitHub Container Registry with every
-release. Pull and run it with:
+release. The image runs as an unprivileged user and expects a read-only root
+filesystem. Pull it and run `glyphctl` with the recommended least-privilege
+profile:
 
 ```bash
 docker pull ghcr.io/rowandark/glyphctl:latest
-docker run --rm ghcr.io/rowandark/glyphctl:latest --version
+docker run \
+  --rm \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  --pids-limit=256 \
+  --memory=512m \
+  --cpus="1.0" \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+  --tmpfs /home/nonroot/.cache:rw,noexec,nosuid,nodev,size=64m \
+  --mount type=volume,source=glyph-data,dst=/home/nonroot/.glyph \
+  --mount type=volume,source=glyph-output,dst=/out \
+  ghcr.io/rowandark/glyphctl:latest --version
 ```
+
+See the [container hardening guide](docs/security/container.md) for additional
+context, CI integration notes, and plugin execution tips.
 
 ## Quickstart
 

--- a/docs/security/container.md
+++ b/docs/security/container.md
@@ -1,0 +1,69 @@
+# Container Hardening
+
+Glyph publishes a container image intended for CI pipelines and tightly scoped
+runtime environments. The image is built on the distroless `static-debian12`
+flavour, runs as an unprivileged user, and exposes no package manager or shell.
+This document captures the default hardening and recommended runtime profile.
+
+## Image build
+
+* Multi-stage build with a minimal Alpine toolchain stage and a distroless
+  runtime image.
+* `glyphctl` binary compiled with CGO disabled and Go build trimming enabled.
+* `nonroot` user enforced as the entrypoint user; no `root` binaries are
+  present.
+* `/home/nonroot/.glyph`, `/home/nonroot/.cache`, and `/out` are declared as
+  volumes to allow a read-only root filesystem.
+* Release pipelines sign the image with Cosign and scan for vulnerabilities
+  using both Trivy and Grype.
+
+## Recommended runtime profile
+
+Run the container with a read-only root filesystem, no extra capabilities, and
+explicit resource limits. A typical invocation looks like:
+
+```bash
+docker run \
+  --rm \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  --pids-limit=256 \
+  --memory=512m \
+  --cpus="1.0" \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+  --tmpfs /home/nonroot/.cache:rw,noexec,nosuid,nodev,size=64m \
+  --mount type=volume,source=glyph-data,dst=/home/nonroot/.glyph \
+  --mount type=volume,source=glyph-output,dst=/out \
+  ghcr.io/rowandark/glyphctl:latest --help
+```
+
+### CI usage
+
+For CI jobs, bind the repository into the container and keep the filesystem
+read-only:
+
+```bash
+docker run \
+  --rm \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
+  --tmpfs /home/nonroot/.cache:rw,noexec,nosuid,nodev,size=64m \
+  --mount type=bind,src="$PWD",dst=/workspace,ro \
+  --workdir /workspace \
+  ghcr.io/rowandark/glyphctl:latest demo
+```
+
+Mount any plugin directories that need to be executed into `/plugins` with a
+read-only bind mount. Plugin execution continues to take place inside the
+sandbox provided by `glyphctl` and does not require elevated container
+privileges.
+
+## Vulnerability scanning
+
+Pull request builds invoke both Trivy and Grype against the locally built image.
+Release builds repeat the scans against the multi-architecture manifest before
+publishing to GitHub Container Registry. Scans fail the pipeline on high or
+critical severities, ensuring new dependencies do not introduce regressions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Threat Model: security/threat-model.md
       - Build Provenance: security/provenance.md
       - Supply Chain: security/supply-chain.md
+      - Container Hardening: security/container.md
 
 theme:
   name: material


### PR DESCRIPTION
## Summary
- pre-create runtime directories in the Docker image, set non-root defaults, and declare writable volumes for read-only deployments
- document hardened container usage in README and dedicated security guide with resource-limited `docker run` examples
- extend CI to build the image and run Trivy/Grype scans for pull requests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2b241d438832ab731ec024a4e74d2