### PR TITLE
Add performance history tracking and CPU metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,13 +123,18 @@ jobs:
           go-version-file: go.mod
 
       - name: Run synthetic workloads
-        run: go run ./cmd/perfbench --baseline perf/baseline/findings_bus_v1.0.json --output perf/results/latest.json --threshold 0.10
+        run: >-
+          go run ./cmd/perfbench --baseline perf/baseline/findings_bus_v1.0.json --output perf/results/latest.json --threshold 0.10
+          --history perf/results/history.jsonl --history-markdown perf/results/history.md
 
       - name: Upload metrics report
         uses: actions/upload-artifact@v4
         with:
           name: perf-metrics
-          path: perf/results/latest.json
+          path: |
+            perf/results/latest.json
+            perf/results/history.jsonl
+            perf/results/history.md
           if-no-files-found: error
 
   container-scan:

--- a/docs/en/dev/performance.md
+++ b/docs/en/dev/performance.md
@@ -19,12 +19,22 @@ The command executes the default workloads defined in
 `internal/perf/workloads.go`, prints a human-readable diff, and exits non-zero
 if any metric regresses by more than the configured threshold (10% by default).
 
+The harness records throughput (URLs/events per second), CPU seconds, memory
+per event, and error rate. Dynamic workloads simulate JavaScript-heavy pages by
+increasing the amount of synthetic work performed for each finding; tune the
+`dynamic_work` field in `internal/perf/workloads.go` to model more complex
+applications.
+
 To regenerate metrics without failing the build you can omit the baseline and
 capture a fresh report:
 
 ```bash
-go run ./cmd/perfbench --output perf/results/latest.json
+go run ./cmd/perfbench --output perf/results/latest.json --history perf/results/history.jsonl --history-markdown perf/results/history.md
 ```
+
+The optional `--history` flag accumulates runs into a JSONL file, while
+`--history-markdown` renders a Markdown summary with sparklines so CI logs and
+PRs can visualise trends over time.
 
 ## Updating the baseline
 

--- a/docs/en/versions/v1.0/dev/performance.md
+++ b/docs/en/versions/v1.0/dev/performance.md
@@ -19,12 +19,22 @@ The command executes the default workloads defined in
 `internal/perf/workloads.go`, prints a human-readable diff, and exits non-zero
 if any metric regresses by more than the configured threshold (10% by default).
 
+The harness records throughput (URLs/events per second), CPU seconds, memory
+per event, and error rate. Dynamic workloads simulate JavaScript-heavy pages by
+increasing the amount of synthetic work performed for each finding; tune the
+`dynamic_work` field in `internal/perf/workloads.go` to model more complex
+applications.
+
 To regenerate metrics without failing the build you can omit the baseline and
 capture a fresh report:
 
 ```bash
-go run ./cmd/perfbench --output perf/results/latest.json
+go run ./cmd/perfbench --output perf/results/latest.json --history perf/results/history.jsonl --history-markdown perf/results/history.md
 ```
+
+The optional `--history` flag accumulates runs into a JSONL file, while
+`--history-markdown` renders a Markdown summary with sparklines so CI logs and
+PRs can visualise trends over time.
 
 ## Updating the baseline
 

--- a/docs/en/versions/v2.0/dev/performance.md
+++ b/docs/en/versions/v2.0/dev/performance.md
@@ -19,12 +19,22 @@ The command executes the default workloads defined in
 `internal/perf/workloads.go`, prints a human-readable diff, and exits non-zero
 if any metric regresses by more than the configured threshold (10% by default).
 
+The harness records throughput (URLs/events per second), CPU seconds, memory
+per event, and error rate. Dynamic workloads simulate JavaScript-heavy pages by
+increasing the amount of synthetic work performed for each finding; tune the
+`dynamic_work` field in `internal/perf/workloads.go` to model more complex
+applications.
+
 To regenerate metrics without failing the build you can omit the baseline and
 capture a fresh report:
 
 ```bash
-go run ./cmd/perfbench --output perf/results/latest.json
+go run ./cmd/perfbench --output perf/results/latest.json --history perf/results/history.jsonl --history-markdown perf/results/history.md
 ```
+
+The optional `--history` flag accumulates runs into a JSONL file, while
+`--history-markdown` renders a Markdown summary with sparklines so CI logs and
+PRs can visualise trends over time.
 
 ## Updating the baseline
 

--- a/internal/perf/history.go
+++ b/internal/perf/history.go
@@ -1,0 +1,231 @@
+package perf
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HistoryPoint captures the headline metrics for a workload at a point in time.
+type HistoryPoint struct {
+	Timestamp           time.Time `json:"timestamp"`
+	GitRef              string    `json:"git_ref"`
+	Workload            string    `json:"workload"`
+	Throughput          float64   `json:"throughput_eps"`
+	CPUSeconds          float64   `json:"cpu_seconds"`
+	ErrorRate           float64   `json:"error_rate"`
+	MemoryBytesPerEvent float64   `json:"memory_bytes_per_event"`
+}
+
+// UpdateHistory appends the current report metrics to the supplied history file
+// and returns the complete timeline sorted by timestamp.
+func UpdateHistory(path string, report Report) ([]HistoryPoint, error) {
+	history, err := LoadHistory(path)
+	if err != nil {
+		return nil, err
+	}
+	for _, wl := range report.Workloads {
+		history = append(history, HistoryPoint{
+			Timestamp:           report.Timestamp,
+			GitRef:              report.GitRef,
+			Workload:            wl.Name,
+			Throughput:          wl.Throughput,
+			CPUSeconds:          wl.CPUSeconds,
+			ErrorRate:           wl.ErrorRate,
+			MemoryBytesPerEvent: wl.Memory.BytesPerEvent,
+		})
+	}
+	sort.Slice(history, func(i, j int) bool {
+		if history[i].Workload == history[j].Workload {
+			return history[i].Timestamp.Before(history[j].Timestamp)
+		}
+		return history[i].Workload < history[j].Workload
+	})
+	if len(history) > 0 {
+		// Keep the most recent 120 entries per workload (~1 year of daily runs).
+		grouped := make(map[string][]HistoryPoint)
+		for _, pt := range history {
+			grouped[pt.Workload] = append(grouped[pt.Workload], pt)
+		}
+		trimmed := make([]HistoryPoint, 0, len(history))
+		for _, pts := range grouped {
+			if len(pts) > 120 {
+				pts = pts[len(pts)-120:]
+			}
+			trimmed = append(trimmed, pts...)
+		}
+		history = trimmed
+	}
+	sort.Slice(history, func(i, j int) bool {
+		if history[i].Workload == history[j].Workload {
+			return history[i].Timestamp.Before(history[j].Timestamp)
+		}
+		return history[i].Workload < history[j].Workload
+	})
+	if err := saveHistory(path, history); err != nil {
+		return nil, err
+	}
+	return history, nil
+}
+
+// LoadHistory reads all points from the history file. It returns an empty slice
+// if the file does not exist.
+func LoadHistory(path string) ([]HistoryPoint, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	history := make([]HistoryPoint, 0)
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var pt HistoryPoint
+		if err := json.Unmarshal([]byte(line), &pt); err != nil {
+			return nil, fmt.Errorf("parse history line: %w", err)
+		}
+		history = append(history, pt)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(history, func(i, j int) bool {
+		if history[i].Workload == history[j].Workload {
+			return history[i].Timestamp.Before(history[j].Timestamp)
+		}
+		return history[i].Workload < history[j].Workload
+	})
+	return history, nil
+}
+
+func saveHistory(path string, history []HistoryPoint) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	writer := bufio.NewWriter(file)
+	encoder := json.NewEncoder(writer)
+	for _, pt := range history {
+		if err := encoder.Encode(pt); err != nil {
+			return err
+		}
+	}
+	return writer.Flush()
+}
+
+// SaveHistoryMarkdown renders a Markdown summary to the supplied path using the
+// provided history points.
+func SaveHistoryMarkdown(path string, history []HistoryPoint) error {
+	summary := RenderHistoryMarkdown(history)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(summary), 0o644)
+}
+
+// RenderHistoryMarkdown converts the supplied history into a Markdown report
+// with sparklines for throughput, CPU, and error rates.
+func RenderHistoryMarkdown(history []HistoryPoint) string {
+	if len(history) == 0 {
+		return "# Performance history\n\n_No data collected yet._\n"
+	}
+	grouped := make(map[string][]HistoryPoint)
+	for _, pt := range history {
+		grouped[pt.Workload] = append(grouped[pt.Workload], pt)
+	}
+	workloads := make([]string, 0, len(grouped))
+	for name := range grouped {
+		workloads = append(workloads, name)
+	}
+	sort.Strings(workloads)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Performance history\n\nGenerated %s with %d samples.\n\n", time.Now().UTC().Format(time.RFC3339), len(history))
+	for _, name := range workloads {
+		pts := grouped[name]
+		sort.Slice(pts, func(i, j int) bool { return pts[i].Timestamp.Before(pts[j].Timestamp) })
+		throughput := make([]float64, 0, len(pts))
+		cpu := make([]float64, 0, len(pts))
+		errors := make([]float64, 0, len(pts))
+		for _, pt := range pts {
+			throughput = append(throughput, pt.Throughput)
+			cpu = append(cpu, pt.CPUSeconds)
+			errors = append(errors, pt.ErrorRate)
+		}
+		fmt.Fprintf(&b, "## %s\n\n", name)
+		fmt.Fprintf(&b, "Throughput (events/s): `%s`\n\n", sparkline(throughput))
+		fmt.Fprintf(&b, "CPU seconds: `%s`\n\n", sparkline(cpu))
+		fmt.Fprintf(&b, "Error rate: `%s`\n\n", sparkline(errors))
+		fmt.Fprintf(&b, "| Timestamp | Git ref | Events/s | CPU (s) | Error rate | Bytes/event |\n")
+		fmt.Fprintf(&b, "| --- | --- | --- | --- | --- | --- |\n")
+		for i := len(pts) - 1; i >= 0 && i >= len(pts)-10; i-- {
+			pt := pts[i]
+			fmt.Fprintf(&b, "| %s | %s | %.0f | %.2f | %.3f | %.0f |\n",
+				pt.Timestamp.Format(time.RFC3339),
+				orDefault(pt.GitRef, "-"),
+				pt.Throughput,
+				pt.CPUSeconds,
+				pt.ErrorRate,
+				pt.MemoryBytesPerEvent,
+			)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func sparkline(values []float64) string {
+	if len(values) == 0 {
+		return ""
+	}
+	const charset = "▁▂▃▄▅▆▇█"
+	runes := []rune(charset)
+	min := values[0]
+	max := values[0]
+	for _, v := range values[1:] {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	if max == min {
+		return strings.Repeat(string(runes[0]), len(values))
+	}
+	span := max - min
+	var b strings.Builder
+	for _, v := range values {
+		idx := int((v - min) / span * float64(len(runes)-1))
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(runes) {
+			idx = len(runes) - 1
+		}
+		b.WriteRune(runes[idx])
+	}
+	return b.String()
+}
+
+func orDefault(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}

--- a/internal/perf/history_test.go
+++ b/internal/perf/history_test.go
@@ -1,0 +1,76 @@
+package perf
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func TestUpdateHistoryAndMarkdown(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "history.jsonl")
+
+	report := Report{
+		Timestamp: time.Date(2024, 10, 10, 15, 0, 0, 0, time.UTC),
+		GitRef:    "abc123",
+		Workloads: []BusWorkloadMetrics{{
+			Name:       "fanout",
+			Throughput: 2000,
+			CPUSeconds: 1.5,
+			ErrorRate:  0.01,
+			Memory: MemoryMetrics{
+				BytesPerEvent: 512,
+			},
+		}},
+	}
+
+	history, err := UpdateHistory(path, report)
+	if err != nil {
+		t.Fatalf("update history: %v", err)
+	}
+	if got := len(history); got != 1 {
+		t.Fatalf("expected 1 history entry, got %d", got)
+	}
+
+	// Append a newer run to ensure chronological ordering is preserved and
+	// the data is persisted to disk.
+	newer := report
+	newer.Timestamp = newer.Timestamp.Add(24 * time.Hour)
+	newer.GitRef = "def456"
+	newer.Workloads[0].Throughput = 2400
+	newer.Workloads[0].CPUSeconds = 1.2
+
+	history, err = UpdateHistory(path, newer)
+	if err != nil {
+		t.Fatalf("update history second run: %v", err)
+	}
+	if got := len(history); got != 2 {
+		t.Fatalf("expected 2 entries, got %d", got)
+	}
+	if history[0].GitRef != "abc123" || history[1].GitRef != "def456" {
+		t.Fatalf("unexpected ordering: %+v", history)
+	}
+
+	md := RenderHistoryMarkdown(history)
+	if !strings.Contains(md, "fanout") {
+		t.Fatalf("markdown missing workload name: %s", md)
+	}
+	if !strings.Contains(md, "abc123") || !strings.Contains(md, "def456") {
+		t.Fatalf("markdown missing git refs: %s", md)
+	}
+}
+
+func TestSparklineConstant(t *testing.T) {
+	t.Parallel()
+	const length = 5
+	line := sparkline([]float64{3, 3, 3, 3, 3})
+	if utf8.RuneCountInString(line) != length {
+		t.Fatalf("expected sparkline length %d, got %d", length, len(line))
+	}
+	if line != strings.Repeat("▁", length) {
+		t.Fatalf("unexpected constant sparkline: %q", line)
+	}
+}

--- a/internal/perf/report.go
+++ b/internal/perf/report.go
@@ -84,7 +84,7 @@ func CompareReports(baseline, current Report, threshold float64) DiffResult {
 	for _, wl := range baseline.Workloads {
 		baseMap[wl.Name] = wl
 	}
-	deltas := make([]MetricDelta, 0, len(current.Workloads)*4)
+	deltas := make([]MetricDelta, 0, len(current.Workloads)*5)
 	for _, curr := range current.Workloads {
 		base, ok := baseMap[curr.Name]
 		if !ok {
@@ -95,6 +95,7 @@ func CompareReports(baseline, current Report, threshold float64) DiffResult {
 			throughputDelta(curr.Name, base, curr, threshold),
 			latencyDelta(curr.Name, "latency_p95_ms", base.Latency.P95, curr.Latency.P95, threshold),
 			memoryDelta(curr.Name, base.Memory.BytesPerEvent, curr.Memory.BytesPerEvent, threshold),
+			cpuDelta(curr.Name, base.CPUSeconds, curr.CPUSeconds, threshold),
 			errorRateDelta(curr.Name, base.ErrorRate, curr.ErrorRate, threshold),
 		)
 	}
@@ -127,6 +128,10 @@ func latencyDelta(workload, metric string, base, curr float64, threshold float64
 
 func memoryDelta(workload string, base, curr float64, threshold float64) MetricDelta {
 	return makeDelta(workload, "memory_bytes_per_event", "bytes/event", "lower", base, curr, threshold)
+}
+
+func cpuDelta(workload string, base, curr float64, threshold float64) MetricDelta {
+	return makeDelta(workload, "cpu_seconds", "seconds", "lower", base, curr, threshold)
 }
 
 func errorRateDelta(workload string, base, curr float64, threshold float64) MetricDelta {

--- a/internal/perf/report_test.go
+++ b/internal/perf/report_test.go
@@ -1,0 +1,29 @@
+package perf
+
+import "testing"
+
+func TestCPUDeltaRegression(t *testing.T) {
+	t.Parallel()
+	base := BusWorkloadMetrics{CPUSeconds: 1.0}
+	curr := BusWorkloadMetrics{CPUSeconds: 1.25}
+	delta := cpuDelta("fanout", base.CPUSeconds, curr.CPUSeconds, 0.10)
+	if !delta.Regression {
+		t.Fatalf("expected regression when CPU increases by >10%%: %+v", delta)
+	}
+	if delta.ChangePercent <= 0 {
+		t.Fatalf("expected positive change percent, got %.2f", delta.ChangePercent)
+	}
+}
+
+func TestCPUDeltaImprovement(t *testing.T) {
+	t.Parallel()
+	base := BusWorkloadMetrics{CPUSeconds: 2.0}
+	curr := BusWorkloadMetrics{CPUSeconds: 1.5}
+	delta := cpuDelta("fanout", base.CPUSeconds, curr.CPUSeconds, 0.10)
+	if delta.Regression {
+		t.Fatalf("did not expect regression when CPU decreased: %+v", delta)
+	}
+	if delta.ChangePercent >= 0 {
+		t.Fatalf("expected negative change percent for improvement: %.2f", delta.ChangePercent)
+	}
+}

--- a/internal/perf/workloads.go
+++ b/internal/perf/workloads.go
@@ -13,6 +13,7 @@ var DefaultBusWorkloads = []BusWorkloadConfig{
 		PayloadBytes: 256,
 		FailureRate:  0,
 		Seed:         42,
+		DynamicWork:  2,
 	},
 	{
 		Name:         "fanout_deep",
@@ -23,6 +24,7 @@ var DefaultBusWorkloads = []BusWorkloadConfig{
 		PayloadBytes: 384,
 		FailureRate:  0,
 		Seed:         84,
+		DynamicWork:  3,
 	},
 	{
 		Name:         "high_concurrency",
@@ -33,5 +35,17 @@ var DefaultBusWorkloads = []BusWorkloadConfig{
 		PayloadBytes: 192,
 		FailureRate:  0,
 		Seed:         126,
+		DynamicWork:  1,
+	},
+	{
+		Name:         "dynamic_content",
+		FanOut:       10,
+		Depth:        2,
+		Concurrency:  12,
+		Events:       9000,
+		PayloadBytes: 320,
+		FailureRate:  0.02,
+		Seed:         512,
+		DynamicWork:  5,
 	},
 }

--- a/perf/baseline/findings_bus_v1.0.json
+++ b/perf/baseline/findings_bus_v1.0.json
@@ -1,7 +1,7 @@
 {
-  "version": "v1.0.0",
-  "timestamp": "2025-10-05T19:46:06.066188056Z",
-  "git_ref": "7bf9d9f",
+  "version": "v1.1.0",
+  "timestamp": "2025-10-07T12:34:51.796844231Z",
+  "git_ref": "c8c1383",
   "workloads": [
     {
       "name": "fanout_wide",
@@ -13,25 +13,27 @@
         "events": 6000,
         "payload_bytes": 256,
         "failure_rate": 0,
-        "seed": 42
+        "seed": 42,
+        "dynamic_work": 2
       },
-      "duration": 26521322,
+      "duration": 23566808,
       "successes": 6000,
       "errors": 0,
-      "throughput_eps": 226233.06636071912,
+      "throughput_eps": 254595.36140829933,
       "error_rate": 0,
       "latency": {
-        "p50_ms": 0.057784,
-        "p95_ms": 0.528366,
-        "p99_ms": 0.961978,
-        "max_ms": 3.054844
+        "p50_ms": 0.05679,
+        "p95_ms": 0.463751,
+        "p99_ms": 0.970254,
+        "max_ms": 3.202009
       },
       "memory": {
-        "bytes_total": 3511920,
-        "bytes_per_event": 585.32,
+        "bytes_total": 3528480,
+        "bytes_per_event": 588.08,
         "peak_goroutines": 40,
         "baseline_goroutines": 35
-      }
+      },
+      "cpu_seconds": 0.083584242
     },
     {
       "name": "fanout_deep",
@@ -43,25 +45,27 @@
         "events": 8000,
         "payload_bytes": 384,
         "failure_rate": 0,
-        "seed": 84
+        "seed": 84,
+        "dynamic_work": 3
       },
-      "duration": 35748599,
+      "duration": 43360299,
       "successes": 8000,
       "errors": 0,
-      "throughput_eps": 223784.9936440866,
+      "throughput_eps": 184500.57274743426,
       "error_rate": 0,
       "latency": {
-        "p50_ms": 0.154005,
-        "p95_ms": 0.497054,
-        "p99_ms": 0.943996,
-        "max_ms": 1.570654
+        "p50_ms": 0.190771,
+        "p95_ms": 0.583748,
+        "p99_ms": 0.977714,
+        "max_ms": 4.860315
       },
       "memory": {
-        "bytes_total": 4692488,
-        "bytes_per_event": 586.561,
+        "bytes_total": 4699872,
+        "bytes_per_event": 587.484,
         "peak_goroutines": 38,
         "baseline_goroutines": 29
-      }
+      },
+      "cpu_seconds": 0.137277096
     },
     {
       "name": "high_concurrency",
@@ -73,25 +77,59 @@
         "events": 10000,
         "payload_bytes": 192,
         "failure_rate": 0,
-        "seed": 126
+        "seed": 126,
+        "dynamic_work": 1
       },
-      "duration": 47802959,
+      "duration": 26683776,
       "successes": 10000,
       "errors": 0,
-      "throughput_eps": 209192.07114354573,
+      "throughput_eps": 374759.5542699804,
       "error_rate": 0,
       "latency": {
-        "p50_ms": 0.065912,
-        "p95_ms": 0.309625,
-        "p99_ms": 0.771782,
-        "max_ms": 24.384567
+        "p50_ms": 0.074001,
+        "p95_ms": 0.334285,
+        "p99_ms": 0.660446,
+        "max_ms": 1.457482
       },
       "memory": {
-        "bytes_total": 5872400,
-        "bytes_per_event": 587.24,
+        "bytes_total": 5895472,
+        "bytes_per_event": 589.5472,
         "peak_goroutines": 45,
         "baseline_goroutines": 28
-      }
+      },
+      "cpu_seconds": 0.083280093
+    },
+    {
+      "name": "dynamic_content",
+      "config": {
+        "name": "dynamic_content",
+        "fan_out": 10,
+        "depth": 2,
+        "concurrency": 12,
+        "events": 9000,
+        "payload_bytes": 320,
+        "failure_rate": 0.02,
+        "seed": 512,
+        "dynamic_work": 5
+      },
+      "duration": 66920022,
+      "successes": 8804,
+      "errors": 196,
+      "throughput_eps": 131560.0284769781,
+      "error_rate": 0.021777777777777778,
+      "latency": {
+        "p50_ms": 0.139256,
+        "p95_ms": 0.722605,
+        "p99_ms": 1.62616,
+        "max_ms": 27.566444
+      },
+      "memory": {
+        "bytes_total": 5272272,
+        "bytes_per_event": 585.808,
+        "peak_goroutines": 47,
+        "baseline_goroutines": 34
+      },
+      "cpu_seconds": 0.20316603299999997
     }
   ]
 }

--- a/perf/history/findings_bus.jsonl
+++ b/perf/history/findings_bus.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2025-10-07T12:34:51.796844231Z","git_ref":"c8c1383","workload":"dynamic_content","throughput_eps":131560.0284769781,"cpu_seconds":0.20316603299999997,"error_rate":0.021777777777777778,"memory_bytes_per_event":585.808}
+{"timestamp":"2025-10-07T12:34:51.796844231Z","git_ref":"c8c1383","workload":"fanout_deep","throughput_eps":184500.57274743426,"cpu_seconds":0.137277096,"error_rate":0,"memory_bytes_per_event":587.484}
+{"timestamp":"2025-10-07T12:34:51.796844231Z","git_ref":"c8c1383","workload":"fanout_wide","throughput_eps":254595.36140829933,"cpu_seconds":0.083584242,"error_rate":0,"memory_bytes_per_event":588.08}
+{"timestamp":"2025-10-07T12:34:51.796844231Z","git_ref":"c8c1383","workload":"high_concurrency","throughput_eps":374759.5542699804,"cpu_seconds":0.083280093,"error_rate":0,"memory_bytes_per_event":589.5472}

--- a/perf/history/findings_bus.jsonl.md
+++ b/perf/history/findings_bus.jsonl.md
@@ -1,0 +1,52 @@
+# Performance history
+
+Generated 2025-10-07T12:35:21Z with 4 samples.
+
+## dynamic_content
+
+Throughput (events/s): `▁`
+
+CPU seconds: `▁`
+
+Error rate: `▁`
+
+| Timestamp | Git ref | Events/s | CPU (s) | Error rate | Bytes/event |
+| --- | --- | --- | --- | --- | --- |
+| 2025-10-07T12:34:51Z | c8c1383 | 131560 | 0.20 | 0.022 | 586 |
+
+## fanout_deep
+
+Throughput (events/s): `▁`
+
+CPU seconds: `▁`
+
+Error rate: `▁`
+
+| Timestamp | Git ref | Events/s | CPU (s) | Error rate | Bytes/event |
+| --- | --- | --- | --- | --- | --- |
+| 2025-10-07T12:34:51Z | c8c1383 | 184501 | 0.14 | 0.000 | 587 |
+
+## fanout_wide
+
+Throughput (events/s): `▁`
+
+CPU seconds: `▁`
+
+Error rate: `▁`
+
+| Timestamp | Git ref | Events/s | CPU (s) | Error rate | Bytes/event |
+| --- | --- | --- | --- | --- | --- |
+| 2025-10-07T12:34:51Z | c8c1383 | 254595 | 0.08 | 0.000 | 588 |
+
+## high_concurrency
+
+Throughput (events/s): `▁`
+
+CPU seconds: `▁`
+
+Error rate: `▁`
+
+| Timestamp | Git ref | Events/s | CPU (s) | Error rate | Bytes/event |
+| --- | --- | --- | --- | --- | --- |
+| 2025-10-07T12:34:51Z | c8c1383 | 374760 | 0.08 | 0.000 | 590 |
+


### PR DESCRIPTION
## Summary
- capture CPU usage and dynamic workload tuning in perfbench while seeding the baseline with the new metrics
- persist benchmark history to JSONL/Markdown via new CLI flags and surface the data in CI artifacts
- document the enhanced harness workflow and check the new functionality with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e506a2bcf8832abc93b31d29f974a7