### PR TITLE
Implement secrets broker token rotation, revocation, and auditing

### DIFF
--- a/internal/logging/audit.go
+++ b/internal/logging/audit.go
@@ -15,21 +15,23 @@ import (
 type EventType string
 
 const (
-	EventPluginLoad       EventType = "plugin_load"
-	EventPluginDisconnect EventType = "plugin_disconnect"
-	EventCapabilityGrant  EventType = "capability_grant"
-	EventCapabilityDenied EventType = "capability_denied"
-	EventRPCCall          EventType = "rpc_call"
-	EventRPCDenied        EventType = "rpc_denied"
-	EventScopeViolation   EventType = "scope_violation"
-	EventFindingReceived  EventType = "finding_received"
-	EventFindingRejected  EventType = "finding_rejected"
-	EventProxyLifecycle   EventType = "proxy_lifecycle"
-	EventReporter         EventType = "reporter_event"
-	EventSecretsToken     EventType = "secrets_token_issue"
-	EventSecretsAccess    EventType = "secrets_access"
-	EventSecretsDenied    EventType = "secrets_denied"
-	EventNetworkDenied    EventType = "network_denied"
+	EventPluginLoad         EventType = "plugin_load"
+	EventPluginDisconnect   EventType = "plugin_disconnect"
+	EventCapabilityGrant    EventType = "capability_grant"
+	EventCapabilityDenied   EventType = "capability_denied"
+	EventRPCCall            EventType = "rpc_call"
+	EventRPCDenied          EventType = "rpc_denied"
+	EventScopeViolation     EventType = "scope_violation"
+	EventFindingReceived    EventType = "finding_received"
+	EventFindingRejected    EventType = "finding_rejected"
+	EventProxyLifecycle     EventType = "proxy_lifecycle"
+	EventReporter           EventType = "reporter_event"
+	EventSecretsToken       EventType = "secrets_token_issue"
+	EventSecretsAccess      EventType = "secrets_access"
+	EventSecretsDenied      EventType = "secrets_denied"
+	EventSecretsTokenRev    EventType = "secrets_token_revoked"
+	EventSecretsTokenExpiry EventType = "secrets_token_expired"
+	EventNetworkDenied      EventType = "network_denied"
 )
 
 type Decision string

--- a/internal/secrets/manager_test.go
+++ b/internal/secrets/manager_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/RowanDark/Glyph/internal/logging"
 )
 
 func TestManagerIssueAndResolve(t *testing.T) {
@@ -43,6 +45,52 @@ func TestManagerIssueAndResolve(t *testing.T) {
 	current = current.Add(5 * time.Minute)
 	if _, err := mgr.Resolve(token, "seer", "run-1", "API_TOKEN"); !errors.Is(err, ErrTokenExpired) {
 		t.Fatalf("expected ErrTokenExpired after ttl, got %v", err)
+	}
+}
+
+func TestManagerRevocation(t *testing.T) {
+	current := time.Unix(0, 0).UTC()
+	clock := func() time.Time { return current }
+	logger, buf := newTestAuditLogger(t)
+	mgr := NewManager(map[string]map[string]string{
+		"seer": {"api_token": "super-secret"},
+	}, WithClock(clock), WithAuditLogger(logger))
+
+	token, _, err := mgr.Issue("seer", "run-42", []string{"API_TOKEN"})
+	if err != nil {
+		t.Fatalf("Issue returned error: %v", err)
+	}
+	if err := mgr.Revoke(token); err != nil {
+		t.Fatalf("Revoke returned error: %v", err)
+	}
+	if _, err := mgr.Resolve(token, "seer", "run-42", "API_TOKEN"); !errors.Is(err, ErrTokenRevoked) {
+		t.Fatalf("expected ErrTokenRevoked, got %v", err)
+	}
+	events := decodeAuditEvents(t, buf.Bytes())
+	if !containsEvent(events, logging.EventSecretsTokenRev) {
+		t.Fatalf("expected revocation audit event, got %#v", events)
+	}
+}
+
+func TestManagerLogsExpiry(t *testing.T) {
+	current := time.Unix(0, 0).UTC()
+	clock := func() time.Time { return current }
+	logger, buf := newTestAuditLogger(t)
+	mgr := NewManager(map[string]map[string]string{
+		"seer": {"api_token": "super-secret"},
+	}, WithClock(clock), WithTTL(time.Minute), WithAuditLogger(logger))
+
+	token, _, err := mgr.Issue("seer", "run-42", []string{"API_TOKEN"})
+	if err != nil {
+		t.Fatalf("Issue returned error: %v", err)
+	}
+	current = current.Add(2 * time.Minute)
+	if _, err := mgr.Resolve(token, "seer", "run-42", "API_TOKEN"); !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("expected ErrTokenExpired, got %v", err)
+	}
+	events := decodeAuditEvents(t, buf.Bytes())
+	if !containsEvent(events, logging.EventSecretsTokenExpiry) {
+		t.Fatalf("expected expiry audit event, got %#v", events)
 	}
 }
 

--- a/internal/secrets/server.go
+++ b/internal/secrets/server.go
@@ -87,6 +87,7 @@ func (s *Server) handleResolveError(plugin, name string, err error) error {
 	switch {
 	case errors.Is(err, ErrTokenNotRecognised),
 		errors.Is(err, ErrTokenExpired),
+		errors.Is(err, ErrTokenRevoked),
 		errors.Is(err, ErrTokenPluginMismatch),
 		errors.Is(err, ErrTokenScopeMismatch),
 		errors.Is(err, ErrSecretNotGranted),

--- a/internal/secrets/testhelpers_test.go
+++ b/internal/secrets/testhelpers_test.go
@@ -1,0 +1,45 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/RowanDark/Glyph/internal/logging"
+)
+
+func newTestAuditLogger(t *testing.T) (*logging.AuditLogger, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	logger, err := logging.NewAuditLogger("test", logging.WithoutStdout(), logging.WithWriter(buf))
+	if err != nil {
+		t.Fatalf("create audit logger: %v", err)
+	}
+	return logger, buf
+}
+
+func decodeAuditEvents(t *testing.T, data []byte) []logging.AuditEvent {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
+	var events []logging.AuditEvent
+	for _, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var event logging.AuditEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			t.Fatalf("decode audit event: %v", err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func containsEvent(events []logging.AuditEvent, eventType logging.EventType) bool {
+	for _, event := range events {
+		if event.EventType == eventType {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- enforce per-token leases with explicit revocation support and audit logging in the secrets manager
- extend the broker to surface revoked tokens and emit denial events for expired tokens
- add regression coverage for expiry, revocation, and audit trails

## Testing
- go test ./internal/secrets...


------
https://chatgpt.com/codex/tasks/task_e_68e50d9df6dc832aaf585848e425fef3