### PR TITLE
Add performance benchmarks and regression guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,29 @@ jobs:
           version: v2.1.6
           args: --out-format=github-actions ./...
 
+  perf-bench:
+    name: Performance benchmarks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run synthetic workloads
+        run: go run ./cmd/perfbench --baseline perf/baseline/findings_bus_v1.0.json --output perf/results/latest.json --threshold 0.10
+
+      - name: Upload metrics report
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-metrics
+          path: perf/results/latest.json
+          if-no-files-found: error
+
   container-scan:
     name: Container security scan
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ __pycache__/
 /out/
 plugins/excavator/benchmarks/latest.json
 plugins/excavator/benchmarks/summary.md
+perf/results/
 
 # IDE files
 .idea/

--- a/cmd/perfbench/main.go
+++ b/cmd/perfbench/main.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/perf"
+)
+
+func main() {
+	var (
+		baselinePath  string
+		outputPath    string
+		threshold     float64
+		iterations    int
+		reportVersion string
+	)
+
+	flag.StringVar(&baselinePath, "baseline", "", "optional baseline report for regression detection")
+	flag.StringVar(&outputPath, "output", "", "where to write the current metrics report (JSON)")
+	flag.Float64Var(&threshold, "threshold", 0.10, "maximum allowed regression expressed as a ratio (0.10 = 10%)")
+	flag.IntVar(&iterations, "iterations", 1, "number of times to run each workload and average the results")
+	flag.StringVar(&reportVersion, "report-version", runtime.Version(), "version label embedded in the metrics report")
+	flag.Parse()
+
+	if threshold <= 0 || threshold >= 1 {
+		log.Fatalf("threshold must be between 0 and 1 (got %.3f)", threshold)
+	}
+	if iterations <= 0 {
+		log.Fatalf("iterations must be positive (got %d)", iterations)
+	}
+
+	ctx := context.Background()
+	results := make([]perf.BusWorkloadMetrics, 0, len(perf.DefaultBusWorkloads))
+
+	for _, cfg := range perf.DefaultBusWorkloads {
+		samples := make([]perf.BusWorkloadMetrics, 0, iterations)
+		for i := 0; i < iterations; i++ {
+			res, err := perf.RunBusWorkload(ctx, cfg)
+			if err != nil {
+				log.Fatalf("workload %s run %d: %v", cfg.Name, i+1, err)
+			}
+			samples = append(samples, res)
+		}
+		results = append(results, averageMetrics(samples))
+	}
+
+	report := perf.Report{
+		Version:   reportVersion,
+		Timestamp: time.Now().UTC(),
+		GitRef:    gitRef(),
+		Workloads: results,
+	}
+
+	if outputPath != "" {
+		if err := perf.SaveReport(outputPath, report); err != nil {
+			log.Fatalf("save report: %v", err)
+		}
+		fmt.Fprintf(os.Stdout, "Saved metrics report to %s\n", outputPath)
+	}
+
+	if baselinePath != "" {
+		baseline, err := perf.LoadReport(baselinePath)
+		if err != nil {
+			log.Fatalf("load baseline: %v", err)
+		}
+		diff := perf.CompareReports(baseline, report, threshold)
+		fmt.Print(diff.RenderText())
+		if diff.HasRegressions() {
+			log.Fatalf("performance regressions detected (threshold %.1f%%)", threshold*100)
+		}
+	} else {
+		printSummary(report)
+	}
+}
+
+func averageMetrics(samples []perf.BusWorkloadMetrics) perf.BusWorkloadMetrics {
+	if len(samples) == 0 {
+		return perf.BusWorkloadMetrics{}
+	}
+	out := samples[0]
+	var durationSum time.Duration
+	var throughputSum float64
+	var errorRateSum float64
+	var p50Sum float64
+	var p95Sum float64
+	var p99Sum float64
+	maxLatency := samples[0].Latency.Max
+	var bytesTotalSum float64
+	var bytesPerEventSum float64
+	peakG := samples[0].Memory.PeakGoroutines
+	baselineG := samples[0].Memory.BaselineGoroutines
+	successes := 0
+	errors := 0
+
+	for _, sample := range samples {
+		durationSum += sample.Duration
+		throughputSum += sample.Throughput
+		errorRateSum += sample.ErrorRate
+		p50Sum += sample.Latency.P50
+		p95Sum += sample.Latency.P95
+		p99Sum += sample.Latency.P99
+		if sample.Latency.Max > maxLatency {
+			maxLatency = sample.Latency.Max
+		}
+		bytesTotalSum += float64(sample.Memory.BytesTotal)
+		bytesPerEventSum += sample.Memory.BytesPerEvent
+		if sample.Memory.PeakGoroutines > peakG {
+			peakG = sample.Memory.PeakGoroutines
+		}
+		successes += sample.Successes
+		errors += sample.Errors
+	}
+
+	count := float64(len(samples))
+	out.Duration = time.Duration(float64(durationSum) / count)
+	out.Throughput = throughputSum / count
+	out.ErrorRate = errorRateSum / count
+	out.Successes = int(math.Round(float64(successes) / count))
+	out.Errors = int(math.Round(float64(errors) / count))
+	out.Latency = perf.LatencyMetrics{
+		P50: p50Sum / count,
+		P95: p95Sum / count,
+		P99: p99Sum / count,
+		Max: maxLatency,
+	}
+	out.Memory = perf.MemoryMetrics{
+		BytesTotal:         uint64(bytesTotalSum / count),
+		BytesPerEvent:      bytesPerEventSum / count,
+		PeakGoroutines:     peakG,
+		BaselineGoroutines: baselineG,
+	}
+	return out
+}
+
+func gitRef() string {
+	cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func printSummary(report perf.Report) {
+	fmt.Println("Synthetic workload metrics:")
+	writer := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintf(writer, "Workload\tThroughput (eps)\tP95 Latency (ms)\tBytes/Event\tErrors\n")
+	for _, wl := range report.Workloads {
+		fmt.Fprintf(writer, "%s\t%.0f\t%.2f\t%.0f\t%d\n",
+			wl.Name,
+			wl.Throughput,
+			wl.Latency.P95,
+			wl.Memory.BytesPerEvent,
+			wl.Errors,
+		)
+	}
+	_ = writer.Flush()
+}

--- a/docs/dev/performance.md
+++ b/docs/dev/performance.md
@@ -1,0 +1,42 @@
+# Performance Benchmarks
+
+Glyph now ships with a dedicated microbenchmark harness that exercises the
+findings bus using synthetic fan-out workloads. The goal is to maintain a stable
+baseline for throughput, latency, memory usage, and error rate so that
+regressions are surfaced before they reach `main`.
+
+## Running the benchmarks locally
+
+```bash
+go run ./cmd/perfbench --baseline perf/baseline/findings_bus_v1.0.json --threshold 0.10
+```
+
+The command executes the default workloads defined in
+`internal/perf/workloads.go`, prints a human-readable diff, and exits non-zero
+if any metric regresses by more than the configured threshold (10% by default).
+
+To regenerate metrics without failing the build you can omit the baseline and
+capture a fresh report:
+
+```bash
+go run ./cmd/perfbench --output perf/results/latest.json
+```
+
+## Updating the baseline
+
+If a legitimate change improves performance you can regenerate the baseline and
+commit the updated JSON:
+
+```bash
+go run ./cmd/perfbench --output perf/baseline/findings_bus_v1.0.json --report-version v1.1.0
+```
+
+Always include the diff from `--baseline` in your pull request description so
+reviewers can assess the impact.
+
+## Continuous Integration
+
+The CI workflow (`ci.yml`) now includes a `Performance benchmarks` job that runs
+`perfbench` on every push and pull request. The job uploads the metrics report
+as an artifact (`perf-metrics`) so teams can inspect the raw numbers alongside
+the console diff.

--- a/internal/perf/bus_workload.go
+++ b/internal/perf/bus_workload.go
@@ -1,0 +1,373 @@
+package perf
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"math/rand"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+// BusWorkloadConfig configures the synthetic pipeline exercised when benchmarking
+// the findings bus.
+type BusWorkloadConfig struct {
+	Name         string  `json:"name"`
+	FanOut       int     `json:"fan_out"`
+	Depth        int     `json:"depth"`
+	Concurrency  int     `json:"concurrency"`
+	Events       int     `json:"events"`
+	PayloadBytes int     `json:"payload_bytes"`
+	FailureRate  float64 `json:"failure_rate"`
+	Seed         int64   `json:"seed"`
+}
+
+// Validate ensures the workload configuration is well formed.
+func (cfg BusWorkloadConfig) Validate() error {
+	if strings.TrimSpace(cfg.Name) == "" {
+		return errors.New("name is required")
+	}
+	if cfg.FanOut <= 0 {
+		return fmt.Errorf("fan_out must be positive (got %d)", cfg.FanOut)
+	}
+	if cfg.Depth < 0 {
+		return fmt.Errorf("depth cannot be negative (got %d)", cfg.Depth)
+	}
+	if cfg.Concurrency <= 0 {
+		return fmt.Errorf("concurrency must be positive (got %d)", cfg.Concurrency)
+	}
+	if cfg.Events <= 0 {
+		return fmt.Errorf("events must be positive (got %d)", cfg.Events)
+	}
+	if cfg.PayloadBytes < 0 {
+		return fmt.Errorf("payload_bytes cannot be negative (got %d)", cfg.PayloadBytes)
+	}
+	if cfg.FailureRate < 0 || cfg.FailureRate >= 1 {
+		return fmt.Errorf("failure_rate must be in [0,1) (got %f)", cfg.FailureRate)
+	}
+	return nil
+}
+
+// BusWorkloadMetrics captures the aggregated statistics observed for a
+// BusWorkloadConfig execution.
+type BusWorkloadMetrics struct {
+	Name       string            `json:"name"`
+	Config     BusWorkloadConfig `json:"config"`
+	Duration   time.Duration     `json:"duration"`
+	Successes  int               `json:"successes"`
+	Errors     int               `json:"errors"`
+	Throughput float64           `json:"throughput_eps"`
+	ErrorRate  float64           `json:"error_rate"`
+	Latency    LatencyMetrics    `json:"latency"`
+	Memory     MemoryMetrics     `json:"memory"`
+}
+
+// LatencyMetrics exposes percentile data in milliseconds.
+type LatencyMetrics struct {
+	P50 float64 `json:"p50_ms"`
+	P95 float64 `json:"p95_ms"`
+	P99 float64 `json:"p99_ms"`
+	Max float64 `json:"max_ms"`
+}
+
+// MemoryMetrics captures allocation statistics for the workload.
+type MemoryMetrics struct {
+	BytesTotal         uint64  `json:"bytes_total"`
+	BytesPerEvent      float64 `json:"bytes_per_event"`
+	PeakGoroutines     int     `json:"peak_goroutines"`
+	BaselineGoroutines int     `json:"baseline_goroutines"`
+}
+
+var workAccumulator atomic.Uint64
+
+type eventResult struct {
+	latency time.Duration
+	err     error
+}
+
+// RunBusWorkload executes the configured synthetic workload and returns the
+// aggregated metrics.
+func RunBusWorkload(ctx context.Context, cfg BusWorkloadConfig) (BusWorkloadMetrics, error) {
+	if err := cfg.Validate(); err != nil {
+		return BusWorkloadMetrics{}, err
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	totalEvents := cfg.Events
+	rootBus := findings.NewBus()
+
+	type stage struct {
+		bus    *findings.Bus
+		wg     *sync.WaitGroup
+		cancel []context.CancelFunc
+	}
+
+	stages := make([]*stage, 0, cfg.Depth+1)
+	stages = append(stages, &stage{bus: rootBus, wg: &sync.WaitGroup{}})
+
+	// Build intermediate processing stages to simulate fan-out/depth.
+	prevBus := rootBus
+	for level := 0; level < cfg.Depth; level++ {
+		nextBus := findings.NewBus()
+		st := &stage{bus: nextBus, wg: &sync.WaitGroup{}}
+		subCtx, subCancel := context.WithCancel(runCtx)
+		st.cancel = append(st.cancel, subCancel)
+		sub := prevBus.Subscribe(subCtx)
+		for worker := 0; worker < cfg.FanOut; worker++ {
+			st.wg.Add(1)
+			go runIntermediateStage(subCtx, st.wg, level, worker, cfg, sub, nextBus)
+		}
+		stages = append(stages, st)
+		prevBus = nextBus
+	}
+
+	// Final sink stage that records metrics.
+	results := make(chan eventResult, totalEvents)
+	finalWG := &sync.WaitGroup{}
+	var startTimes sync.Map
+	lastStage := stages[len(stages)-1]
+	subCtx, subCancel := context.WithCancel(runCtx)
+	lastStage.cancel = append(lastStage.cancel, subCancel)
+	sub := prevBus.Subscribe(subCtx)
+	for worker := 0; worker < cfg.FanOut; worker++ {
+		finalWG.Add(1)
+		go runFinalStage(subCtx, finalWG, cfg, worker, sub, results, &startTimes)
+	}
+
+	runtime.GC()
+	before := runtime.MemStats{}
+	runtime.ReadMemStats(&before)
+	baselineG := runtime.NumGoroutine()
+
+	emitWG := &sync.WaitGroup{}
+	emitWG.Add(cfg.Concurrency)
+
+	start := time.Now()
+	for worker := 0; worker < cfg.Concurrency; worker++ {
+		count := totalEvents / cfg.Concurrency
+		if worker == cfg.Concurrency-1 {
+			count += totalEvents % cfg.Concurrency
+		}
+		go func(workerID int, count int) {
+			defer emitWG.Done()
+			rng := rand.New(rand.NewSource(cfg.Seed + int64(workerID)*97))
+			payload := strings.Repeat("x", cfg.PayloadBytes)
+			baseFinding := findings.Finding{
+				Version:    findings.SchemaVersion,
+				Plugin:     "perfbench",
+				Type:       fmt.Sprintf("fanout_%d_depth_%d", cfg.FanOut, cfg.Depth),
+				Message:    fmt.Sprintf("synthetic payload %d", cfg.PayloadBytes),
+				Severity:   findings.SeverityLow,
+				DetectedAt: findings.NewTimestamp(time.Now()),
+			}
+			for i := 0; i < count; i++ {
+				id := findings.NewID()
+				f := baseFinding
+				f.ID = id
+				metadata := map[string]string{
+					"payload": payload,
+				}
+				if cfg.PayloadBytes > 0 {
+					metadata["nonce"] = fmt.Sprintf("%d", rng.Int63())
+				}
+				f.Metadata = metadata
+				startTimes.Store(id, time.Now())
+				rootBus.Emit(f)
+			}
+		}(worker, count)
+	}
+
+	go func() {
+		finalWG.Wait()
+		close(results)
+	}()
+
+	metrics := BusWorkloadMetrics{
+		Name:   cfg.Name,
+		Config: cfg,
+	}
+
+	latencies := make([]time.Duration, 0, totalEvents)
+	var maxLatency time.Duration
+	processed := 0
+	success := 0
+	errorsCount := 0
+	cancelOnce := sync.Once{}
+	peakG := baselineG
+
+	for res := range results {
+		processed++
+		if res.err != nil {
+			errorsCount++
+		} else {
+			success++
+			latencies = append(latencies, res.latency)
+			if res.latency > maxLatency {
+				maxLatency = res.latency
+			}
+		}
+		if g := runtime.NumGoroutine(); g > peakG {
+			peakG = g
+		}
+		if processed >= totalEvents {
+			cancelOnce.Do(cancel)
+		}
+	}
+
+	cancelOnce.Do(cancel)
+	emitWG.Wait()
+	finalWG.Wait()
+	for _, st := range stages {
+		st.wg.Wait()
+		for _, c := range st.cancel {
+			c()
+		}
+	}
+
+	duration := time.Since(start)
+	runtime.GC()
+	after := runtime.MemStats{}
+	runtime.ReadMemStats(&after)
+
+	metrics.Duration = duration
+	metrics.Successes = success
+	metrics.Errors = errorsCount
+	if duration > 0 {
+		metrics.Throughput = float64(success) / duration.Seconds()
+	}
+	if processed > 0 {
+		metrics.ErrorRate = float64(errorsCount) / float64(processed)
+	}
+	metrics.Latency = summariseLatencies(latencies, maxLatency)
+
+	allocBytes := after.TotalAlloc - before.TotalAlloc
+	metrics.Memory = MemoryMetrics{
+		BytesTotal:         allocBytes,
+		BytesPerEvent:      safeDivideFloat(float64(allocBytes), float64(processed)),
+		PeakGoroutines:     peakG,
+		BaselineGoroutines: baselineG,
+	}
+
+	return metrics, nil
+}
+
+func runIntermediateStage(ctx context.Context, wg *sync.WaitGroup, level int, workerID int, cfg BusWorkloadConfig, sub <-chan findings.Finding, next *findings.Bus) {
+	defer wg.Done()
+	payload := make([]byte, cfg.PayloadBytes)
+	for i := range payload {
+		payload[i] = byte((i + level + workerID) % 251)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case f, ok := <-sub:
+			if !ok {
+				return
+			}
+			simulateWork(level, workerID, payload, f.ID)
+			next.Emit(f)
+		}
+	}
+}
+
+func runFinalStage(ctx context.Context, wg *sync.WaitGroup, cfg BusWorkloadConfig, workerID int, sub <-chan findings.Finding, results chan<- eventResult, startTimes *sync.Map) {
+	defer wg.Done()
+	payload := make([]byte, cfg.PayloadBytes)
+	for i := range payload {
+		payload[i] = byte((i + workerID*3) % 251)
+	}
+	rng := rand.New(rand.NewSource(cfg.Seed + int64(workerID)*131 + 17))
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case f, ok := <-sub:
+			if !ok {
+				return
+			}
+			simulateWork(cfg.Depth, workerID, payload, f.ID)
+			startTime, ok := startTimes.LoadAndDelete(f.ID)
+			if !ok {
+				results <- eventResult{err: errors.New("missing start timestamp")}
+				continue
+			}
+			latency := time.Since(startTime.(time.Time))
+			if cfg.FailureRate > 0 && rng.Float64() < cfg.FailureRate {
+				results <- eventResult{latency: latency, err: errors.New("simulated failure")}
+				continue
+			}
+			results <- eventResult{latency: latency}
+		}
+	}
+}
+
+func simulateWork(level int, workerID int, payload []byte, id string) {
+	hasher := fnv.New64a()
+	_, _ = hasher.Write(payload)
+	_, _ = hasher.Write([]byte(id))
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(level+workerID))
+	_, _ = hasher.Write(buf[:])
+	workAccumulator.Add(hasher.Sum64())
+}
+
+func summariseLatencies(latencies []time.Duration, max time.Duration) LatencyMetrics {
+	if len(latencies) == 0 {
+		return LatencyMetrics{}
+	}
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	return LatencyMetrics{
+		P50: durationToMillis(percentile(latencies, 0.50)),
+		P95: durationToMillis(percentile(latencies, 0.95)),
+		P99: durationToMillis(percentile(latencies, 0.99)),
+		Max: durationToMillis(max),
+	}
+}
+
+func percentile(values []time.Duration, p float64) time.Duration {
+	if len(values) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return values[0]
+	}
+	if p >= 1 {
+		return values[len(values)-1]
+	}
+	rank := p * float64(len(values)-1)
+	lower := int(math.Floor(rank))
+	upper := int(math.Ceil(rank))
+	if lower == upper {
+		return values[lower]
+	}
+	weight := rank - float64(lower)
+	low := float64(values[lower])
+	high := float64(values[upper])
+	interpolated := low + (high-low)*weight
+	return time.Duration(interpolated)
+}
+
+func durationToMillis(d time.Duration) float64 {
+	if d <= 0 {
+		return 0
+	}
+	return float64(d) / float64(time.Millisecond)
+}
+
+func safeDivideFloat(num, denom float64) float64 {
+	if denom == 0 {
+		return 0
+	}
+	return num / denom
+}

--- a/internal/perf/report.go
+++ b/internal/perf/report.go
@@ -1,0 +1,202 @@
+package perf
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Report captures the outcome of one or more synthetic workloads.
+type Report struct {
+	Version   string               `json:"version"`
+	Timestamp time.Time            `json:"timestamp"`
+	GitRef    string               `json:"git_ref"`
+	Workloads []BusWorkloadMetrics `json:"workloads"`
+}
+
+// MetricDelta summarises the difference between the baseline and a fresh run for
+// a single metric.
+type MetricDelta struct {
+	Workload      string  `json:"workload"`
+	Metric        string  `json:"metric"`
+	Units         string  `json:"units"`
+	Baseline      float64 `json:"baseline"`
+	Current       float64 `json:"current"`
+	Change        float64 `json:"change"`
+	ChangePercent float64 `json:"change_percent"`
+	BetterWhen    string  `json:"better_when"`
+	Regression    bool    `json:"regression"`
+	Threshold     float64 `json:"threshold"`
+}
+
+// DiffResult contains the computed deltas for all workloads and indicates
+// whether regressions were observed.
+type DiffResult struct {
+	Threshold   float64       `json:"threshold"`
+	Deltas      []MetricDelta `json:"deltas"`
+	Regressions []MetricDelta `json:"regressions"`
+}
+
+// HasRegressions reports whether any metric breached the supplied threshold.
+func (d DiffResult) HasRegressions() bool {
+	return len(d.Regressions) > 0
+}
+
+// RenderText returns a human-readable summary suitable for CI logs.
+func (d DiffResult) RenderText() string {
+	if len(d.Deltas) == 0 {
+		return "No overlapping workloads found between baseline and current run.\n"
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Performance diff (threshold %.1f%%)\n", d.Threshold*100)
+	current := ""
+	for _, delta := range d.Deltas {
+		if delta.Workload != current {
+			current = delta.Workload
+			fmt.Fprintf(&sb, "%s:\n", current)
+		}
+		status := "OK"
+		if delta.Regression {
+			status = "REGRESSION"
+		}
+		fmt.Fprintf(&sb, "  • %s: %.2f %s → %.2f %s (%+.2f%%) [%s]\n",
+			delta.Metric,
+			delta.Baseline,
+			delta.Units,
+			delta.Current,
+			delta.Units,
+			delta.ChangePercent,
+			status,
+		)
+	}
+	return sb.String()
+}
+
+// CompareReports computes the metric deltas between the provided baseline and
+// current run using the supplied regression threshold.
+func CompareReports(baseline, current Report, threshold float64) DiffResult {
+	baseMap := make(map[string]BusWorkloadMetrics, len(baseline.Workloads))
+	for _, wl := range baseline.Workloads {
+		baseMap[wl.Name] = wl
+	}
+	deltas := make([]MetricDelta, 0, len(current.Workloads)*4)
+	for _, curr := range current.Workloads {
+		base, ok := baseMap[curr.Name]
+		if !ok {
+			// New workload – no baseline to compare against yet.
+			continue
+		}
+		deltas = append(deltas,
+			throughputDelta(curr.Name, base, curr, threshold),
+			latencyDelta(curr.Name, "latency_p95_ms", base.Latency.P95, curr.Latency.P95, threshold),
+			memoryDelta(curr.Name, base.Memory.BytesPerEvent, curr.Memory.BytesPerEvent, threshold),
+			errorRateDelta(curr.Name, base.ErrorRate, curr.ErrorRate, threshold),
+		)
+	}
+	sort.Slice(deltas, func(i, j int) bool {
+		if deltas[i].Workload == deltas[j].Workload {
+			return deltas[i].Metric < deltas[j].Metric
+		}
+		return deltas[i].Workload < deltas[j].Workload
+	})
+	regressions := make([]MetricDelta, 0)
+	for _, delta := range deltas {
+		if delta.Regression {
+			regressions = append(regressions, delta)
+		}
+	}
+	return DiffResult{
+		Threshold:   threshold,
+		Deltas:      deltas,
+		Regressions: regressions,
+	}
+}
+
+func throughputDelta(workload string, base, curr BusWorkloadMetrics, threshold float64) MetricDelta {
+	return makeDelta(workload, "throughput_eps", "events/s", "higher", base.Throughput, curr.Throughput, threshold)
+}
+
+func latencyDelta(workload, metric string, base, curr float64, threshold float64) MetricDelta {
+	return makeDelta(workload, metric, "ms", "lower", base, curr, threshold)
+}
+
+func memoryDelta(workload string, base, curr float64, threshold float64) MetricDelta {
+	return makeDelta(workload, "memory_bytes_per_event", "bytes/event", "lower", base, curr, threshold)
+}
+
+func errorRateDelta(workload string, base, curr float64, threshold float64) MetricDelta {
+	delta := MetricDelta{
+		Workload:      workload,
+		Metric:        "error_rate",
+		Units:         "fraction",
+		Baseline:      base,
+		Current:       curr,
+		BetterWhen:    "lower",
+		Threshold:     threshold,
+		Change:        curr - base,
+		ChangePercent: (curr - base) * 100,
+	}
+	epsilon := math.Max(0.001, base*threshold)
+	delta.Regression = curr > base+epsilon
+	return delta
+}
+
+func makeDelta(workload, metric, units, betterWhen string, base, curr, threshold float64) MetricDelta {
+	delta := MetricDelta{
+		Workload:   workload,
+		Metric:     metric,
+		Units:      units,
+		Baseline:   base,
+		Current:    curr,
+		BetterWhen: betterWhen,
+		Threshold:  threshold,
+		Change:     curr - base,
+	}
+	if base != 0 {
+		delta.ChangePercent = ((curr - base) / base) * 100
+	}
+	switch betterWhen {
+	case "higher":
+		if base > 0 {
+			delta.Regression = curr < base*(1-threshold)
+		}
+	case "lower":
+		if base > 0 {
+			delta.Regression = curr > base*(1+threshold)
+		} else {
+			// No baseline yet – treat any increase beyond the threshold as a regression.
+			delta.Regression = curr > threshold
+		}
+	}
+	return delta
+}
+
+// LoadReport reads a report from disk.
+func LoadReport(path string) (Report, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Report{}, err
+	}
+	var rep Report
+	if err := json.Unmarshal(data, &rep); err != nil {
+		return Report{}, fmt.Errorf("parse report %s: %w", path, err)
+	}
+	return rep, nil
+}
+
+// SaveReport persists the report to disk creating any missing directories.
+func SaveReport(path string, rep Report) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/perf/workloads.go
+++ b/internal/perf/workloads.go
@@ -1,0 +1,37 @@
+package perf
+
+// DefaultBusWorkloads enumerates the synthetic scenarios exercised by the
+// perfbench command. They are designed to stress different shapes of the
+// findings bus: wide fan-out, deep pipelines, and high concurrency emitters.
+var DefaultBusWorkloads = []BusWorkloadConfig{
+	{
+		Name:         "fanout_wide",
+		FanOut:       16,
+		Depth:        1,
+		Concurrency:  4,
+		Events:       6000,
+		PayloadBytes: 256,
+		FailureRate:  0,
+		Seed:         42,
+	},
+	{
+		Name:         "fanout_deep",
+		FanOut:       6,
+		Depth:        3,
+		Concurrency:  8,
+		Events:       8000,
+		PayloadBytes: 384,
+		FailureRate:  0,
+		Seed:         84,
+	},
+	{
+		Name:         "high_concurrency",
+		FanOut:       8,
+		Depth:        2,
+		Concurrency:  16,
+		Events:       10000,
+		PayloadBytes: 192,
+		FailureRate:  0,
+		Seed:         126,
+	},
+}

--- a/perf/baseline/findings_bus_v1.0.json
+++ b/perf/baseline/findings_bus_v1.0.json
@@ -1,0 +1,97 @@
+{
+  "version": "v1.0.0",
+  "timestamp": "2025-10-05T19:46:06.066188056Z",
+  "git_ref": "7bf9d9f",
+  "workloads": [
+    {
+      "name": "fanout_wide",
+      "config": {
+        "name": "fanout_wide",
+        "fan_out": 16,
+        "depth": 1,
+        "concurrency": 4,
+        "events": 6000,
+        "payload_bytes": 256,
+        "failure_rate": 0,
+        "seed": 42
+      },
+      "duration": 26521322,
+      "successes": 6000,
+      "errors": 0,
+      "throughput_eps": 226233.06636071912,
+      "error_rate": 0,
+      "latency": {
+        "p50_ms": 0.057784,
+        "p95_ms": 0.528366,
+        "p99_ms": 0.961978,
+        "max_ms": 3.054844
+      },
+      "memory": {
+        "bytes_total": 3511920,
+        "bytes_per_event": 585.32,
+        "peak_goroutines": 40,
+        "baseline_goroutines": 35
+      }
+    },
+    {
+      "name": "fanout_deep",
+      "config": {
+        "name": "fanout_deep",
+        "fan_out": 6,
+        "depth": 3,
+        "concurrency": 8,
+        "events": 8000,
+        "payload_bytes": 384,
+        "failure_rate": 0,
+        "seed": 84
+      },
+      "duration": 35748599,
+      "successes": 8000,
+      "errors": 0,
+      "throughput_eps": 223784.9936440866,
+      "error_rate": 0,
+      "latency": {
+        "p50_ms": 0.154005,
+        "p95_ms": 0.497054,
+        "p99_ms": 0.943996,
+        "max_ms": 1.570654
+      },
+      "memory": {
+        "bytes_total": 4692488,
+        "bytes_per_event": 586.561,
+        "peak_goroutines": 38,
+        "baseline_goroutines": 29
+      }
+    },
+    {
+      "name": "high_concurrency",
+      "config": {
+        "name": "high_concurrency",
+        "fan_out": 8,
+        "depth": 2,
+        "concurrency": 16,
+        "events": 10000,
+        "payload_bytes": 192,
+        "failure_rate": 0,
+        "seed": 126
+      },
+      "duration": 47802959,
+      "successes": 10000,
+      "errors": 0,
+      "throughput_eps": 209192.07114354573,
+      "error_rate": 0,
+      "latency": {
+        "p50_ms": 0.065912,
+        "p95_ms": 0.309625,
+        "p99_ms": 0.771782,
+        "max_ms": 24.384567
+      },
+      "memory": {
+        "bytes_total": 5872400,
+        "bytes_per_event": 587.24,
+        "peak_goroutines": 45,
+        "baseline_goroutines": 28
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a perfbench command and internal perf harness to run synthetic findings bus workloads and collect throughput, latency, memory, and error metrics
- store a v1.0 baseline report, document how to run or refresh the benchmarks, and ignore transient perf results
- wire the perfbench run into CI so pull requests fail when metrics regress beyond the 10% threshold and publish the latest report as an artifact

## Testing
- go test ./... *(fails: runtime/cgo: pthread_create failed in github.com/RowanDark/Glyph/internal/plugins/runner)*
- go run ./cmd/perfbench --baseline perf/baseline/findings_bus_v1.0.json --threshold 0.10

------
https://chatgpt.com/codex/tasks/task_e_68e2c65c3984832a86e598e8adcd894b