### PR TITLE
docs: generate plugin catalog from manifests

### DIFF
--- a/docs/en/data/plugin-catalog.json
+++ b/docs/en/data/plugin-catalog.json
@@ -5,10 +5,21 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "TypeScript",
-    "summary": "Active crawler that maps application structure and discovers new surfaces for reconnaissance.",
-    "categories": ["crawler", "reconnaissance"],
-    "capabilities": ["CAP_SPIDER", "CAP_EMIT_FINDINGS"],
-    "homepage": "../plugins/cartographer/"
+    "summary": "Cartographer charts application surfaces discovered by crawlers and passive sensors so other plugins can prioritize exploration.",
+    "capabilities": [
+      "CAP_EMIT_FINDINGS",
+      "CAP_SPIDER"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "f54b4fe62f3e51008998a1520e6ccc416a82481bfa3a21779178c255f246892d",
+    "links": {
+      "documentation": "../plugins/_catalog/cartographer/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer#getting-started"
+    }
   },
   {
     "id": "cryptographer",
@@ -16,10 +27,40 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "TypeScript",
-    "summary": "Generates signed compliance reports and publishes them to downstream audit systems.",
-    "categories": ["reporting"],
-    "capabilities": ["CAP_REPORT"],
-    "homepage": "../plugins/cryptographer/"
+    "summary": "Cryptographer is a CyberChef-inspired utility surface for quickly transforming payloads and experimenting with encoding operations during investigations.",
+    "capabilities": [
+      "CAP_REPORT"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "01ea86b0677f49572e048da1ce3a0eab4edb85f8b431886d6aef33945119e91e",
+    "links": {
+      "documentation": "../plugins/_catalog/cryptographer/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer#getting-started"
+    }
+  },
+  {
+    "id": "example-hello",
+    "name": "Example Hello",
+    "version": "0.1.0",
+    "author": "Glyph Team",
+    "language": "Go",
+    "summary": "Example Hello is a Glyph plugin.",
+    "capabilities": [
+      "CAP_EMIT_FINDINGS"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "779e349dd31e35291496df536b5ae87721cf219fa8cefe74f57f8e891aa81969",
+    "links": {
+      "documentation": "../plugins/_catalog/example-hello/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/main.go",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/main.go.sig"
+    }
   },
   {
     "id": "excavator",
@@ -27,10 +68,22 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "TypeScript",
-    "summary": "Passive reconnaissance toolkit that collects open directories and metadata.",
-    "categories": ["crawler", "reconnaissance"],
-    "capabilities": ["CAP_HTTP_PASSIVE", "CAP_SPIDER", "CAP_EMIT_FINDINGS"],
-    "homepage": "../plugins/excavator/"
+    "summary": "Excavator is the Playwright-powered crawler foundation for Glyph. It provides a reproducible baseline for scripted reconnaissance of target applications.",
+    "capabilities": [
+      "CAP_EMIT_FINDINGS",
+      "CAP_HTTP_PASSIVE",
+      "CAP_SPIDER"
+    ],
+    "last_updated": "2025-10-03T12:53:02-04:00",
+    "signature_sha256": "2bc2a623ba05c425735f1fc72530ed2db0f3b16602b57c6d0a0779dbf1555975",
+    "links": {
+      "documentation": "../plugins/_catalog/excavator/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator#getting-started"
+    }
   },
   {
     "id": "galdr-proxy",
@@ -38,10 +91,21 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "TypeScript",
-    "summary": "Bidirectional HTTP/WebSocket proxy that enables authenticated attack surface testing.",
-    "categories": ["exploit", "proxy"],
-    "capabilities": ["CAP_HTTP_ACTIVE", "CAP_HTTP_PASSIVE", "CAP_WS"],
-    "homepage": "../plugins/galdr-proxy/"
+    "summary": "Galdr Proxy is the interception layer for Glyph. It terminates client HTTP/HTTPS sessions, applies rules-based modifications, and records a tamper-proof history that other plugins can consume.",
+    "capabilities": [
+      "CAP_HTTP_ACTIVE",
+      "CAP_HTTP_PASSIVE",
+      "CAP_WS"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "50a8b2a25abd06346fc849bab40232de2d768cc60d6f9155bb42caf76b1dcb60",
+    "links": {
+      "documentation": "../plugins/_catalog/galdr-proxy/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/plugin.js.sig"
+    }
   },
   {
     "id": "grapher",
@@ -49,10 +113,20 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "Go",
-    "summary": "Transforms findings into relationship graphs for link analysis and triage workflows.",
-    "categories": ["analysis", "storage"],
-    "capabilities": ["CAP_STORAGE", "CAP_EMIT_FINDINGS"],
-    "homepage": "../plugins/grapher/"
+    "summary": "Grapher performs unauthenticated discovery of API schemas so downstream Glyph workflows can reason about surfaced endpoints without touching production credentials.",
+    "capabilities": [
+      "CAP_EMIT_FINDINGS",
+      "CAP_STORAGE"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "ca64abd3b27388206879f4134976387239fd50f4ac6fc3044d812703f8d2af20",
+    "links": {
+      "documentation": "../plugins/_catalog/grapher/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/main.go",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/main.go.sig"
+    }
   },
   {
     "id": "osint-well",
@@ -60,10 +134,21 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "TypeScript",
-    "summary": "Aggregates open-source intelligence feeds and normalises the signals Glyph understands.",
-    "categories": ["reconnaissance", "intelligence"],
-    "capabilities": ["CAP_EMIT_FINDINGS", "CAP_STORAGE"],
-    "homepage": "../plugins/osint-well/"
+    "summary": "OSINT Well wraps [OWASP Amass](https://github.com/owasp-amass/amass) to surface open-source intelligence such as subdomains and infrastructure relationships. The plugin intentionally defaults to passive reconnaissance so that it can be executed safely in shared or sensitive environments.",
+    "capabilities": [
+      "CAP_EMIT_FINDINGS",
+      "CAP_STORAGE"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "e7a804c5ede93f41fd2eb0871ab380f53d3342b0667f6a969c5c6fcb95b2c027",
+    "links": {
+      "documentation": "../plugins/_catalog/osint-well/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well#installation"
+    }
   },
   {
     "id": "raider",
@@ -71,10 +156,22 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "TypeScript",
-    "summary": "Active attack executor with payload libraries for common Glyph exploitation scenarios.",
-    "categories": ["exploit"],
-    "capabilities": ["CAP_HTTP_ACTIVE", "CAP_HTTP_PASSIVE", "CAP_EMIT_FINDINGS"],
-    "homepage": "../plugins/raider/"
+    "summary": "Raider coordinates focused offensive testing campaigns once high-value targets are identified by discovery plugins.",
+    "capabilities": [
+      "CAP_EMIT_FINDINGS",
+      "CAP_HTTP_ACTIVE",
+      "CAP_HTTP_PASSIVE"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "ac97711a74c78f33d6dbb08d3a4a7e9f9534671db0be96afa84a4b8e451c69dd",
+    "links": {
+      "documentation": "../plugins/_catalog/raider/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider#getting-started"
+    }
   },
   {
     "id": "ranker",
@@ -82,10 +179,21 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "TypeScript",
-    "summary": "Prioritises findings using weighted scoring tuned for Glyph automation pipelines.",
-    "categories": ["analysis", "scoring"],
-    "capabilities": ["CAP_STORAGE", "CAP_EMIT_FINDINGS"],
-    "homepage": "../plugins/ranker/"
+    "summary": "Ranker scores assets, findings, and leads so teams focus on the highest-impact work first.",
+    "capabilities": [
+      "CAP_EMIT_FINDINGS",
+      "CAP_STORAGE"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "a45acedbd3421c054d07db91f12938ac13f928d47170de6cec88770c5fde13f3",
+    "links": {
+      "documentation": "../plugins/_catalog/ranker/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker#getting-started"
+    }
   },
   {
     "id": "scribe",
@@ -93,10 +201,20 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "TypeScript",
-    "summary": "Produces long-form human readable reports consolidating Glyph run history.",
-    "categories": ["reporting"],
-    "capabilities": ["CAP_REPORT"],
-    "homepage": "../plugins/scribe/"
+    "summary": "Scribe renders investigation output into human-friendly reports, summarizing findings across the Glyph pipeline.",
+    "capabilities": [
+      "CAP_REPORT"
+    ],
+    "last_updated": "2025-09-30T10:30:42-04:00",
+    "signature_sha256": "61b004d72d616382997a2689a3f85d6a032cb29ffe2e53297440a4ee5bb1c0d0",
+    "links": {
+      "documentation": "../plugins/_catalog/scribe/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe#getting-started"
+    }
   },
   {
     "id": "seer",
@@ -104,9 +222,19 @@
     "version": "0.1.0",
     "author": "Glyph Team",
     "language": "Go",
-    "summary": "Passive reconnaissance agent for running allowlist-enforced detection sweeps.",
-    "categories": ["reconnaissance", "detection"],
-    "capabilities": ["CAP_HTTP_PASSIVE", "CAP_EMIT_FINDINGS"],
-    "homepage": "../plugins/seer/"
+    "summary": "Seer inspects passive telemetry to spot anomalies and suspicious behaviors before they escalate into incidents. The v0.3 release focuses on low-noise secret and PII detection tailored for HTTP response bodies.",
+    "capabilities": [
+      "CAP_EMIT_FINDINGS",
+      "CAP_HTTP_PASSIVE"
+    ],
+    "last_updated": "2025-10-03T08:53:18-04:00",
+    "signature_sha256": "46e816b1b0cbd7f804430df0a730f8983004f3136739b6b62818a00b7b7b0fce",
+    "links": {
+      "documentation": "../plugins/_catalog/seer/",
+      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/main.go",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/main.go.sig"
+    }
   }
 ]

--- a/docs/en/plugins/_catalog/cartographer.md
+++ b/docs/en/plugins/_catalog/cartographer.md
@@ -1,0 +1,46 @@
+---
+title: "Cartographer"
+description: "Cartographer charts application surfaces discovered by crawlers and passive sensors so other plugins can prioritize exploration."
+---
+
+# Cartographer
+
+Cartographer charts application surfaces discovered by crawlers and passive sensors so other plugins can prioritize exploration.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | TypeScript |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_EMIT_FINDINGS`
+- `CAP_SPIDER`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer#getting-started) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/plugin.js)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/plugin.js.sig)
+
+
+### Signature
+
+`f54b4fe62f3e51008998a1520e6ccc416a82481bfa3a21779178c255f246892d`

--- a/docs/en/plugins/_catalog/cryptographer.md
+++ b/docs/en/plugins/_catalog/cryptographer.md
@@ -1,0 +1,45 @@
+---
+title: "Cryptographer"
+description: "Cryptographer is a CyberChef-inspired utility surface for quickly transforming payloads and experimenting with encoding operations during investigations."
+---
+
+# Cryptographer
+
+Cryptographer is a CyberChef-inspired utility surface for quickly transforming payloads and experimenting with encoding operations during investigations.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | TypeScript |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_REPORT`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer#getting-started) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/plugin.js)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/plugin.js.sig)
+
+
+### Signature
+
+`01ea86b0677f49572e048da1ce3a0eab4edb85f8b431886d6aef33945119e91e`

--- a/docs/en/plugins/_catalog/example-hello.md
+++ b/docs/en/plugins/_catalog/example-hello.md
@@ -1,0 +1,45 @@
+---
+title: "Example Hello"
+description: "Example Hello is a Glyph plugin."
+---
+
+# Example Hello
+
+Example Hello is a Glyph plugin.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | Go |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_EMIT_FINDINGS`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello#readme) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/main.go)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/main.go.sig)
+
+
+### Signature
+
+`779e349dd31e35291496df536b5ae87721cf219fa8cefe74f57f8e891aa81969`

--- a/docs/en/plugins/_catalog/excavator.md
+++ b/docs/en/plugins/_catalog/excavator.md
@@ -1,0 +1,47 @@
+---
+title: "Excavator"
+description: "Excavator is the Playwright-powered crawler foundation for Glyph. It provides a reproducible baseline for scripted reconnaissance of target applications."
+---
+
+# Excavator
+
+Excavator is the Playwright-powered crawler foundation for Glyph. It provides a reproducible baseline for scripted reconnaissance of target applications.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | TypeScript |
+| Last updated | Oct 03, 2025 |
+
+
+## Capabilities
+
+- `CAP_EMIT_FINDINGS`
+- `CAP_HTTP_PASSIVE`
+- `CAP_SPIDER`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator#getting-started) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/plugin.js)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/plugin.js.sig)
+
+
+### Signature
+
+`2bc2a623ba05c425735f1fc72530ed2db0f3b16602b57c6d0a0779dbf1555975`

--- a/docs/en/plugins/_catalog/galdr-proxy.md
+++ b/docs/en/plugins/_catalog/galdr-proxy.md
@@ -1,0 +1,47 @@
+---
+title: "Galdr Proxy"
+description: "Galdr Proxy is the interception layer for Glyph. It terminates client HTTP/HTTPS sessions, applies rules-based modifications, and records a tamper-proof history that other plugins can consume."
+---
+
+# Galdr Proxy
+
+Galdr Proxy is the interception layer for Glyph. It terminates client HTTP/HTTPS sessions, applies rules-based modifications, and records a tamper-proof history that other plugins can consume.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | TypeScript |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_HTTP_ACTIVE`
+- `CAP_HTTP_PASSIVE`
+- `CAP_WS`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy#readme) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/plugin.js)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/plugin.js.sig)
+
+
+### Signature
+
+`50a8b2a25abd06346fc849bab40232de2d768cc60d6f9155bb42caf76b1dcb60`

--- a/docs/en/plugins/_catalog/grapher.md
+++ b/docs/en/plugins/_catalog/grapher.md
@@ -1,0 +1,46 @@
+---
+title: "Grapher"
+description: "Grapher performs unauthenticated discovery of API schemas so downstream Glyph workflows can reason about surfaced endpoints without touching production credentials."
+---
+
+# Grapher
+
+Grapher performs unauthenticated discovery of API schemas so downstream Glyph workflows can reason about surfaced endpoints without touching production credentials.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | Go |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_EMIT_FINDINGS`
+- `CAP_STORAGE`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher#readme) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/main.go)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/main.go.sig)
+
+
+### Signature
+
+`ca64abd3b27388206879f4134976387239fd50f4ac6fc3044d812703f8d2af20`

--- a/docs/en/plugins/_catalog/osint-well.md
+++ b/docs/en/plugins/_catalog/osint-well.md
@@ -1,0 +1,46 @@
+---
+title: "OSINT Well"
+description: "OSINT Well wraps [OWASP Amass](https://github.com/owasp-amass/amass) to surface open-source intelligence such as subdomains and infrastructure relationships. The plugin intentionally defaults to passive reconnaissance so that it can be executed safely in shared or sensitive environments."
+---
+
+# OSINT Well
+
+OSINT Well wraps [OWASP Amass](https://github.com/owasp-amass/amass) to surface open-source intelligence such as subdomains and infrastructure relationships. The plugin intentionally defaults to passive reconnaissance so that it can be executed safely in shared or sensitive environments.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | TypeScript |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_EMIT_FINDINGS`
+- `CAP_STORAGE`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well#installation) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/plugin.js)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/plugin.js.sig)
+
+
+### Signature
+
+`e7a804c5ede93f41fd2eb0871ab380f53d3342b0667f6a969c5c6fcb95b2c027`

--- a/docs/en/plugins/_catalog/raider.md
+++ b/docs/en/plugins/_catalog/raider.md
@@ -1,0 +1,47 @@
+---
+title: "Raider"
+description: "Raider coordinates focused offensive testing campaigns once high-value targets are identified by discovery plugins."
+---
+
+# Raider
+
+Raider coordinates focused offensive testing campaigns once high-value targets are identified by discovery plugins.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | TypeScript |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_EMIT_FINDINGS`
+- `CAP_HTTP_ACTIVE`
+- `CAP_HTTP_PASSIVE`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider#getting-started) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/plugin.js)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/plugin.js.sig)
+
+
+### Signature
+
+`ac97711a74c78f33d6dbb08d3a4a7e9f9534671db0be96afa84a4b8e451c69dd`

--- a/docs/en/plugins/_catalog/ranker.md
+++ b/docs/en/plugins/_catalog/ranker.md
@@ -1,0 +1,46 @@
+---
+title: "Ranker"
+description: "Ranker scores assets, findings, and leads so teams focus on the highest-impact work first."
+---
+
+# Ranker
+
+Ranker scores assets, findings, and leads so teams focus on the highest-impact work first.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | TypeScript |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_EMIT_FINDINGS`
+- `CAP_STORAGE`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker#getting-started) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/plugin.js)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/plugin.js.sig)
+
+
+### Signature
+
+`a45acedbd3421c054d07db91f12938ac13f928d47170de6cec88770c5fde13f3`

--- a/docs/en/plugins/_catalog/scribe.md
+++ b/docs/en/plugins/_catalog/scribe.md
@@ -1,0 +1,45 @@
+---
+title: "Scribe"
+description: "Scribe renders investigation output into human-friendly reports, summarizing findings across the Glyph pipeline."
+---
+
+# Scribe
+
+Scribe renders investigation output into human-friendly reports, summarizing findings across the Glyph pipeline.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | TypeScript |
+| Last updated | Sep 30, 2025 |
+
+
+## Capabilities
+
+- `CAP_REPORT`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe#getting-started) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/plugin.js)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/plugin.js.sig)
+
+
+### Signature
+
+`61b004d72d616382997a2689a3f85d6a032cb29ffe2e53297440a4ee5bb1c0d0`

--- a/docs/en/plugins/_catalog/seer.md
+++ b/docs/en/plugins/_catalog/seer.md
@@ -1,0 +1,46 @@
+---
+title: "Seer"
+description: "Seer inspects passive telemetry to spot anomalies and suspicious behaviors before they escalate into incidents. The v0.3 release focuses on low-noise secret and PII detection tailored for HTTP response bodies."
+---
+
+# Seer
+
+Seer inspects passive telemetry to spot anomalies and suspicious behaviors before they escalate into incidents. The v0.3 release focuses on low-noise secret and PII detection tailored for HTTP response bodies.
+
+## Metadata
+
+| Field | Value |
+
+| ----- | ----- |
+
+| Version | 0.1.0 |
+| Author | Glyph Team |
+| Language | Go |
+| Last updated | Oct 03, 2025 |
+
+
+## Capabilities
+
+- `CAP_EMIT_FINDINGS`
+- `CAP_HTTP_PASSIVE`
+
+
+## Installation
+
+Download the signed artefact and verify its signature before running the plugin.
+
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer#readme) for detailed steps.
+
+
+### Downloads
+
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/manifest.json)
+
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/main.go)
+
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/main.go.sig)
+
+
+### Signature
+
+`46e816b1b0cbd7f804430df0a730f8983004f3136739b6b62818a00b7b7b0fce`

--- a/docs/en/plugins/catalog.md
+++ b/docs/en/plugins/catalog.md
@@ -7,7 +7,8 @@ description: Discover Glyph plugins, filter by capability, and explore their com
 
 Glyph ships with an extensible plugin runtime and a curated marketplace of
 first-party extensions. Use the catalogue below to browse every maintained
-plugin, inspect its capabilities, and jump straight into the author guides.
+plugin, inspect its capabilities, verify the detached signature, and jump
+straight into the author guides.
 
 <div class="plugin-catalog__toolbar">
   <label class="plugin-catalog__filter">
@@ -38,15 +39,18 @@ plugin, inspect its capabilities, and jump straight into the author guides.
 ## Marketplace metadata feeds
 
 The data that powers the marketplace is stored in
-[`docs/data/plugin-catalog.json`](../data/plugin-catalog.json). The file is
-updated every time a plugin ships or gains a new capability. Repository owners
-can extend the schema with custom fields—new properties automatically appear in
-this table without changes to the JavaScript renderer.
+[`docs/en/data/plugin-catalog.json`](../data/plugin-catalog.json). The file is
+generated from the manifests under `plugins/<id>/manifest.json` by running
+`python scripts/update_plugin_catalog.py`. The command captures the declared
+capabilities, summary, last Git commit date, and the SHA-256 hash of each
+detached signature. Repository owners can extend the schema with custom
+fields—new properties automatically appear in this catalogue without changes to
+the JavaScript renderer.
 
 If you are publishing a third-party plugin, open a pull request that updates the
-catalogue entry with the plugin name, version, author, categories, and
-capability list. The docs build picks up the change and republishes the
-marketplace page without additional configuration.
+manifest and README under `plugins/<id>/`. Re-run the catalogue generator so the
+metadata and per-plugin reference page are refreshed; the docs build picks up
+the change and republishes the marketplace without additional configuration.
 
 ## Discover more
 

--- a/docs/javascripts/plugin-catalog.js
+++ b/docs/javascripts/plugin-catalog.js
@@ -1,6 +1,7 @@
 (function () {
   const docsRoot = resolveDocsRoot('plugin-catalog.js');
   let cachedPlugins = null;
+  let catalogDataUrl = null;
 
   const slugify = (value) =>
     (value || '')
@@ -36,7 +37,8 @@
     emptyState.setAttribute('aria-live', 'polite');
     emptyState.tabIndex = -1;
 
-    const dataUrl = new URL('data/plugin-catalog.json', docsRoot);
+    catalogDataUrl = new URL('data/plugin-catalog.json', docsRoot);
+    const dataUrl = catalogDataUrl;
 
     const loadPlugins = cachedPlugins
       ? Promise.resolve(cachedPlugins)
@@ -262,7 +264,8 @@
       }
       const link = document.createElement('a');
       link.className = 'plugin-card__link';
-      const resolved = new URL(href, docsRoot);
+      const base = catalogDataUrl || docsRoot;
+      const resolved = new URL(href, base);
       link.href = resolved.href;
       link.textContent = label;
       return link;

--- a/docs/stylesheets/marketplace.css
+++ b/docs/stylesheets/marketplace.css
@@ -65,6 +65,32 @@
   font-size: 0.9rem;
 }
 
+.plugin-card__details {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+.plugin-card__details dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--md-default-fg-color--light);
+}
+
+.plugin-card__details dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.plugin-card__details code {
+  font-size: 0.75rem;
+  word-break: break-all;
+}
+
 .plugin-card__label {
   margin: 0.5rem 0 0.25rem;
   font-size: 0.85rem;
@@ -98,8 +124,20 @@
   margin-top: auto;
 }
 
+.plugin-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .plugin-card__link {
   font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--md-default-fg-color--lightest);
 }
 
 .plugin-catalog__empty {

--- a/scripts/update_plugin_catalog.py
+++ b/scripts/update_plugin_catalog.py
@@ -1,0 +1,362 @@
+"""Generate the plugin marketplace metadata used by the documentation site."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+
+ROOT = Path(__file__).resolve().parent.parent
+PLUGINS_DIR = ROOT / "plugins"
+DOCS_DIR = ROOT / "docs"
+DEFAULT_LANGUAGE = "en"
+CATALOG_DATA_PATH = DOCS_DIR / DEFAULT_LANGUAGE / "data" / "plugin-catalog.json"
+CATALOG_DOCS_DIR = DOCS_DIR / DEFAULT_LANGUAGE / "plugins" / "_catalog"
+
+
+LANGUAGE_MAP = {
+    ".js": "TypeScript",
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript",
+    ".mjs": "TypeScript",
+    ".cjs": "TypeScript",
+    ".go": "Go",
+    ".py": "Python",
+    ".rb": "Ruby",
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ref",
+        default=_current_git_ref(),
+        help="Git ref used for GitHub links (defaults to the current commit)",
+    )
+    parser.add_argument(
+        "--repo-url",
+        default=_detect_repo_url(),
+        help="Repository URL used for documentation links",
+    )
+    args = parser.parse_args()
+
+    repo_url = args.repo_url.rstrip("/")
+    owner, repo = _extract_github_repo(repo_url)
+    raw_base = f"https://raw.githubusercontent.com/{owner}/{repo}/{args.ref}/"
+    tree_base = f"{repo_url}/tree/{args.ref}/"
+
+    entries: list[dict[str, Any]] = []
+    generated_docs: dict[str, Path] = {}
+
+    for manifest_path in sorted(PLUGINS_DIR.glob("*/manifest.json")):
+        plugin_dir = manifest_path.parent
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        plugin_id = manifest.get("name") or plugin_dir.name
+        plugin_slug = _normalise_identifier(plugin_id)
+
+        readme_path = plugin_dir / "README.md"
+        metadata = _parse_readme(readme_path)
+        display_name = metadata.name or _title_from_identifier(plugin_id)
+        summary = metadata.summary or _default_summary(display_name)
+
+        language = _detect_language(manifest, plugin_dir)
+        author = manifest.get("author") or "Glyph Team"
+        capabilities = sorted(set(manifest.get("capabilities") or []))
+
+        artifact_path = _resolve_path(manifest.get("artifact"), base=plugin_dir)
+        signature_rel = manifest.get("signature", {}).get("signature")
+        signature_path = _resolve_path(signature_rel, base=plugin_dir)
+
+        if artifact_path is None or signature_path is None:
+            raise SystemExit(f"Manifest {manifest_path} is missing an artefact or signature path")
+
+        manifest_rel = manifest_path.relative_to(ROOT).as_posix()
+        artifact_rel = artifact_path.relative_to(ROOT).as_posix()
+        signature_rel_path = signature_path.relative_to(ROOT).as_posix()
+
+        signature_sha256 = _sha256(signature_path)
+        last_updated = _git_last_updated(plugin_dir)
+
+        install_anchor = metadata.anchors.get("installation") or metadata.anchors.get("getting-started")
+        documentation_url = f"../plugins/_catalog/{plugin_slug}/"
+        install_url = None
+        if install_anchor:
+            install_url = f"{tree_base}{plugin_dir.relative_to(ROOT).as_posix()}#" f"{install_anchor}"
+
+        entry = {
+            "id": plugin_slug,
+            "name": display_name,
+            "version": manifest.get("version", "0.0.0"),
+            "author": author,
+            "language": language,
+            "summary": summary,
+            "capabilities": capabilities,
+            "last_updated": last_updated,
+            "signature_sha256": signature_sha256,
+            "links": {
+                "documentation": documentation_url,
+                "readme": f"{tree_base}{plugin_dir.relative_to(ROOT).as_posix()}#readme",
+                "manifest": f"{raw_base}{manifest_rel}",
+                "artifact": f"{raw_base}{artifact_rel}",
+                "signature": f"{raw_base}{signature_rel_path}",
+            },
+        }
+        if install_url:
+            entry["links"]["installation"] = install_url
+
+        entries.append(entry)
+
+        generated_docs[plugin_slug] = _write_plugin_doc(
+            output_dir=CATALOG_DOCS_DIR,
+            plugin_id=plugin_slug,
+            name=display_name,
+            summary=summary,
+            version=entry["version"],
+            language=language,
+            author=author,
+            capabilities=capabilities,
+            last_updated=last_updated,
+            signature_sha256=signature_sha256,
+            links=entry["links"],
+        )
+
+    entries.sort(key=lambda item: item["name"].lower())
+    CATALOG_DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CATALOG_DATA_PATH.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+
+    _prune_stale_docs(CATALOG_DOCS_DIR, set(generated_docs))
+
+
+def _current_git_ref() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "main"
+
+
+def _detect_repo_url() -> str:
+    mkdocs_path = ROOT / "mkdocs.yml"
+    if not mkdocs_path.exists():
+        return "https://github.com/RowanDark/Glyph"
+    for line in mkdocs_path.read_text(encoding="utf-8").splitlines():
+        if line.strip().startswith("repo_url:"):
+            _, value = line.split(":", 1)
+            return value.strip().strip("'\"")
+    return "https://github.com/RowanDark/Glyph"
+
+
+def _extract_github_repo(url: str) -> tuple[str, str]:
+    parsed = urlparse(url)
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) < 2:
+        raise SystemExit(f"Unable to determine GitHub repository owner from URL: {url}")
+    return parts[0], parts[1]
+
+
+def _normalise_identifier(identifier: str) -> str:
+    return re.sub(r"[^a-z0-9-]", "-", identifier.lower()).strip("-") or identifier
+
+
+def _title_from_identifier(identifier: str) -> str:
+    return identifier.replace("-", " ").title()
+
+
+class ReadmeMetadata:
+    def __init__(self, name: str | None, summary: str | None, anchors: dict[str, str]):
+        self.name = name
+        self.summary = summary
+        self.anchors = anchors
+
+
+def _parse_readme(path: Path) -> ReadmeMetadata:
+    if not path.exists():
+        return ReadmeMetadata(None, None, {})
+
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    name: str | None = None
+    summary: str | None = None
+    anchors: dict[str, str] = {}
+    collecting_summary = False
+    summary_lines: list[str] = []
+
+    for line in lines:
+        if line.startswith("# "):
+            if name is None:
+                name = line[2:].strip()
+                collecting_summary = True
+            else:
+                collecting_summary = False
+            continue
+        if line.startswith("## "):
+            heading = line[3:].strip()
+            anchors[_slugify(heading)] = _slugify(heading)
+            collecting_summary = False
+            if summary_lines and summary is None:
+                summary = " ".join(summary_lines).strip()
+            continue
+        if collecting_summary:
+            stripped = line.strip()
+            if not stripped:
+                if summary_lines and summary is None:
+                    summary = " ".join(summary_lines).strip()
+                    summary_lines = []
+                continue
+            summary_lines.append(stripped)
+
+    if summary is None and summary_lines:
+        summary = " ".join(summary_lines).strip()
+
+    return ReadmeMetadata(name, summary, anchors)
+
+
+def _slugify(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9\s-]", "", value)
+    value = re.sub(r"\s+", "-", value)
+    return value
+
+
+def _default_summary(name: str) -> str:
+    return f"{name} is a Glyph plugin.".strip()
+
+
+def _detect_language(manifest: dict[str, Any], base: Path) -> str:
+    candidates = [manifest.get("entry"), manifest.get("artifact")]
+    for candidate in candidates:
+        resolved = _resolve_path(candidate, base=base)
+        if resolved is None:
+            continue
+        suffix = resolved.suffix.lower()
+        if suffix in LANGUAGE_MAP:
+            return LANGUAGE_MAP[suffix]
+    return "Unknown"
+
+
+def _resolve_path(path: str | None, *, base: Path) -> Path | None:
+    if not path:
+        return None
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    base_candidate = (base / candidate).resolve()
+    if base_candidate.exists():
+        return base_candidate
+    root_candidate = (ROOT / candidate).resolve()
+    if root_candidate.exists():
+        return root_candidate
+    return base_candidate
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git_last_updated(path: Path) -> str | None:
+    try:
+        output = subprocess.check_output(
+            ["git", "log", "-1", "--format=%cI", str(path.relative_to(ROOT))],
+            cwd=ROOT,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return output or None
+
+
+def _write_plugin_doc(
+    *,
+    output_dir: Path,
+    plugin_id: str,
+    name: str,
+    summary: str,
+    version: str,
+    language: str,
+    author: str,
+    capabilities: Iterable[str],
+    last_updated: str | None,
+    signature_sha256: str,
+    links: dict[str, str],
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    doc_path = output_dir / f"{plugin_id}.md"
+
+    manifest_link = links.get("manifest", "")
+    artifact_link = links.get("artifact", "")
+    signature_link = links.get("signature", "")
+    readme_link = links.get("installation") or links.get("readme", "")
+
+    metadata_rows = [
+        ("Version", version),
+        ("Author", author),
+        ("Language", language),
+    ]
+    if last_updated:
+        try:
+            dt = datetime.fromisoformat(last_updated.replace("Z", "+00:00"))
+            formatted = dt.strftime("%b %d, %Y")
+            metadata_rows.append(("Last updated", formatted))
+        except ValueError:
+            metadata_rows.append(("Last updated", last_updated))
+
+    table = "\n".join(f"| {label} | {value} |" for label, value in metadata_rows)
+
+    capability_lines = "\n".join(f"- `{cap}`" for cap in capabilities) or "- _None declared_"
+
+    sections = [
+        f"---\ntitle: \"{_escape_yaml(name)}\"\ndescription: \"{_escape_yaml(summary)}\"\n---",
+        f"# {name}",
+        summary,
+        "## Metadata",
+        "| Field | Value |",
+        "| ----- | ----- |",
+        table,
+        "\n## Capabilities",
+        capability_lines,
+        "\n## Installation",
+        "Download the signed artefact and verify its signature before running the plugin.",
+    ]
+    if readme_link:
+        sections.append(f"Follow the [installation guide]({readme_link}) for detailed steps.")
+
+    sections.extend(
+        [
+            "\n### Downloads",
+            f"- [Manifest]({manifest_link})",
+            f"- [Plugin artefact]({artifact_link})",
+            f"- [Detached signature]({signature_link})",
+            "\n### Signature",
+            f"`{signature_sha256}`",
+        ]
+    )
+
+    doc_path.write_text("\n\n".join(sections).strip() + "\n", encoding="utf-8")
+    return doc_path
+
+
+def _escape_yaml(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("\"", "\\\"")
+
+
+def _prune_stale_docs(directory: Path, valid_ids: set[str]) -> None:
+    if not directory.exists():
+        return
+    for path in directory.glob("*.md"):
+        if path.stem not in valid_ids:
+            path.unlink()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a catalogue generator that builds plugin metadata from manifests and READMEs
- publish generated plugin reference pages with download, signature, and manifest links
- enhance the marketplace UI to surface last updates, signature hashes, and install/download actions

## Testing
- not run (docs serve requires mkdocs i18n plugin configuration supported by our CI image)


------
https://chatgpt.com/codex/tasks/task_e_68e452f46e74832a8643056a8409e80b