### PR TITLE
feat: expand Windows packaging automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
   goreleaser:
     name: GoReleaser
     runs-on: ubuntu-latest
+    env:
+      WINDOWS_CODESIGN_PFX: ${{ secrets.WINDOWS_CODESIGN_PFX }}
+      WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,8 +51,45 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install msitools
-        run: sudo apt-get update && sudo apt-get install -y msitools
+      - name: Install packaging dependencies
+        run: sudo apt-get update && sudo apt-get install -y msitools osslsigncode
+
+      - name: Sign Windows binaries
+        if: env.WINDOWS_CODESIGN_PFX != ''
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cert=$(mktemp)
+          trap 'rm -f "$cert"' EXIT
+          echo "$WINDOWS_CODESIGN_PFX" | base64 -d >"$cert"
+          shopt -s nullglob
+          for archive in dist/glyphctl_${TAG}_windows_*.zip; do
+            workdir=$(mktemp -d)
+            unzip -q "$archive" -d "$workdir"
+            if [[ ! -f "$workdir/glyphctl.exe" ]]; then
+              echo "glyphctl.exe missing from $archive" >&2
+              exit 1
+            fi
+            if [[ -n "${WINDOWS_CODESIGN_PASSWORD:-}" ]]; then
+              pass_args=(-pass "$WINDOWS_CODESIGN_PASSWORD")
+            else
+              pass_args=()
+            fi
+            osslsigncode sign \
+              -pkcs12 "$cert" \
+              "${pass_args[@]}" \
+              -n "Glyph CLI" \
+              -i "https://github.com/RowanDark/Glyph" \
+              -t "http://timestamp.digicert.com" \
+              -in "$workdir/glyphctl.exe" \
+              -out "$workdir/glyphctl-signed.exe"
+            mv "$workdir/glyphctl-signed.exe" "$workdir/glyphctl.exe"
+            rm -f "$archive"
+            (cd "$workdir" && zip -r9 "$OLDPWD/$(basename "$archive")" .)
+            rm -rf "$workdir"
+            echo "Signed $archive"
+          done
 
       - name: Build Windows installers
         env:

--- a/.github/workflows/windows-install.yml
+++ b/.github/workflows/windows-install.yml
@@ -33,6 +33,41 @@ jobs:
           Copy-Item LICENSE (Join-Path $portable 'LICENSE.txt')
           Compress-Archive -Path "$portable\*" -DestinationPath dist/glyphctl_ci_windows_portable.zip -Force
 
+      - name: Install WiX Toolset
+        shell: pwsh
+        run: choco install wixtoolset --no-progress --yes
+
+      - name: Build MSI installer
+        shell: pwsh
+        run: |
+          $script = (Resolve-Path 'scripts/build_windows_installer.ps1').Path
+          $payload = (Resolve-Path 'dist').Path
+          & $script -Tag 'v0.0.0-ci' -Arch 'amd64' -PayloadDir $payload -OutputDir $payload
+
+      - name: Smoke test MSI install
+        shell: pwsh
+        run: |
+          $msi = (Resolve-Path 'dist/glyphctl_v0.0.0-ci_windows_amd64.msi').Path
+          Start-Process msiexec.exe -ArgumentList "/i `"$msi`" /qn /norestart" -Wait
+          $glyph = Join-Path $env:ProgramFiles 'Glyph\glyphctl.exe'
+          if (-not (Test-Path $glyph -PathType Leaf)) {
+            throw "glyphctl.exe was not installed"
+          }
+          & $glyph --version
+          $artifact = (Resolve-Path 'plugins/samples/passive-header-scan/main.go').Path
+          $hash = (Get-FileHash $artifact -Algorithm SHA256).Hash
+          & $glyph plugin verify $artifact --hash $hash
+
+      - name: Uninstall MSI
+        shell: pwsh
+        run: |
+          $msi = (Resolve-Path 'dist/glyphctl_v0.0.0-ci_windows_amd64.msi').Path
+          Start-Process msiexec.exe -ArgumentList "/x `"$msi`" /qn /norestart" -Wait
+          $glyphDir = Join-Path $env:ProgramFiles 'Glyph'
+          if (Test-Path $glyphDir) {
+            throw "Install directory still present after uninstall"
+          }
+
       - name: Smoke test portable build
         shell: pwsh
         run: |

--- a/docs/en/cli/windows.md
+++ b/docs/en/cli/windows.md
@@ -1,0 +1,86 @@
+# Windows installation
+
+Glyph ships Windows builds in two flavours: an MSI installer for system-wide
+deployments and a portable ZIP archive that runs without installation. Both
+variants are produced by the release workflow and validated in CI to ensure the
+version command and plugin subsystem operate correctly.
+
+## Installer (MSI)
+
+1. Download the `glyphctl_v<version>_windows_<arch>.msi` asset from the
+   [GitHub Releases page](https://github.com/RowanDark/Glyph/releases).
+2. Install it with the Windows Installer UI or from PowerShell:
+
+   ```powershell
+   msiexec /i .\glyphctl_v<version>_windows_amd64.msi /qn /norestart
+   ```
+
+   Replace `<arch>` with `amd64` or `arm64` depending on your platform.
+3. The installer places `glyphctl.exe` under `C:\Program Files\Glyph`, amends the
+   system `PATH`, and registers an uninstall entry. Open a new PowerShell
+   session and confirm the CLI is reachable:
+
+   ```powershell
+   glyphctl --version
+   ```
+
+   You can remove Glyph at any point with:
+
+   ```powershell
+   msiexec /x .\glyphctl_v<version>_windows_amd64.msi /qn /norestart
+   ```
+
+## Portable ZIP
+
+Each release also provides `glyphctl_v<version>_windows_<arch>.zip`. Extract it
+anywhere (for example, under `C:\Tools\Glyph`) and run the CLI without touching
+system state:
+
+```powershell
+Expand-Archive -Path .\glyphctl_v<version>_windows_amd64.zip -DestinationPath C:\Tools\Glyph
+C:\Tools\Glyph\glyphctl.exe --version
+```
+
+Portable archives bundle `LICENSE.txt` and `README.txt` alongside the binary so
+you can keep the documentation near the executable.
+
+## Scoop bucket
+
+If you prefer package managers, add the Glyph bucket to Scoop and install the
+manifest published from this repository:
+
+```powershell
+scoop bucket add glyph https://github.com/RowanDark/Glyph
+scoop install glyphctl
+glyphctl --version
+```
+
+Scoop installs the same signed binary shipped in the portable ZIP.
+
+## Verifying plugin support
+
+To confirm plugin loading works, point `glyphctl` at one of the sample plugins
+shipped in the repository. Compute the SHA-256 hash and ask Glyph to verify it:
+
+```powershell
+$plugin = Resolve-Path 'plugins/samples/passive-header-scan/main.go'
+$hash = (Get-FileHash $plugin -Algorithm SHA256).Hash
+glyphctl plugin verify $plugin --hash $hash
+```
+
+A successful run prints `signature ok` and the plugin's metadata.
+
+## Code signing
+
+Releases sign Windows executables whenever the project maintains a code-signing
+certificate. The CI pipeline re-signs the `glyphctl.exe` included in each
+portable archive before building the MSI, so both distribution formats embed the
+same signature. To inspect it locally:
+
+```powershell
+Get-AuthenticodeSignature "C:\Program Files\Glyph\glyphctl.exe"
+```
+
+The output should report `Status : Valid` when a certificate is available. If no
+certificate is configured, the builds remain unsigned but the packaging and
+verification steps still run in CI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - CLI:
       - Overview: cli/index.md
       - Configuration: cli/configuration.md
+      - Windows installation: cli/windows.md
   - Developer Guide: dev-guide/index.md
   - Security:
       - Overview: security/index.md

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -1,0 +1,80 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Tag,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('amd64', 'arm64')]
+    [string]$Arch,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PayloadDir,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -Path $PayloadDir -PathType Container)) {
+    throw "Payload directory '$PayloadDir' does not exist."
+}
+
+switch ($Arch) {
+    'amd64' { $wixPlatform = 'x64' }
+    'arm64' { $wixPlatform = 'arm64' }
+    default { throw "Unsupported architecture: $Arch" }
+}
+
+$version = $Tag.TrimStart('v')
+if ([string]::IsNullOrWhiteSpace($version) -or $version -eq $Tag) {
+    throw "Could not derive version from tag '$Tag'."
+}
+
+$msiVersion = $version.Split('-', '+')[0]
+if ([string]::IsNullOrWhiteSpace($msiVersion)) {
+    throw "Tag '$Tag' does not contain a numeric version component."
+}
+
+if ($msiVersion -notmatch '^[0-9]+(\.[0-9]+){0,3}$') {
+    throw "Tag '$Tag' yields invalid MSI version '$msiVersion'. Expected 'major.minor.build(.revision)'."
+}
+
+$payloadExecutable = Join-Path -Path $PayloadDir -ChildPath 'glyphctl.exe'
+if (-not (Test-Path -Path $payloadExecutable -PathType Leaf)) {
+    throw "glyphctl.exe not found in payload directory '$PayloadDir'."
+}
+
+$tempDir = New-Item -ItemType Directory -Path (Join-Path -Path ([IO.Path]::GetTempPath()) -ChildPath ([IO.Path]::GetRandomFileName()))
+try {
+    $repoRoot = (Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '..')).Path
+    Copy-Item -Path $payloadExecutable -Destination (Join-Path -Path $tempDir -ChildPath 'glyphctl.exe')
+    Copy-Item -Path (Join-Path -Path $repoRoot -ChildPath 'README.md') -Destination (Join-Path -Path $tempDir -ChildPath 'README.txt')
+    Copy-Item -Path (Join-Path -Path $repoRoot -ChildPath 'LICENSE') -Destination (Join-Path -Path $tempDir -ChildPath 'LICENSE.txt')
+
+    $wxsPath = (Resolve-Path (Join-Path -Path $repoRoot -ChildPath 'packaging/windows/glyphctl.wxs')).Path
+    $wixObj = Join-Path -Path $tempDir -ChildPath 'glyphctl.wixobj'
+
+    & candle.exe "-dVersion=$msiVersion" "-dWixPlatform=$wixPlatform" "-dPayloadDir=$tempDir" "-out" $wixObj $wxsPath -ext WixUtilExtension
+    if ($LASTEXITCODE -ne 0) {
+        throw "candle.exe failed with exit code $LASTEXITCODE"
+    }
+
+    if (-not (Test-Path -Path $OutputDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $OutputDir | Out-Null
+    }
+
+    $outputPath = Join-Path -Path $OutputDir -ChildPath "glyphctl_${Tag}_windows_${Arch}.msi"
+    & light.exe "-out" $outputPath $wixObj -ext WixUtilExtension
+    if ($LASTEXITCODE -ne 0) {
+        throw "light.exe failed with exit code $LASTEXITCODE"
+    }
+
+    Write-Host "Built MSI: $outputPath"
+}
+finally {
+    if (Test-Path -Path $tempDir) {
+        Remove-Item -Path $tempDir -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary
- add a PowerShell helper to build the Glyph MSI installer on Windows runners
- extend the windows-install workflow to build, install, verify, and uninstall the MSI alongside the portable ZIP smoke test
- teach the release workflow to install signing tooling, optionally sign Windows archives, and document installation options

## Testing
- not run (CI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e5122f2ca0832ab05b4f08f11d8cac