### PR TITLE
Add version comparison view to docs

### DIFF
--- a/docs/en/versions/compare.md
+++ b/docs/en/versions/compare.md
@@ -1,0 +1,34 @@
+---
+title: Compare documentation versions
+---
+
+# Compare documentation versions
+
+Use the selector below to preload a GitHub diff between two releases. After the
+compare view opens you can use GitHub's **Filter changed files** search box to
+type `docs/` and focus on documentation updates. The helper also surfaces quick
+links to release notes and the project changelog.
+
+<div data-version-diff class="doc-version-diff">
+  <noscript>
+    <p><strong>JavaScript required:</strong> enable JavaScript to build the diff
+    view. As a fallback you can open <a href="https://github.com/RowanDark/Glyph/blob/main/CHANGELOG.md" target="_blank" rel="noopener">the changelog</a>
+    or use the GitHub compare tool manually:</p>
+    <ol>
+      <li>Navigate to <a href="https://github.com/RowanDark/Glyph/compare" target="_blank" rel="noopener">github.com/RowanDark/Glyph/compare</a>.</li>
+      <li>Enter the base (older) version tag, then the newer target tag.</li>
+      <li>Add <code>?diff=split</code> to the URL (or use the UI controls) and
+        type <code>docs/</code> into the <strong>Filter changed files</strong> box
+        to narrow the list to documentation changes.</li>
+    </ol>
+  </noscript>
+</div>
+
+## Tips for sharing diffs
+
+- GitHub remembers the chosen versions and any file filter text in the URL, so
+  you can share a link to a specific comparison.
+- Release notes link to the corresponding GitHub tag so you can see binaries,
+  issues, and merged pull requests for that version.
+- Documentation snapshots remain available under `/versions/<id>/` if you need
+  a stable permalink to an older page.

--- a/docs/en/versions/index.md
+++ b/docs/en/versions/index.md
@@ -4,6 +4,12 @@ Glyph ships the online documentation with per-release snapshots so you can keep
 working against a stable API or CLI surface even after the latest release
 moves forward.
 
+## See what's changed
+
+Head to the [comparison view](compare.md) to generate a diff between any two
+published versions. The helper preloads GitHub's compare view and surfaces quick
+links to the relevant release notes and changelog entries.
+
 ## Selecting a version
 
 Use the **Version** drop-down in the site header to jump between the currently

--- a/docs/es/versions/compare.md
+++ b/docs/es/versions/compare.md
@@ -1,0 +1,35 @@
+---
+title: Comparar versiones de la documentación
+---
+
+# Comparar versiones de la documentación
+
+Usa el selector para precargar un diff en GitHub entre dos versiones. Una vez
+abierta la vista de comparación, utiliza el campo **Filter changed files** de
+GitHub para escribir `docs/` y centrarte en los cambios de documentación. El
+asistente también ofrece enlaces rápidos a las notas de lanzamiento y al
+changelog del proyecto.
+
+<div data-version-diff class="doc-version-diff">
+  <noscript>
+    <p><strong>Se requiere JavaScript:</strong> habilita JavaScript para generar el
+    diff. Como alternativa abre el <a href="https://github.com/RowanDark/Glyph/blob/main/CHANGELOG.md" target="_blank" rel="noopener">changelog</a> o usa
+    manualmente la herramienta de comparación de GitHub:</p>
+    <ol>
+      <li>Visita <a href="https://github.com/RowanDark/Glyph/compare" target="_blank" rel="noopener">github.com/RowanDark/Glyph/compare</a>.</li>
+      <li>Introduce la etiqueta de la versión base (más antigua) y después la etiqueta destino.</li>
+      <li>Añade <code>?diff=split</code> a la URL (o usa los controles de la
+        interfaz) y escribe <code>docs/</code> en el cuadro <strong>Filter changed
+        files</strong> para centrarte en la documentación.</li>
+    </ol>
+  </noscript>
+</div>
+
+## Consejos para compartir diffs
+
+- GitHub guarda las versiones elegidas y cualquier texto del filtro de archivos
+  en la URL, lo que facilita compartir un enlace con una comparación concreta.
+- Las notas de lanzamiento apuntan a la etiqueta correspondiente de GitHub para
+  ver binarios, incidencias y pull requests fusionados en esa versión.
+- Las instantáneas de la documentación siguen disponibles bajo `/versions/<id>/`
+  si necesitas un enlace estable a una página anterior.

--- a/docs/es/versions/index.md
+++ b/docs/es/versions/index.md
@@ -3,6 +3,13 @@
 Glyph publica instantáneas de la documentación para cada versión estable. Así
 puedes seguir una API o CLI concreta aunque aparezcan lanzamientos más nuevos.
 
+## Consulta qué ha cambiado
+
+Visita la [vista de comparación](compare.md) para generar un diff entre dos
+versiones publicadas. El asistente precarga la vista de comparación de GitHub y
+ofrece accesos rápidos a las notas de lanzamiento y al changelog
+correspondientes.
+
 ## Seleccionar una versión
 
 Utiliza el menú **Version** en la cabecera del sitio para cambiar entre la

--- a/docs/javascripts/version-diff.js
+++ b/docs/javascripts/version-diff.js
@@ -1,0 +1,162 @@
+(function () {
+  const GITHUB_REPO = 'https://github.com/RowanDark/Glyph';
+  const GITHUB_CHANGELOG = `${GITHUB_REPO}/blob/main/CHANGELOG.md`;
+
+  function init() {
+    const targets = Array.from(document.querySelectorAll('[data-version-diff]'));
+    if (targets.length === 0) {
+      return;
+    }
+
+    const docsRoot = resolveDocsRoot('version-diff.js');
+    const manifestUrl = new URL('data/doc-versions.json', docsRoot);
+
+    fetch(manifestUrl)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load version manifest: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((manifest) => {
+        if (!manifest || !Array.isArray(manifest.versions) || manifest.versions.length === 0) {
+          return;
+        }
+        const versions = manifest.versions.map((entry) => ({
+          id: entry.id,
+          name: entry.name || entry.id,
+        }));
+        targets.forEach((container) => render(container, versions));
+      })
+      .catch((error) => {
+        console.warn('Unable to build version diff widget', error); // eslint-disable-line no-console
+      });
+  }
+
+  function render(container, versions) {
+    container.innerHTML = '';
+    container.classList.add('doc-version-diff--ready');
+
+    const heading = document.createElement('p');
+    heading.className = 'doc-version-diff__intro';
+    heading.textContent = 'Compare two published releases to review documentation updates.';
+    container.appendChild(heading);
+
+    const form = document.createElement('form');
+    form.className = 'doc-version-diff__form';
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+    });
+
+    const fromField = buildSelect('from', 'From version', versions);
+    const toField = buildSelect('to', 'To version', versions);
+
+    const compareButton = document.createElement('a');
+    compareButton.className = 'md-button doc-version-diff__action';
+    compareButton.target = '_blank';
+    compareButton.rel = 'noopener';
+    compareButton.textContent = 'Open documentation diff';
+
+    const releaseLink = document.createElement('a');
+    releaseLink.className = 'doc-version-diff__secondary';
+    releaseLink.target = '_blank';
+    releaseLink.rel = 'noopener';
+    releaseLink.textContent = 'View release notes';
+
+    const changelogLink = document.createElement('a');
+    changelogLink.className = 'doc-version-diff__secondary';
+    changelogLink.textContent = 'Open changelog';
+
+    const updateLinks = () => {
+      const fromVersion = fromField.select.value;
+      const toVersion = toField.select.value;
+      if (!fromVersion || !toVersion || fromVersion === toVersion) {
+        compareButton.setAttribute('aria-disabled', 'true');
+        compareButton.classList.add('doc-version-diff__action--disabled');
+        compareButton.removeAttribute('href');
+      } else {
+        compareButton.removeAttribute('aria-disabled');
+        compareButton.classList.remove('doc-version-diff__action--disabled');
+        compareButton.href = `${GITHUB_REPO}/compare/${encodeURIComponent(fromVersion)}...${encodeURIComponent(toVersion)}?diff=split`;
+      }
+      if (toVersion) {
+        releaseLink.href = `${GITHUB_REPO}/releases/tag/${encodeURIComponent(toVersion)}`;
+      } else {
+        releaseLink.removeAttribute('href');
+      }
+      changelogLink.href = `${GITHUB_CHANGELOG}#${encodeURIComponent(toVersion || fromVersion || '')}`;
+    };
+
+    fromField.select.addEventListener('change', updateLinks);
+    toField.select.addEventListener('change', updateLinks);
+
+    form.appendChild(fromField.wrapper);
+    form.appendChild(toField.wrapper);
+    form.appendChild(compareButton);
+
+    container.appendChild(form);
+
+    const secondary = document.createElement('div');
+    secondary.className = 'doc-version-diff__secondary-links';
+    secondary.appendChild(releaseLink);
+    secondary.appendChild(changelogLink);
+    container.appendChild(secondary);
+
+    if (versions.length > 1) {
+      fromField.select.value = versions[1].id;
+      toField.select.value = versions[0].id;
+    } else if (versions.length === 1) {
+      fromField.select.value = versions[0].id;
+      toField.select.value = versions[0].id;
+    }
+    updateLinks();
+  }
+
+  function buildSelect(name, labelText, versions) {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'doc-version-diff__field';
+
+    const label = document.createElement('span');
+    label.className = 'doc-version-diff__label';
+    label.textContent = labelText;
+    wrapper.appendChild(label);
+
+    const select = document.createElement('select');
+    select.name = name;
+    select.className = 'doc-version-diff__select';
+    versions.forEach((version) => {
+      const option = document.createElement('option');
+      option.value = version.id;
+      option.textContent = version.name;
+      select.appendChild(option);
+    });
+    wrapper.appendChild(select);
+
+    return { wrapper, select };
+  }
+
+  function resolveDocsRoot(scriptName) {
+    let script = document.currentScript;
+    if (!script || !(script.src || '').includes(scriptName)) {
+      script = Array.from(document.getElementsByTagName('script')).find((element) =>
+        (element.src || '').includes(scriptName),
+      );
+    }
+    if (!script) {
+      return new URL('.', window.location.href);
+    }
+    const scriptUrl = new URL(script.src, window.location.href);
+    return new URL('..', scriptUrl);
+  }
+
+  const initOnce = () => window.requestAnimationFrame(init);
+  if (window.document$ && typeof window.document$.subscribe === 'function') {
+    window.document$.subscribe(initOnce);
+  }
+
+  if (document.readyState !== 'loading') {
+    initOnce();
+  } else {
+    document.addEventListener('DOMContentLoaded', initOnce);
+  }
+})();

--- a/docs/stylesheets/marketplace.css
+++ b/docs/stylesheets/marketplace.css
@@ -182,3 +182,76 @@
     width: 100%;
   }
 }
+
+.doc-version-diff {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin: 1.5rem 0;
+  background: var(--md-default-bg-color);
+}
+
+.doc-version-diff__intro {
+  margin-top: 0;
+  color: var(--md-default-fg-color--light);
+}
+
+.doc-version-diff__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.doc-version-diff__field {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 12rem;
+  gap: 0.35rem;
+}
+
+.doc-version-diff__label {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--lighter);
+}
+
+.doc-version-diff__select {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.25rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+}
+
+.doc-version-diff__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 14rem;
+  margin-left: auto;
+}
+
+.doc-version-diff__action--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.doc-version-diff__secondary-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.doc-version-diff__secondary {
+  color: var(--md-accent-fg-color);
+}
+
+@media screen and (max-width: 768px) {
+  .doc-version-diff__action {
+    width: 100%;
+    margin-left: 0;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,9 @@ nav:
       - Build Provenance: security/provenance.md
       - Supply Chain: security/supply-chain.md
       - Container Hardening: security/container.md
-  - Versions: versions/index.md
+  - Versions:
+      - Overview: versions/index.md
+      - Compare releases: versions/compare.md
 
 theme:
   name: material
@@ -64,6 +66,8 @@ plugins:
           Developer Guide: Guía de desarrollo
           Security: Seguridad
           Versions: Versiones
+          Overview: Descripción general
+          Compare releases: Comparar versiones
   - git-revision-date-localized:
       fallback_to_build_date: true
       type: datetime
@@ -167,6 +171,8 @@ extra_javascript:
   - path: javascripts/sidebar-state.js
     defer: true
   - path: javascripts/version-dropdown.js
+    defer: true
+  - path: javascripts/version-diff.js
     defer: true
   - path: javascripts/plugin-catalog.js
     defer: true


### PR DESCRIPTION
## Summary
- add a dedicated comparison page in English and Spanish with instructions for filtering documentation diffs
- introduce a reusable JavaScript widget and styling that renders a release diff selector and links to release notes and the changelog
- expose the comparison view from the versions navigation and overview pages, including updated Spanish translations

## Testing
- `mkdocs build --strict` *(fails: Plugin 'i18n' option 'languages' expects a list in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e591252b80832aaec31b2c5149713b