### PR TITLE
CI docs: broken link detection & auto-reporting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,24 @@ jobs:
         run: mkdocs build --strict
 
       - name: Check generated site links
-        run: python docs/scripts/check_links.py site
+        run: python docs/scripts/check_links.py --skip-external site
+
+      - name: Run LinkChecker on generated site
+        run: |
+          linkchecker \
+            --check-extern \
+            --no-robots \
+            --timeout=10 \
+            --threads=8 \
+            --user-agent "GlyphDocsLinkChecker/1.0" \
+            --ignore-url "^mailto:" \
+            --ignore-url "^tel:" \
+            --ignore-url "^javascript:" \
+            --ignore-url "^data:" \
+            --ignore-url "^https?://localhost" \
+            --ignore-url "^https?://127\\.0\\.0\\.1" \
+            --verbose \
+            site/index.html
 
       - name: Upload static site
         uses: actions/upload-pages-artifact@v3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-redirects
 mkdocs-git-revision-date-localized-plugin
 mkdocs-static-i18n
 requests>=2.32
+LinkChecker>=10.3

--- a/docs/scripts/check_links.py
+++ b/docs/scripts/check_links.py
@@ -109,7 +109,7 @@ def main() -> None:
                 documents,
                 session,
                 external_cache,
-                check_external=not args.skip_external,
+                check_external_links=not args.skip_external,
             )
             if error:
                 errors.append((document_path, link, error))
@@ -132,7 +132,7 @@ def validate_link(
     session: requests.Session,
     cache: Dict[str, str | None],
     *,
-    check_external: bool,
+    check_external_links: bool,
 ) -> str | None:
     url = link.url
     if not url or url.lower().startswith(("mailto:", "tel:", "javascript:", "data:")):
@@ -140,7 +140,7 @@ def validate_link(
 
     parsed = urlparse(url)
     if parsed.scheme in {"http", "https"} or parsed.netloc:
-        if not check_external:
+        if not check_external_links:
             return None
         return check_external(url, session, cache)
 


### PR DESCRIPTION
## Summary
- run the custom link validation with external checks disabled in CI
- install LinkChecker during the docs job and scan the built site for broken links

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3bff75dd4832abad342ea3f51652d