### PR TITLE
Add tracing instrumentation and observability assets

### DIFF
--- a/docs/observability/alerts.yaml
+++ b/docs/observability/alerts.yaml
@@ -1,0 +1,34 @@
+groups:
+  - name: glyph-observability
+    rules:
+      - alert: GlyphPluginLatencyCritical
+        expr: histogram_quantile(0.95, sum(rate(glyph_plugin_event_duration_seconds_bucket[5m])) by (le, plugin)) > 5
+        for: 3m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Plugin {{ $labels.plugin }} processing is slow"
+          description: |
+            Glyph has spent more than 5 seconds (p95) handling plugin events for
+            {{ $labels.plugin }} during the last 5 minutes. Investigate plugin logs and traces
+            for long-running EventStream handlers.
+      - alert: GlyphHTTPFailureRate
+        expr: sum(rate(glyph_http_backoff_total[5m])) by (plugin) / sum(rate(glyph_http_request_duration_seconds_count[5m])) by (plugin) > 0.2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High HTTP error rate for plugin {{ $labels.plugin }}"
+          description: |
+            More than 20% of proxied HTTP requests for {{ $labels.plugin }} have resulted
+            in backoff-triggering responses during the last 5 minutes.
+      - alert: GlyphQueueBackpressure
+        expr: max_over_time(glyph_plugin_queue_length[2m]) > 80
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Plugin queue saturation"
+          description: |
+            The plugin outbound queue has exceeded 80 entries for more than two minutes,
+            indicating downstream pressure. Review queue depth and dispatch traces.

--- a/docs/observability/grafana-dashboard.json
+++ b/docs/observability/grafana-dashboard.json
@@ -1,0 +1,159 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1680000000000,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 },
+              { "color": "red", "value": 80 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "max_over_time(glyph_plugin_queue_length{job=~\"$job\",plugin=~\"$plugin\"}[5m])",
+          "legendFormat": "{{plugin}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Plugin Queue Depth",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 2 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(glyph_http_request_duration_seconds_bucket{job=~\"$job\",plugin=~\"$plugin\"}[5m])) by (le))",
+          "legendFormat": "95th percentile",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Latency (95th percentile)",
+      "type": "timeSeries"
+    },
+    {
+      "datasource": null,
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "displayMode": "gradient",
+        "legend": { "displayMode": "table" },
+        "reduceOptions": { "calcs": ["mean"], "fields": "", "values": false },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (component,method) (rate(glyph_rpc_duration_seconds_sum{job=~\"$job\"}[5m]) / rate(glyph_rpc_duration_seconds_count{job=~\"$job\"}[5m]))",
+          "legendFormat": "{{component}} :: {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPC Handler Duration (avg over 5m)",
+      "type": "heatmap"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["glyph"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "query": "label_values(glyph_rpc_requests_total, job)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": { "selected": false, "text": "all", "value": ".*" },
+        "datasource": "Prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Plugin",
+        "multi": false,
+        "name": "plugin",
+        "query": "label_values(glyph_plugin_queue_length, plugin)",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": { "refresh_intervals": ["10s", "30s", "1m", "5m"] },
+  "timezone": "",
+  "title": "Glyph Operations Overview",
+  "version": 1
+}

--- a/docs/observability/otel-collector.yaml
+++ b/docs/observability/otel-collector.yaml
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+exporters:
+  logging:
+    loglevel: warn
+  otlphttp/tempo:
+    endpoint: http://tempo:4318
+    tls:
+      insecure: true
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, otlphttp/tempo]

--- a/internal/bus/server_fuzz_test.go
+++ b/internal/bus/server_fuzz_test.go
@@ -83,7 +83,7 @@ func FuzzPluginRPCFraming(f *testing.F) {
 			eventChan:    make(chan *pb.HostEvent, 1),
 			capabilities: map[string]struct{}{CapEmitFindings: {}},
 		}
-		_ = srv.receiveEvents(recvStream, pluginConn, "fuzz-plugin")
+		_ = srv.receiveEvents(context.Background(), recvStream, pluginConn, "fuzz-plugin")
 	})
 }
 

--- a/internal/bus/server_test.go
+++ b/internal/bus/server_test.go
@@ -220,7 +220,7 @@ func TestPublishFindingEmitsToBus(t *testing.T) {
 		},
 	}
 
-	server.publishFinding("plugin-1", incoming)
+	server.publishFinding(ctx, "plugin-1", incoming)
 
 	select {
 	case finding := <-ch:

--- a/internal/logging/audit.go
+++ b/internal/logging/audit.go
@@ -50,6 +50,7 @@ type AuditEvent struct {
 	Metadata  map[string]any `json:"metadata,omitempty"`
 	Decision  Decision       `json:"decision,omitempty"`
 	Reason    string         `json:"reason,omitempty"`
+	TraceID   string         `json:"trace_id,omitempty"`
 }
 
 type Option func(*config) error

--- a/internal/observability/tracing/config.go
+++ b/internal/observability/tracing/config.go
@@ -1,0 +1,296 @@
+package tracing
+
+import (
+	"context"
+	crand "crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Config controls how tracing is initialised for the process.
+type Config struct {
+	// Endpoint is the optional OTLP/HTTP collector endpoint (e.g. http://collector:4318/v1/traces).
+	Endpoint string
+	// Headers are optional headers that should be included with OTLP requests.
+	Headers map[string]string
+	// SkipTLSVerify disables TLS verification when communicating with the collector.
+	SkipTLSVerify bool
+	// ServiceName is recorded on exported spans to identify the emitting service.
+	ServiceName string
+	// SampleRatio controls probabilistic sampling for root spans. Values outside the range
+	// (0,1] are clamped. A value of 0 disables tracing, whereas 1 samples all spans.
+	SampleRatio float64
+	// FilePath controls the location where a JSONL copy of spans is written. When empty,
+	// spans are not persisted locally.
+	FilePath string
+}
+
+var (
+	globalMu     sync.RWMutex
+	globalTracer *Tracer
+)
+
+// Setup configures the global tracer. The returned shutdown function must be invoked when
+// the process exits to ensure spans are flushed.
+func Setup(ctx context.Context, cfg Config) (func(context.Context) error, error) {
+	tracer, err := newTracer(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if tracer == nil {
+		return func(context.Context) error { return nil }, nil
+	}
+
+	globalMu.Lock()
+	if globalTracer != nil {
+		_ = globalTracer.Shutdown(ctx)
+	}
+	globalTracer = tracer
+	globalMu.Unlock()
+
+	return tracer.Shutdown, nil
+}
+
+// CurrentTracer returns the active tracer, or nil if tracing is disabled.
+func CurrentTracer() *Tracer {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return globalTracer
+}
+
+// Tracer represents the process level tracing configuration.
+type Tracer struct {
+	exporters   *exportManager
+	sampleRatio float64
+	serviceName string
+	rngMu       sync.Mutex
+	rng         *rand.Rand
+}
+
+func newTracer(cfg Config) (*Tracer, error) {
+	ratio := math.Max(0, math.Min(1, cfg.SampleRatio))
+	if ratio == 0 {
+		return nil, nil
+	}
+	exporters, err := newExportManager(cfg)
+	if err != nil {
+		return nil, err
+	}
+	seed, err := randInt64()
+	if err != nil {
+		return nil, err
+	}
+	tracer := &Tracer{
+		exporters:   exporters,
+		sampleRatio: ratio,
+		serviceName: strings.TrimSpace(cfg.ServiceName),
+		rng:         rand.New(rand.NewSource(seed)),
+	}
+	return tracer, nil
+}
+
+func randInt64() (int64, error) {
+	n, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return 0, err
+	}
+	return n.Int64(), nil
+}
+
+// Shutdown flushes exporters and releases resources.
+func (t *Tracer) Shutdown(ctx context.Context) error {
+	if t == nil {
+		return nil
+	}
+	if t.exporters == nil {
+		return nil
+	}
+	return t.exporters.shutdown(ctx)
+}
+
+// sampledRoot determines whether a new root span should be sampled.
+func (t *Tracer) sampledRoot() bool {
+	if t == nil {
+		return false
+	}
+	t.rngMu.Lock()
+	defer t.rngMu.Unlock()
+	return t.rng.Float64() < t.sampleRatio
+}
+
+// StartSpan begins a new span derived from ctx.
+func StartSpan(ctx context.Context, name string, opts ...SpanStartOption) (context.Context, Span) {
+	tracer := CurrentTracer()
+	if tracer == nil {
+		return ctx, noopSpan{}
+	}
+	cfg := spanConfig{kind: SpanKindInternal}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	parent := SpanContextFromContext(ctx)
+	spanVal, spanCtx := tracer.startSpan(parent, name, cfg)
+	combined := context.WithValue(ctx, spanContextKey{}, spanCtx)
+	if realSpan, ok := spanVal.(*span); ok {
+		combined = context.WithValue(combined, activeSpanKey{}, realSpan)
+	}
+	return combined, spanVal
+}
+
+// SpanFromContext retrieves the active span, returning a noop span if none exists.
+func SpanFromContext(ctx context.Context) Span {
+	if ctx == nil {
+		return noopSpan{}
+	}
+	if sp, ok := ctx.Value(activeSpanKey{}).(Span); ok && sp != nil {
+		return sp
+	}
+	return noopSpan{ctx: SpanContextFromContext(ctx)}
+}
+
+// SpanContextFromContext returns the span context stored on ctx.
+func SpanContextFromContext(ctx context.Context) SpanContext {
+	if ctx == nil {
+		return SpanContext{}
+	}
+	if sc, ok := ctx.Value(spanContextKey{}).(SpanContext); ok {
+		return sc
+	}
+	return SpanContext{}
+}
+
+// TraceIDFromContext extracts the trace identifier, or "" when unavailable.
+func TraceIDFromContext(ctx context.Context) string {
+	sc := SpanContextFromContext(ctx)
+	if !sc.Valid() {
+		return ""
+	}
+	return sc.TraceID
+}
+
+// WithSpanContext returns a new context containing sc.
+func WithSpanContext(ctx context.Context, sc SpanContext) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, spanContextKey{}, sc)
+}
+
+// SpanContext holds distributed tracing identity information.
+type SpanContext struct {
+	TraceID string
+	SpanID  string
+	Sampled bool
+}
+
+// Valid returns true when the context contains identifiers.
+func (sc SpanContext) Valid() bool {
+	return len(sc.TraceID) == 32 && len(sc.SpanID) == 16
+}
+
+func newTraceID() string {
+	b := make([]byte, 16)
+	if _, err := crand.Read(b); err != nil {
+		panic(fmt.Errorf("generate trace id: %w", err))
+	}
+	return hex.EncodeToString(b)
+}
+
+func newSpanID() string {
+	b := make([]byte, 8)
+	if _, err := crand.Read(b); err != nil {
+		panic(fmt.Errorf("generate span id: %w", err))
+	}
+	return hex.EncodeToString(b)
+}
+
+// SpanKind describes the role of the span relative to external systems.
+type SpanKind string
+
+const (
+	SpanKindInternal SpanKind = "internal"
+	SpanKindServer   SpanKind = "server"
+	SpanKindClient   SpanKind = "client"
+)
+
+type spanContextKey struct{}
+type activeSpanKey struct{}
+
+type spanConfig struct {
+	kind       SpanKind
+	attributes map[string]any
+}
+
+// SpanStartOption configures start behaviour for spans.
+type SpanStartOption interface{ apply(*spanConfig) }
+
+type spanStartOptionFunc func(*spanConfig)
+
+func (fn spanStartOptionFunc) apply(cfg *spanConfig) { fn(cfg) }
+
+// WithSpanKind sets the span kind.
+func WithSpanKind(kind SpanKind) SpanStartOption {
+	return spanStartOptionFunc(func(cfg *spanConfig) {
+		cfg.kind = kind
+	})
+}
+
+// WithAttributes attaches attributes to the span on start.
+func WithAttributes(attrs map[string]any) SpanStartOption {
+	return spanStartOptionFunc(func(cfg *spanConfig) {
+		if len(attrs) == 0 {
+			return
+		}
+		if cfg.attributes == nil {
+			cfg.attributes = make(map[string]any, len(attrs))
+		}
+		for k, v := range attrs {
+			cfg.attributes[k] = v
+		}
+	})
+}
+
+func cloneAttributes(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func (t *Tracer) startSpan(parent SpanContext, name string, cfg spanConfig) (Span, SpanContext) {
+	if t == nil {
+		return noopSpan{}, SpanContext{}
+	}
+	traceID := parent.TraceID
+	sampled := parent.Sampled
+	if !parent.Valid() {
+		sampled = t.sampledRoot()
+		traceID = newTraceID()
+	}
+	spanID := newSpanID()
+	sc := SpanContext{TraceID: traceID, SpanID: spanID, Sampled: sampled}
+	if !sampled {
+		return noopSpan{ctx: sc}, sc
+	}
+	s := &span{
+		tracer:      t,
+		context:     sc,
+		parent:      parent,
+		name:        name,
+		kind:        cfg.kind,
+		attributes:  cloneAttributes(cfg.attributes),
+		startTime:   time.Now(),
+		serviceName: t.serviceName,
+	}
+	return s, sc
+}

--- a/internal/observability/tracing/exporter.go
+++ b/internal/observability/tracing/exporter.go
@@ -156,16 +156,7 @@ type otlpExporter struct {
 
 func newOTLPExporter(endpoint string, headers map[string]string, skipTLS bool, service string) (*otlpExporter, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	if skipTLS {
-		allowInsecure := os.Getenv("ALLOW_INSECURE_TLS")
-		if allowInsecure != "1" && strings.ToLower(allowInsecure) != "true" {
-			return nil, fmt.Errorf("insecure TLS requested but not permitted; set ALLOW_INSECURE_TLS=1 to allow")
-		}
-		if transport.TLSClientConfig == nil {
-			transport.TLSClientConfig = &tls.Config{}
-		}
-		transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // allowed by explicit env override
-	}
+	// Do not disable TLS certificate verification in production code.
 	client := &http.Client{Timeout: 10 * time.Second, Transport: transport}
 	hdrs := make(map[string]string, len(headers))
 	for k, v := range headers {

--- a/internal/observability/tracing/exporter.go
+++ b/internal/observability/tracing/exporter.go
@@ -1,0 +1,298 @@
+package tracing
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type exporter interface {
+	Export(ctx context.Context, span *SpanSnapshot) error
+	Shutdown(ctx context.Context) error
+}
+
+type exportManager struct {
+	exporters []exporter
+	ch        chan *SpanSnapshot
+	wg        sync.WaitGroup
+}
+
+func newExportManager(cfg Config) (*exportManager, error) {
+	exps := make([]exporter, 0, 2)
+	if path := strings.TrimSpace(cfg.FilePath); path != "" {
+		fileExp, err := newFileExporter(path)
+		if err != nil {
+			return nil, err
+		}
+		exps = append(exps, fileExp)
+	}
+	if endpoint := strings.TrimSpace(cfg.Endpoint); endpoint != "" {
+		otlp, err := newOTLPExporter(endpoint, cfg.Headers, cfg.SkipTLSVerify, cfg.ServiceName)
+		if err != nil {
+			return nil, err
+		}
+		exps = append(exps, otlp)
+	}
+	mgr := &exportManager{
+		exporters: exps,
+		ch:        make(chan *SpanSnapshot, 128),
+	}
+	if len(exps) > 0 {
+		mgr.wg.Add(1)
+		go mgr.run()
+	}
+	return mgr, nil
+}
+
+func (m *exportManager) run() {
+	defer m.wg.Done()
+	for span := range m.ch {
+		for _, exp := range m.exporters {
+			if err := exp.Export(context.Background(), span); err != nil {
+				fmt.Fprintf(os.Stderr, "trace export error: %v\n", err)
+			}
+		}
+	}
+}
+
+func (m *exportManager) export(span *SpanSnapshot) {
+	if m == nil || len(m.exporters) == 0 || span == nil {
+		return
+	}
+	select {
+	case m.ch <- span:
+	default:
+		// Drop spans when the exporter is overwhelmed to avoid blocking the pipeline.
+		fmt.Fprintln(os.Stderr, "trace export queue full; dropping span")
+	}
+}
+
+func (m *exportManager) shutdown(ctx context.Context) error {
+	if m == nil || len(m.exporters) == 0 {
+		return nil
+	}
+	close(m.ch)
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
+	var firstErr error
+	for _, exp := range m.exporters {
+		if err := exp.Shutdown(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+type fileExporter struct {
+	mu  sync.Mutex
+	fw  *os.File
+	enc *json.Encoder
+}
+
+func newFileExporter(path string) (*fileExporter, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	enc := json.NewEncoder(f)
+	return &fileExporter{fw: f, enc: enc}, nil
+}
+
+func (f *fileExporter) Export(_ context.Context, span *SpanSnapshot) error {
+	if f == nil || span == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.enc.Encode(span)
+}
+
+func (f *fileExporter) Shutdown(context.Context) error {
+	if f == nil || f.fw == nil {
+		return nil
+	}
+	return f.fw.Close()
+}
+
+type otlpExporter struct {
+	client      *http.Client
+	endpoint    string
+	headers     map[string]string
+	serviceName string
+}
+
+func newOTLPExporter(endpoint string, headers map[string]string, skipTLS bool, service string) (*otlpExporter, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if skipTLS {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // user requested insecure transport
+	}
+	client := &http.Client{Timeout: 10 * time.Second, Transport: transport}
+	hdrs := make(map[string]string, len(headers))
+	for k, v := range headers {
+		hdrs[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return &otlpExporter{client: client, endpoint: endpoint, headers: hdrs, serviceName: service}, nil
+}
+
+func (o *otlpExporter) Export(ctx context.Context, span *SpanSnapshot) error {
+	if o == nil || span == nil {
+		return nil
+	}
+	payload := o.buildPayload(span)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range o.headers {
+		if k == "" {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("otlp export failed: %s", resp.Status)
+	}
+	return nil
+}
+
+func (o *otlpExporter) buildPayload(span *SpanSnapshot) map[string]any {
+	attrs := make([]map[string]any, 0, len(span.Attributes))
+	for k, v := range span.Attributes {
+		attrs = append(attrs, otlpKeyValue(k, v))
+	}
+	events := make([]map[string]any, 0, len(span.Events))
+	for _, evt := range span.Events {
+		evtAttrs := make([]map[string]any, 0, len(evt.Attributes))
+		for k, v := range evt.Attributes {
+			evtAttrs = append(evtAttrs, otlpKeyValue(k, v))
+		}
+		events = append(events, map[string]any{
+			"name":         evt.Name,
+			"timeUnixNano": strconv.FormatInt(evt.Time.UnixNano(), 10),
+			"attributes":   evtAttrs,
+		})
+	}
+	status := map[string]any{}
+	switch span.Status {
+	case StatusOK:
+		status["code"] = 1
+	case StatusError:
+		status["code"] = 2
+	default:
+		status["code"] = 0
+	}
+	if span.StatusMsg != "" {
+		status["message"] = span.StatusMsg
+	}
+	resAttrs := []map[string]any{}
+	if o.serviceName != "" {
+		resAttrs = append(resAttrs, otlpKeyValue("service.name", o.serviceName))
+	}
+	payload := map[string]any{
+		"resourceSpans": []map[string]any{
+			{
+				"resource": map[string]any{
+					"attributes": resAttrs,
+				},
+				"scopeSpans": []map[string]any{
+					{
+						"scope": map[string]any{"name": "glyph"},
+						"spans": []map[string]any{
+							{
+								"traceId":           span.TraceID,
+								"spanId":            span.SpanID,
+								"parentSpanId":      span.ParentSpanID,
+								"name":              span.Name,
+								"kind":              otlpSpanKind(span.Kind),
+								"startTimeUnixNano": strconv.FormatInt(span.StartTime.UnixNano(), 10),
+								"endTimeUnixNano":   strconv.FormatInt(span.EndTime.UnixNano(), 10),
+								"attributes":        attrs,
+								"events":            events,
+								"status":            status,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return payload
+}
+
+func (o *otlpExporter) Shutdown(context.Context) error { return nil }
+
+func otlpSpanKind(kind SpanKind) int {
+	switch kind {
+	case SpanKindServer:
+		return 2
+	case SpanKindClient:
+		return 3
+	case SpanKindInternal:
+		fallthrough
+	default:
+		return 1
+	}
+}
+
+func otlpKeyValue(key string, value any) map[string]any {
+	m := map[string]any{"key": key}
+	switch v := value.(type) {
+	case string:
+		m["value"] = map[string]any{"stringValue": v}
+	case fmt.Stringer:
+		m["value"] = map[string]any{"stringValue": v.String()}
+	case bool:
+		m["value"] = map[string]any{"boolValue": v}
+	case int:
+		m["value"] = map[string]any{"intValue": strconv.FormatInt(int64(v), 10)}
+	case int32:
+		m["value"] = map[string]any{"intValue": strconv.FormatInt(int64(v), 10)}
+	case int64:
+		m["value"] = map[string]any{"intValue": strconv.FormatInt(v, 10)}
+	case uint:
+		m["value"] = map[string]any{"intValue": strconv.FormatUint(uint64(v), 10)}
+	case uint32:
+		m["value"] = map[string]any{"intValue": strconv.FormatUint(uint64(v), 10)}
+	case uint64:
+		m["value"] = map[string]any{"intValue": strconv.FormatUint(v, 10)}
+	case float32:
+		m["value"] = map[string]any{"doubleValue": float64(v)}
+	case float64:
+		m["value"] = map[string]any{"doubleValue": v}
+	default:
+		m["value"] = map[string]any{"stringValue": fmt.Sprint(v)}
+	}
+	return m
+}

--- a/internal/observability/tracing/grpc.go
+++ b/internal/observability/tracing/grpc.go
@@ -1,0 +1,100 @@
+package tracing
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// UnaryServerInterceptor instruments unary gRPC handlers with tracing spans.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		ctx = ContextWithMetadataSpan(ctx)
+		attrs := map[string]any{"rpc.system": "grpc", "rpc.grpc.type": "unary"}
+		service, method := splitMethod(info.FullMethod)
+		if service != "" {
+			attrs["rpc.service"] = service
+		}
+		if method != "" {
+			attrs["rpc.method"] = method
+		}
+		ctx, span := StartSpan(ctx, info.FullMethod, WithSpanKind(SpanKindServer), WithAttributes(attrs))
+		resp, err := handler(ctx, req)
+		if err != nil {
+			span.RecordError(err)
+			span.End()
+			return resp, err
+		}
+		span.EndWithStatus(StatusOK, "")
+		return resp, nil
+	}
+}
+
+// StreamServerInterceptor instruments streaming gRPC handlers with tracing spans.
+func StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := ContextWithMetadataSpan(ss.Context())
+		attrs := map[string]any{"rpc.system": "grpc", "rpc.grpc.type": streamType(info)}
+		service, method := splitMethod(info.FullMethod)
+		if service != "" {
+			attrs["rpc.service"] = service
+		}
+		if method != "" {
+			attrs["rpc.method"] = method
+		}
+		ctx, span := StartSpan(ctx, info.FullMethod, WithSpanKind(SpanKindServer), WithAttributes(attrs))
+		wrapped := &serverStream{ServerStream: ss, ctx: ctx}
+		err := handler(srv, wrapped)
+		if err != nil {
+			span.RecordError(err)
+			span.End()
+			return err
+		}
+		span.EndWithStatus(StatusOK, "")
+		return nil
+	}
+}
+
+type serverStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *serverStream) Context() context.Context { return s.ctx }
+
+func splitMethod(full string) (string, string) {
+	full = strings.TrimPrefix(full, "/")
+	parts := strings.Split(full, "/")
+	if len(parts) != 2 {
+		return full, ""
+	}
+	return parts[0], parts[1]
+}
+
+func streamType(info *grpc.StreamServerInfo) string {
+	switch {
+	case info.IsClientStream && info.IsServerStream:
+		return "bidi"
+	case info.IsClientStream:
+		return "client_stream"
+	case info.IsServerStream:
+		return "server_stream"
+	default:
+		return "unary"
+	}
+}
+
+// InjectTraceParent appends the current span context to outgoing metadata.
+func InjectTraceParent(ctx context.Context, md metadata.MD) metadata.MD {
+	if md == nil {
+		md = metadata.New(nil)
+	}
+	sc := SpanContextFromContext(ctx)
+	if !sc.Valid() {
+		return md
+	}
+	md.Set(traceparentHeader, FormatTraceParent(sc))
+	return md
+}

--- a/internal/observability/tracing/propagation.go
+++ b/internal/observability/tracing/propagation.go
@@ -1,0 +1,92 @@
+package tracing
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const traceparentHeader = "traceparent"
+
+// ParseTraceParent converts a W3C traceparent header into a span context.
+func ParseTraceParent(header string) (SpanContext, error) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return SpanContext{}, fmt.Errorf("empty traceparent")
+	}
+	parts := strings.Split(header, "-")
+	if len(parts) != 4 {
+		return SpanContext{}, fmt.Errorf("invalid traceparent format")
+	}
+	version, traceID, spanID, flags := parts[0], parts[1], parts[2], parts[3]
+	if len(version) != 2 || len(traceID) != 32 || len(spanID) != 16 || len(flags) != 2 {
+		return SpanContext{}, fmt.Errorf("malformed traceparent components")
+	}
+	if _, err := hex.DecodeString(traceID); err != nil {
+		return SpanContext{}, fmt.Errorf("invalid trace id: %w", err)
+	}
+	if _, err := hex.DecodeString(spanID); err != nil {
+		return SpanContext{}, fmt.Errorf("invalid span id: %w", err)
+	}
+	sampled := strings.HasSuffix(flags, "1")
+	return SpanContext{TraceID: traceID, SpanID: spanID, Sampled: sampled}, nil
+}
+
+// FormatTraceParent renders sc into the W3C traceparent representation.
+func FormatTraceParent(sc SpanContext) string {
+	if !sc.Valid() {
+		return ""
+	}
+	flags := "00"
+	if sc.Sampled {
+		flags = "01"
+	}
+	return fmt.Sprintf("00-%s-%s-%s", sc.TraceID, sc.SpanID, flags)
+}
+
+// ExtractFromMetadata obtains the span context from gRPC metadata when available.
+func ExtractFromMetadata(md metadata.MD) SpanContext {
+	if md == nil {
+		return SpanContext{}
+	}
+	values := md.Get(traceparentHeader)
+	for _, header := range values {
+		sc, err := ParseTraceParent(header)
+		if err == nil {
+			return sc
+		}
+	}
+	return SpanContext{}
+}
+
+// InjectHTTP propagates the current span context onto the outbound request.
+func InjectHTTP(req *http.Request) {
+	if req == nil {
+		return
+	}
+	sc := SpanContextFromContext(req.Context())
+	if !sc.Valid() {
+		return
+	}
+	req.Header.Set(traceparentHeader, FormatTraceParent(sc))
+}
+
+// ContextWithMetadataSpan extracts trace information from incoming metadata and attaches it to ctx.
+func ContextWithMetadataSpan(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+	sc := ExtractFromMetadata(md)
+	if !sc.Valid() {
+		return ctx
+	}
+	return WithSpanContext(ctx, sc)
+}

--- a/internal/observability/tracing/span.go
+++ b/internal/observability/tracing/span.go
@@ -1,0 +1,212 @@
+package tracing
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Span represents an in-flight trace span.
+type Span interface {
+	Context() SpanContext
+	End()
+	EndWithStatus(status SpanStatus, description string)
+	SetAttribute(key string, value any)
+	AddEvent(name string, attributes map[string]any)
+	RecordError(err error)
+}
+
+type span struct {
+	tracer      *Tracer
+	context     SpanContext
+	parent      SpanContext
+	name        string
+	kind        SpanKind
+	attributes  map[string]any
+	events      []spanEvent
+	status      SpanStatus
+	statusMsg   string
+	startTime   time.Time
+	endTime     time.Time
+	ended       bool
+	mu          sync.Mutex
+	serviceName string
+}
+
+type spanEvent struct {
+	Name       string         `json:"name"`
+	Time       time.Time      `json:"time"`
+	Attributes map[string]any `json:"attributes,omitempty"`
+}
+
+// SpanStatus represents the outcome of a span.
+type SpanStatus string
+
+const (
+	StatusUnset SpanStatus = "unset"
+	StatusOK    SpanStatus = "ok"
+	StatusError SpanStatus = "error"
+)
+
+func (s *span) Context() SpanContext {
+	if s == nil {
+		return SpanContext{}
+	}
+	return s.context
+}
+
+func (s *span) End() { s.EndWithStatus(s.status, s.statusMsg) }
+
+func (s *span) EndWithStatus(status SpanStatus, description string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.ended {
+		s.mu.Unlock()
+		return
+	}
+	s.ended = true
+	s.endTime = time.Now()
+	if status != "" {
+		s.status = status
+		s.statusMsg = description
+	}
+	snapshot := s.snapshotLocked()
+	s.mu.Unlock()
+	if snapshot != nil && s.tracer != nil && s.tracer.exporters != nil {
+		s.tracer.exporters.export(snapshot)
+	}
+}
+
+func (s *span) SetAttribute(key string, value any) {
+	if s == nil || key == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.attributes == nil {
+		s.attributes = make(map[string]any)
+	}
+	s.attributes[key] = value
+	s.mu.Unlock()
+}
+
+func (s *span) AddEvent(name string, attributes map[string]any) {
+	if s == nil || name == "" {
+		return
+	}
+	s.mu.Lock()
+	evt := spanEvent{Name: name, Time: time.Now()}
+	if len(attributes) > 0 {
+		evt.Attributes = cloneAttributes(attributes)
+	}
+	s.events = append(s.events, evt)
+	s.mu.Unlock()
+}
+
+func (s *span) RecordError(err error) {
+	if s == nil || err == nil {
+		return
+	}
+	msg := err.Error()
+	s.AddEvent("error", map[string]any{"message": msg})
+	s.mu.Lock()
+	s.status = StatusError
+	s.statusMsg = msg
+	s.mu.Unlock()
+}
+
+func (s *span) snapshotLocked() *SpanSnapshot {
+	if s == nil {
+		return nil
+	}
+	attrs := cloneAttributes(s.attributes)
+	events := make([]spanEvent, len(s.events))
+	copy(events, s.events)
+	return &SpanSnapshot{
+		TraceID:      s.context.TraceID,
+		SpanID:       s.context.SpanID,
+		ParentSpanID: s.parent.SpanID,
+		Name:         s.name,
+		Kind:         s.kind,
+		Attributes:   attrs,
+		Events:       events,
+		Status:       s.status,
+		StatusMsg:    s.statusMsg,
+		StartTime:    s.startTime,
+		EndTime:      s.endTime,
+		ServiceName:  s.serviceName,
+	}
+}
+
+type noopSpan struct {
+	ctx SpanContext
+}
+
+func (n noopSpan) Context() SpanContext           { return n.ctx }
+func (noopSpan) End()                             {}
+func (noopSpan) EndWithStatus(SpanStatus, string) {}
+func (noopSpan) SetAttribute(string, any)         {}
+func (noopSpan) AddEvent(string, map[string]any)  {}
+func (noopSpan) RecordError(error)                {}
+
+// SpanSnapshot captures the immutable span data exported to sinks.
+type SpanSnapshot struct {
+	TraceID      string         `json:"trace_id"`
+	SpanID       string         `json:"span_id"`
+	ParentSpanID string         `json:"parent_span_id,omitempty"`
+	Name         string         `json:"name"`
+	Kind         SpanKind       `json:"kind"`
+	Attributes   map[string]any `json:"attributes,omitempty"`
+	Events       []spanEvent    `json:"events,omitempty"`
+	Status       SpanStatus     `json:"status"`
+	StatusMsg    string         `json:"status_message,omitempty"`
+	StartTime    time.Time      `json:"start_time"`
+	EndTime      time.Time      `json:"end_time"`
+	ServiceName  string         `json:"service_name,omitempty"`
+}
+
+// Duration returns the elapsed time recorded by the span.
+func (s *SpanSnapshot) Duration() time.Duration {
+	if s == nil {
+		return 0
+	}
+	if s.EndTime.IsZero() || s.StartTime.IsZero() {
+		return 0
+	}
+	return s.EndTime.Sub(s.StartTime)
+}
+
+func (s *SpanSnapshot) MarshalJSON() ([]byte, error) {
+	type alias SpanSnapshot
+	out := &struct {
+		*alias
+		Start int64 `json:"start_time_unix_nano"`
+		End   int64 `json:"end_time_unix_nano"`
+	}{alias: (*alias)(s)}
+	out.Start = s.StartTime.UnixNano()
+	out.End = s.EndTime.UnixNano()
+	return json.Marshal(out)
+}
+
+// ErrSpanEnded indicates operations were attempted on an already completed span.
+var ErrSpanEnded = errors.New("span already ended")
+
+func (s *span) ensureActive() error {
+	if s == nil {
+		return errors.New("nil span")
+	}
+	if s.ended {
+		return ErrSpanEnded
+	}
+	return nil
+}
+
+func (s *span) String() string {
+	if s == nil {
+		return "<nil span>"
+	}
+	return fmt.Sprintf("span %s/%s", s.context.TraceID, s.context.SpanID)
+}


### PR DESCRIPTION
## Summary
- introduce an internal tracing package with OTLP/HTTP export, JSONL capture, and gRPC interceptors
- wire glyphd, the plugin bus, and netgate HTTP client to emit spans and propagate trace IDs into audit logs
- add observability documentation, sample Grafana dashboard, OTEL collector config, and alert rules

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e51e7ebd68832ab6561bfd3f270f80