### PR TITLE
Dynamic version & status badges in README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,3 +124,36 @@ jobs:
           ${{ matrix.setup }}
           ${{ matrix.install }}
           glyphctl --version
+  update-readme-badge:
+    name: Update README badge
+    runs-on: ubuntu-latest
+    needs:
+      - linux-package-smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Refresh release badge
+        env:
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "Skipping badge update for ref type ${GITHUB_REF_TYPE}"
+            exit 0
+          fi
+
+          python3 scripts/update_version_badge.py "${RELEASE_TAG}"
+
+          if git diff --quiet README.md; then
+            echo "README already up to date"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "docs: refresh release badge for ${RELEASE_TAG}"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Glyph
 
-[![Docs](https://img.shields.io/badge/docs-material-blue)](https://rowandark.github.io/Glyph/) [![Plugin ecosystem](https://img.shields.io/endpoint?url=https://rowandark.github.io/Glyph/api/plugin-stats.json&cacheSeconds=3600)](https://rowandark.github.io/Glyph/plugins/catalog/)
+<!-- version-badge -->[![Release](https://img.shields.io/badge/release-v0.0.0--dev-blue)](https://github.com/RowanDark/Glyph/releases/latest)<!-- /version-badge --> [![Build status](https://github.com/RowanDark/Glyph/actions/workflows/ci.yml/badge.svg)](https://github.com/RowanDark/Glyph/actions/workflows/ci.yml) [![Docs](https://img.shields.io/badge/docs-material-blue)](https://rowandark.github.io/Glyph/) [![Plugin count](https://img.shields.io/endpoint?url=https://rowandark.github.io/Glyph/api/plugin-stats.json&cacheSeconds=3600)](https://rowandark.github.io/Glyph/plugins/catalog/)
 
 Glyph is an automation toolkit for orchestrating red-team and detection workflows.
 It coordinates plugins such as Galdr (HTTP rewriting proxy), Excavator (Playwright
 crawler), Seer (secret/PII detector), Ranker, and Scribe to turn raw telemetry into
 ranked findings and human-readable reports.
+
+The badges above highlight the most recent Glyph release, continuous-integration
+status, documentation portal, and the live plugin catalog size published from the
+docs build pipeline.
 
 > Read this page in [Spanish](README.es.md).
 

--- a/scripts/update_version_badge.py
+++ b/scripts/update_version_badge.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Update the release badge in the README with the provided tag."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+MARKER_START = "<!-- version-badge -->"
+MARKER_END = "<!-- /version-badge -->"
+BADGE_TEMPLATE = (
+    "[![Release](https://img.shields.io/badge/release-{message}-blue)]"
+    "(https://github.com/RowanDark/Glyph/releases/latest)"
+)
+
+
+def _shields_escape(tag: str) -> str:
+    """Escape a version string for use in a static Shields badge."""
+
+    escaped = tag
+    escaped = escaped.replace("-", "--")
+    escaped = escaped.replace("_", "__")
+    escaped = escaped.replace(" ", "%20")
+    escaped = escaped.replace("+", "%2B")
+    return escaped
+
+
+def update_badge(readme_path: Path, tag: str) -> bool:
+    """Update the README badge and return True if a change was made."""
+
+    original = readme_path.read_text(encoding="utf-8")
+    escaped_tag = _shields_escape(tag)
+    badge = f"{MARKER_START}{BADGE_TEMPLATE.format(message=escaped_tag)}{MARKER_END}"
+
+    pattern = re.compile(
+        re.escape(MARKER_START) + r".*?" + re.escape(MARKER_END),
+        flags=re.DOTALL,
+    )
+
+    if not pattern.search(original):
+        raise SystemExit("Version badge markers not found in README.md")
+
+    updated, count = pattern.subn(badge, original, count=1)
+    if count == 0 or updated == original:
+        return False
+
+    readme_path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("Usage: update_version_badge.py <tag>", file=sys.stderr)
+        return 1
+
+    tag = argv[1]
+    repo_root = Path(__file__).resolve().parents[1]
+    readme_path = repo_root / "README.md"
+
+    changed = update_badge(readme_path, tag)
+    return 0 if changed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add release, build, documentation, and plugin catalog badges to the README header
- document what the badges represent and ensure the plugin catalog size is highlighted
- add a release workflow step and helper script to refresh the static release badge after tagging

## Testing
- python3 -m compileall scripts/update_version_badge.py

------
https://chatgpt.com/codex/tasks/task_e_68e459bd1318832a845a77c4dbe3c1e8