### PR TITLE
Add quickstart fallback and fix JavaScript minification

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -154,6 +154,8 @@ def _minify_js(text: str) -> str:
         if in_string:
             result.append(char)
             if char == "\\":
+                if i + 1 < length:
+                    result.append(text[i + 1])
                 i += 2
                 continue
             if char == string_char:

--- a/docs/javascripts/quickstart-demo.js
+++ b/docs/javascripts/quickstart-demo.js
@@ -55,13 +55,23 @@
       return Promise.resolve(cachedScenario);
     }
     const docsRoot = resolveDocsRoot(scriptId);
+    const locale = resolveLocale();
     const url = new URL('data/quickstart-demo.json', docsRoot);
-    return fetch(url)
-      .then((response) => {
+    const fetchJson = (targetUrl) =>
+      fetch(targetUrl).then((response) => {
         if (!response.ok) {
           throw new Error(`Unable to load quickstart scenario: ${response.status}`);
         }
         return response.json();
+      });
+    return fetchJson(url)
+      .catch((error) => {
+        if (locale === 'en') {
+          throw error;
+        }
+        const englishRoot = new URL('../en/', docsRoot);
+        const fallbackUrl = new URL('data/quickstart-demo.json', englishRoot);
+        return fetchJson(fallbackUrl);
       })
       .then((scenario) => {
         cachedScenario = scenario;


### PR DESCRIPTION
## Summary
- ensure the quickstart demo falls back to the English scenario data when localized assets are unavailable
- preserve escaped characters when minifying JavaScript strings so generated assets remain valid

## Testing
- python -m compileall docs/hooks.py

------
https://chatgpt.com/codex/tasks/task_e_68e39e7f033c832aa633d60639a27a01