### PR TITLE
Add container smoke test and document hardened usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,39 @@ jobs:
           load: true
           tags: glyphctl:ci
 
+      - name: Container smoke test
+        run: |
+          set -euo pipefail
+
+          data_volume="$(docker volume create glyph-ci-data)"
+          out_volume="$(docker volume create glyph-ci-out)"
+
+          cleanup() {
+            docker volume rm -f "$data_volume" "$out_volume" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          common_flags=(
+            --rm
+            --read-only
+            --cap-drop=ALL
+            --security-opt no-new-privileges
+            --pids-limit=256
+            --memory=512m
+            --cpus="1.0"
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m
+            --tmpfs /home/nonroot/.cache:rw,noexec,nosuid,nodev,size=64m
+            --mount "type=volume,src=${data_volume},dst=/home/nonroot/.glyph"
+          )
+
+          docker run "${common_flags[@]}" \
+            --mount "type=volume,src=${out_volume},dst=/out" \
+            glyphctl:ci demo --out /out/demo
+
+          docker run "${common_flags[@]}" \
+            --mount "type=volume,src=${out_volume},dst=/out,ro" \
+            glyphctl:ci findings validate --input /out/demo/findings.jsonl
+
       - name: Trivy vulnerability scan
         uses: aquasecurity/trivy-action@0.22.0
         with:


### PR DESCRIPTION
## Summary
- add a container smoke test to CI that runs the demo workflow inside a locked-down Docker runtime before scanning
- document example Docker invocations for the demo and read-only validation, and note the CI coverage in the container hardening guide

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e40caec0cc832a898a05b1426dd616