### PR TITLE
Improve docs navigation and metadata

### DIFF
--- a/docs/dev/performance.md
+++ b/docs/dev/performance.md
@@ -1,3 +1,7 @@
+---
+search: false
+---
+
 # Performance Benchmarks
 
 Glyph now ships with a dedicated microbenchmark harness that exercises the

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mkdocs.structure.pages import Page
+
+
+def on_page_content(html: str, page: Page, config: dict[str, Any], files: Any) -> str:  # noqa: ARG001
+    """Append a Last updated banner to each rendered page."""
+    last_updated = page.meta.get("git_revision_date_localized") if page.meta else None
+    if not last_updated:
+        return html
+
+    banner = (
+        '\n<div class="doc-last-updated" data-md-component="last-updated">'
+        f'<span class="doc-last-updated__label">Last updated:</span> {last_updated}'
+        "</div>\n"
+    )
+    if "doc-last-updated" in html:
+        return html
+    return html + banner

--- a/docs/javascripts/search-fallback.js
+++ b/docs/javascripts/search-fallback.js
@@ -1,0 +1,73 @@
+(function () {
+  const FALLBACK_ID = "doc-search-fallback";
+
+  function renderFallback(container, input, results) {
+    const query = input.value.trim();
+    const existing = container.querySelector(`#${FALLBACK_ID}`);
+    const hasResults = results.querySelector(".md-search-result__item") !== null;
+
+    if (!query || hasResults) {
+      if (existing) {
+        existing.remove();
+      }
+      return;
+    }
+
+    const url = `https://github.com/RowanDark/Glyph/search?q=${encodeURIComponent(query)}&type=code`;
+    const fallback = existing || document.createElement("div");
+    fallback.id = FALLBACK_ID;
+    fallback.className = "md-search-result__meta md-typeset";
+
+    const paragraph = fallback.querySelector("p") || document.createElement("p");
+    paragraph.className = "doc-search-fallback__text";
+    paragraph.innerHTML = `No results found. <a href="${url}" target="_blank" rel="noopener">Search the entire repository</a>.`;
+    if (!paragraph.parentNode) {
+      fallback.appendChild(paragraph);
+    }
+
+    if (!existing) {
+      container.appendChild(fallback);
+    }
+  }
+
+  function initialize() {
+    const searchDialog = document.querySelector('[data-md-component="search"]');
+    if (!searchDialog) {
+      return;
+    }
+
+    const input = searchDialog.querySelector('input[data-md-component="search-query"]');
+    const resultsContainer = searchDialog.querySelector('.md-search-result__scrollwrap');
+    const resultsList = searchDialog.querySelector('.md-search-result__list');
+    if (!input || !resultsContainer || !resultsList) {
+      return;
+    }
+
+    const observer = new MutationObserver(function () {
+      renderFallback(resultsContainer, input, resultsList);
+    });
+    observer.observe(resultsList, { childList: true, subtree: false });
+
+    input.addEventListener("input", function () {
+      window.requestAnimationFrame(function () {
+        renderFallback(resultsContainer, input, resultsList);
+      });
+    });
+
+    searchDialog.addEventListener("keydown", function (event) {
+      if (event.key === "Enter") {
+        window.requestAnimationFrame(function () {
+          renderFallback(resultsContainer, input, resultsList);
+        });
+      }
+    });
+
+    renderFallback(resultsContainer, input, resultsList);
+  }
+
+  if (document.readyState !== "loading") {
+    initialize();
+  } else {
+    document.addEventListener("DOMContentLoaded", initialize);
+  }
+})();

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,3 +1,7 @@
+---
+search: false
+---
+
 # Glyph Telemetry
 
 Glyph now exposes a Prometheus-compatible metrics endpoint that makes it possible to build dashboards and alerts without custom instrumentation.

--- a/docs/projectboard.md
+++ b/docs/projectboard.md
@@ -1,3 +1,7 @@
+---
+search: false
+---
+
 # Project Board
 
 Glyph uses a GitHub Projects board to visualise work and keep releases on track. The board lives at `https://github.com/orgs/<ORG>/projects/<ID>` (replace with the organisation and project identifiers for your deployment).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs>=1.5
 mkdocs-material
 mkdocs-redirects
+mkdocs-git-revision-date-localized-plugin

--- a/docs/sprint-plan.md
+++ b/docs/sprint-plan.md
@@ -1,3 +1,7 @@
+---
+search: false
+---
+
 # Sprint Plan: Galdr, Excavator, Scribe, Seer, and OSINT Well
 
 ## Overview

--- a/docs/stylesheets/last-updated.css
+++ b/docs/stylesheets/last-updated.css
@@ -1,0 +1,22 @@
+.doc-last-updated {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--md-typeset-table-color);
+  color: var(--md-default-fg-color--lighter);
+  font-size: 0.875rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+
+.doc-last-updated__label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+}
+
+div[data-md-color-scheme="slate"] .doc-last-updated {
+  border-color: var(--md-typeset-table-color);
+}

--- a/docs/visual-tests/README.md
+++ b/docs/visual-tests/README.md
@@ -1,3 +1,7 @@
+---
+search: false
+---
+
 # Docs visual regression tests
 
 This package captures Playwright screenshots for critical documentation pages and compares them against the version currently deployed to GitHub Pages. The suite will fail if the pixel drift exceeds the configured threshold, ensuring that unintended visual changes are caught before deployment.
@@ -16,7 +20,7 @@ npm run --prefix docs/visual-tests test         # validate against the productio
 npm run --prefix docs/visual-tests test:update  # refresh snapshots after intentional UI changes
 ```
 
-By default the tests build the MkDocs site into `docs/visual-tests/.site` and serve it locally. They fetch the baseline from [`https://rowandark.github.io/Glyph/`](https://rowandark.github.io/Glyph/) so the comparison always runs against the latest public documentation. Override the baseline with `DOCS_BASELINE_URL` when comparing against a staging environment.
+By default the tests build the MkDocs site into `docs/visual-tests/.site` and serve it locally. They fetch the baseline from the published [documentation homepage](../index.md) (default `DOCS_BASELINE_URL=https://rowandark.github.io/Glyph/`) so the comparison always runs against the latest public documentation. Override the baseline with `DOCS_BASELINE_URL` when comparing against a staging environment.
 
 ```bash
 DOCS_BASELINE_URL="https://docs-preview.example.com" \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,9 +28,11 @@ theme:
     - navigation.instant
     - navigation.sections
     - navigation.indexes
+    - navigation.path
     - content.code.copy
     - search.suggest
     - search.highlight
+  custom_dir: docs/overrides
   palette:
     - scheme: default
       toggle:
@@ -43,6 +45,14 @@ theme:
 
 plugins:
   - search
+  - git-revision-date-localized:
+      fallback_to_build_date: true
+      type: datetime
+      timezone: UTC
+      locale: en
+      format: "%b %-d, %Y"
+hooks:
+  - docs/hooks.py
   - redirects:
       redirect_maps:
         # Legacy single-page CLI docs
@@ -81,3 +91,7 @@ extra:
   cname: glyph.rowandark.com
   version:
     provider: mike
+extra_css:
+  - stylesheets/last-updated.css
+extra_javascript:
+  - javascripts/search-fallback.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,8 +51,6 @@ plugins:
       timezone: UTC
       locale: en
       format: "%b %-d, %Y"
-hooks:
-  - docs/hooks.py
   - redirects:
       redirect_maps:
         # Legacy single-page CLI docs
@@ -77,6 +75,9 @@ hooks:
         "docs/QuickStart.html": "quickstart/"
         "docs/Quickstart/index.html": "quickstart/"
         "docs/QuickStart/index.html": "quickstart/"
+
+hooks:
+  - docs/hooks.py
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- enable Material breadcrumbs and add the git revision date plugin for automatic "Last updated" metadata
- append a reusable footer banner plus styling and include a search fallback script for empty result sets
- flag internal-only docs to be omitted from search results and adjust documentation links to stay relative

## Testing
- pip install -r docs/requirements.txt *(fails: proxy blocked fetching mkdocs-git-revision-date-localized-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f10eddd0832aa2cd27d01fc1c615