### PR TITLE
Add plugin registry backend and docs integration

### DIFF
--- a/cmd/glyph-registry/main.go
+++ b/cmd/glyph-registry/main.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/registry"
+)
+
+func main() {
+	listen := flag.String("listen", ":8088", "address to listen on")
+	dataPath := flag.String("data", "docs/en/data/plugin-registry.json", "path to the registry dataset")
+	enableCORS := flag.Bool("cors", false, "allow cross-origin requests")
+	flag.Parse()
+
+	srv := &server{dataPath: *dataPath, allowCORS: *enableCORS}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", srv.handleHealth)
+	mux.HandleFunc("/registry.json", srv.handleRegistry)
+	mux.HandleFunc("/plugins", srv.handlePlugins)
+	mux.HandleFunc("/plugins/", srv.handlePluginByID)
+	mux.HandleFunc("/compatibility", srv.handleCompatibility)
+
+	httpSrv := &http.Server{
+		Addr:    *listen,
+		Handler: srv.withMiddleware(mux),
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("registry server: %v", err)
+			stop()
+		}
+	}()
+
+	<-ctx.Done()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := httpSrv.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Printf("registry shutdown: %v", err)
+	}
+}
+
+type server struct {
+	dataPath  string
+	allowCORS bool
+}
+
+func (s *server) withMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.allowCORS {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.methodNotAllowed(w)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *server) handleRegistry(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.methodNotAllowed(w)
+		return
+	}
+	dataset, err := s.load()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, dataset)
+}
+
+func (s *server) handlePlugins(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.methodNotAllowed(w)
+		return
+	}
+	dataset, err := s.load()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	query := r.URL.Query()
+	filter := registry.Filter{
+		Query:      coalesce(query.Get("q"), query.Get("query")),
+		Language:   query.Get("language"),
+		Category:   query.Get("category"),
+		Capability: query.Get("capability"),
+		Glyph:      query.Get("glyph"),
+		Status:     query.Get("status"),
+	}
+	plugins := dataset.FilterPlugins(filter)
+	response := struct {
+		Count         int               `json:"count"`
+		Total         int               `json:"total"`
+		GlyphVersions []string          `json:"glyph_versions"`
+		Plugins       []registry.Plugin `json:"plugins"`
+	}{
+		Count:         len(plugins),
+		Total:         len(dataset.Plugins),
+		GlyphVersions: dataset.GlyphVersions,
+		Plugins:       plugins,
+	}
+	s.writeJSON(w, http.StatusOK, response)
+}
+
+func (s *server) handlePluginByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.methodNotAllowed(w)
+		return
+	}
+	dataset, err := s.load()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/plugins/")
+	id = strings.TrimSpace(id)
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	plugin, ok := dataset.Plugin(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, plugin)
+}
+
+func (s *server) handleCompatibility(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.methodNotAllowed(w)
+		return
+	}
+	dataset, err := s.load()
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	type compatibilityEntry struct {
+		ID            string                            `json:"id"`
+		Name          string                            `json:"name"`
+		Version       string                            `json:"version"`
+		Compatibility map[string]registry.Compatibility `json:"compatibility"`
+	}
+	entries := make([]compatibilityEntry, 0, len(dataset.Plugins))
+	for _, plugin := range dataset.Plugins {
+		entries = append(entries, compatibilityEntry{
+			ID:            plugin.ID,
+			Name:          plugin.Name,
+			Version:       plugin.Version,
+			Compatibility: plugin.Compatibility,
+		})
+	}
+	payload := struct {
+		GlyphVersions []string             `json:"glyph_versions"`
+		Plugins       []compatibilityEntry `json:"plugins"`
+	}{
+		GlyphVersions: dataset.GlyphVersions,
+		Plugins:       entries,
+	}
+	s.writeJSON(w, http.StatusOK, payload)
+}
+
+func (s *server) methodNotAllowed(w http.ResponseWriter) {
+	w.Header().Set("Allow", http.MethodGet)
+	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+}
+
+func (s *server) writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		log.Printf("write response: %v", err)
+	}
+}
+
+func (s *server) writeError(w http.ResponseWriter, status int, err error) {
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	type errorPayload struct {
+		Error string `json:"error"`
+	}
+	s.writeJSON(w, status, errorPayload{Error: message})
+}
+
+func (s *server) load() (registry.Dataset, error) {
+	dataset, err := registry.Load(s.dataPath)
+	if err != nil {
+		return registry.Dataset{}, fmt.Errorf("load registry: %w", err)
+	}
+	return dataset, nil
+}
+
+func coalesce(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -41,20 +41,22 @@ func main() {
 		os.Exit(runConfig(args[1:]))
 	case "scope":
 		os.Exit(runScope(args[1:]))
-	case "plugin":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "plugin subcommand required")
-			os.Exit(2)
-		}
-		switch args[1] {
-		case "run":
-			os.Exit(runPluginRun(args[2:]))
-		case "verify":
-			os.Exit(runPluginVerify(args[2:]))
-		default:
-			fmt.Fprintf(os.Stderr, "unknown plugin subcommand: %s\n", args[1])
-			os.Exit(2)
-		}
+        case "plugin":
+                if len(args) < 2 {
+                        fmt.Fprintln(os.Stderr, "plugin subcommand required")
+                        os.Exit(2)
+                }
+                switch args[1] {
+                case "run":
+                        os.Exit(runPluginRun(args[2:]))
+                case "verify":
+                        os.Exit(runPluginVerify(args[2:]))
+                case "registry":
+                        os.Exit(runPluginRegistry(args[2:]))
+                default:
+                        fmt.Fprintf(os.Stderr, "unknown plugin subcommand: %s\n", args[1])
+                        os.Exit(2)
+                }
 	case "raider":
 		os.Exit(runRaider(args[1:]))
 	case "history":

--- a/cmd/glyphctl/plugin_registry.go
+++ b/cmd/glyphctl/plugin_registry.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+var runRegistryCommand = runExternalCommand
+
+func runPluginRegistry(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "plugin registry subcommand required")
+		return 2
+	}
+	switch args[0] {
+	case "publish":
+		return runPluginRegistryPublish(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown plugin registry subcommand: %s\n", args[0])
+		return 2
+	}
+}
+
+func runPluginRegistryPublish(args []string) int {
+	fs := flag.NewFlagSet("glyphctl plugin registry publish", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	ref := fs.String("ref", "", "git ref used for generated links")
+	repoURL := fs.String("repo-url", "", "repository URL used for documentation links")
+	pythonBin := fs.String("python", "python", "python interpreter to execute the generator")
+	script := fs.String("script", filepath.Join("scripts", "update_plugin_catalog.py"), "path to the registry generator script")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cmdArgs := make([]string, 0, 6)
+	if *ref != "" {
+		cmdArgs = append(cmdArgs, "--ref", *ref)
+	}
+	if *repoURL != "" {
+		cmdArgs = append(cmdArgs, "--repo-url", *repoURL)
+	}
+	cmdArgs = append(cmdArgs, fs.Args()...)
+
+	command := append([]string{*script}, cmdArgs...)
+	if err := runRegistryCommand(context.Background(), *pythonBin, command); err != nil {
+		fmt.Fprintf(os.Stderr, "regenerate plugin registry: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runExternalCommand(ctx context.Context, program string, args []string) error {
+	cmd := exec.CommandContext(ctx, program, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	return cmd.Run()
+}

--- a/cmd/glyphctl/plugin_registry_test.go
+++ b/cmd/glyphctl/plugin_registry_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestRunPluginRegistryMissingSubcommand(t *testing.T) {
+	if code := runPluginRegistry(nil); code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+}
+
+func TestRunPluginRegistryPublish(t *testing.T) {
+	var (
+		invoked         bool
+		receivedProgram string
+		receivedArgs    []string
+	)
+	previous := runRegistryCommand
+	runRegistryCommand = func(ctx context.Context, program string, args []string) error {
+		invoked = true
+		receivedProgram = program
+		receivedArgs = append([]string(nil), args...)
+		return nil
+	}
+	defer func() { runRegistryCommand = previous }()
+
+	code := runPluginRegistry([]string{"publish", "--python", "python3", "--ref", "HEAD", "--repo-url", "https://example.com", "--", "--verbose"})
+	if code != 0 {
+		t.Fatalf("expected success exit code, got %d", code)
+	}
+	if !invoked {
+		t.Fatalf("expected generator command to be invoked")
+	}
+	if receivedProgram != "python3" {
+		t.Fatalf("expected python3 executable, got %s", receivedProgram)
+	}
+	expectedScript := filepath.Join("scripts", "update_plugin_catalog.py")
+	if len(receivedArgs) == 0 || receivedArgs[0] != expectedScript {
+		t.Fatalf("expected script path %s, got %v", expectedScript, receivedArgs)
+	}
+	if !reflect.DeepEqual(receivedArgs[1:], []string{"--ref", "HEAD", "--repo-url", "https://example.com", "--verbose"}) {
+		t.Fatalf("unexpected arguments: %v", receivedArgs)
+	}
+}

--- a/docs/en/data/plugin-catalog.json
+++ b/docs/en/data/plugin-catalog.json
@@ -14,11 +14,29 @@
     "signature_sha256": "f54b4fe62f3e51008998a1520e6ccc416a82481bfa3a21779178c255f246892d",
     "links": {
       "documentation": "../plugins/_catalog/cartographer/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/plugin.js",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/plugin.js.sig",
-      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer#getting-started"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer#getting-started"
+    },
+    "categories": [
+      "Discovery",
+      "Recon"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "compatible",
+        "notes": "1.0.0+"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -35,11 +53,28 @@
     "signature_sha256": "01ea86b0677f49572e048da1ce3a0eab4edb85f8b431886d6aef33945119e91e",
     "links": {
       "documentation": "../plugins/_catalog/cryptographer/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/plugin.js",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/plugin.js.sig",
-      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer#getting-started"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer#getting-started"
+    },
+    "categories": [
+      "Utilities"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "compatible",
+        "notes": "1.0.0+"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -56,10 +91,27 @@
     "signature_sha256": "779e349dd31e35291496df536b5ae87721cf219fa8cefe74f57f8e891aa81969",
     "links": {
       "documentation": "../plugins/_catalog/example-hello/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/main.go",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/main.go.sig"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/main.go",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/main.go.sig"
+    },
+    "categories": [
+      "Examples"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "compatible",
+        "notes": "1.0.0+"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -78,11 +130,29 @@
     "signature_sha256": "2bc2a623ba05c425735f1fc72530ed2db0f3b16602b57c6d0a0779dbf1555975",
     "links": {
       "documentation": "../plugins/_catalog/excavator/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/plugin.js",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/plugin.js.sig",
-      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator#getting-started"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator#getting-started"
+    },
+    "categories": [
+      "Automation",
+      "Discovery"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "limited",
+        "notes": "Requires passive mode patch"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -101,10 +171,26 @@
     "signature_sha256": "50a8b2a25abd06346fc849bab40232de2d768cc60d6f9155bb42caf76b1dcb60",
     "links": {
       "documentation": "../plugins/_catalog/galdr-proxy/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/plugin.js",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/plugin.js.sig"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/plugin.js.sig"
+    },
+    "categories": [
+      "Interception"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "unsupported"
+      },
+      "1.1": {
+        "status": "limited",
+        "notes": "HTTP-only support"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -122,10 +208,27 @@
     "signature_sha256": "ca64abd3b27388206879f4134976387239fd50f4ac6fc3044d812703f8d2af20",
     "links": {
       "documentation": "../plugins/_catalog/grapher/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/main.go",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/main.go.sig"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/main.go",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/main.go.sig"
+    },
+    "categories": [
+      "Visualization"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "compatible",
+        "notes": "1.0.0+"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -143,11 +246,28 @@
     "signature_sha256": "e7a804c5ede93f41fd2eb0871ab380f53d3342b0667f6a969c5c6fcb95b2c027",
     "links": {
       "documentation": "../plugins/_catalog/osint-well/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/plugin.js",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/plugin.js.sig",
-      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well#installation"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well#installation"
+    },
+    "categories": [
+      "Intelligence"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "compatible",
+        "notes": "1.0.0+"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -166,11 +286,27 @@
     "signature_sha256": "ac97711a74c78f33d6dbb08d3a4a7e9f9534671db0be96afa84a4b8e451c69dd",
     "links": {
       "documentation": "../plugins/_catalog/raider/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/plugin.js",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/plugin.js.sig",
-      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider#getting-started"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider#getting-started"
+    },
+    "categories": [
+      "Offense"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "unsupported"
+      },
+      "1.1": {
+        "status": "limited",
+        "notes": "Requires v1.1.5 hotfix"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -188,11 +324,28 @@
     "signature_sha256": "a45acedbd3421c054d07db91f12938ac13f928d47170de6cec88770c5fde13f3",
     "links": {
       "documentation": "../plugins/_catalog/ranker/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/plugin.js",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/plugin.js.sig",
-      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker#getting-started"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker#getting-started"
+    },
+    "categories": [
+      "Analytics"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "compatible",
+        "notes": "1.0.0+"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -209,11 +362,28 @@
     "signature_sha256": "61b004d72d616382997a2689a3f85d6a032cb29ffe2e53297440a4ee5bb1c0d0",
     "links": {
       "documentation": "../plugins/_catalog/scribe/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/plugin.js",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/plugin.js.sig",
-      "installation": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe#getting-started"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/plugin.js",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/plugin.js.sig",
+      "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe#getting-started"
+    },
+    "categories": [
+      "Reporting"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "compatible",
+        "notes": "1.0.3+"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   },
   {
@@ -231,10 +401,27 @@
     "signature_sha256": "46e816b1b0cbd7f804430df0a730f8983004f3136739b6b62818a00b7b7b0fce",
     "links": {
       "documentation": "../plugins/_catalog/seer/",
-      "readme": "https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer#readme",
-      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/manifest.json",
-      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/main.go",
-      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/main.go.sig"
+      "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer#readme",
+      "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/manifest.json",
+      "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/main.go",
+      "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/main.go.sig"
+    },
+    "categories": [
+      "Detection"
+    ],
+    "compatibility": {
+      "1.0": {
+        "status": "limited",
+        "notes": "Passive-only mode"
+      },
+      "1.1": {
+        "status": "compatible",
+        "notes": "1.1.0+"
+      },
+      "2.0": {
+        "status": "compatible",
+        "notes": "2.0.0+"
+      }
     }
   }
 ]

--- a/docs/en/data/plugin-registry.json
+++ b/docs/en/data/plugin-registry.json
@@ -1,0 +1,435 @@
+{
+  "generated_at": "2025-10-07T23:07:39Z",
+  "glyph_versions": [
+    "1.0",
+    "1.1",
+    "2.0"
+  ],
+  "plugins": [
+    {
+      "id": "cartographer",
+      "name": "Cartographer",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "TypeScript",
+      "summary": "Cartographer charts application surfaces discovered by crawlers and passive sensors so other plugins can prioritize exploration.",
+      "capabilities": [
+        "CAP_EMIT_FINDINGS",
+        "CAP_SPIDER"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "f54b4fe62f3e51008998a1520e6ccc416a82481bfa3a21779178c255f246892d",
+      "links": {
+        "documentation": "../plugins/_catalog/cartographer/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/plugin.js",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/plugin.js.sig",
+        "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer#getting-started"
+      },
+      "categories": [
+        "Discovery",
+        "Recon"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "compatible",
+          "notes": "1.0.0+"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "cryptographer",
+      "name": "Cryptographer",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "TypeScript",
+      "summary": "Cryptographer is a CyberChef-inspired utility surface for quickly transforming payloads and experimenting with encoding operations during investigations.",
+      "capabilities": [
+        "CAP_REPORT"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "01ea86b0677f49572e048da1ce3a0eab4edb85f8b431886d6aef33945119e91e",
+      "links": {
+        "documentation": "../plugins/_catalog/cryptographer/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/plugin.js",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/plugin.js.sig",
+        "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer#getting-started"
+      },
+      "categories": [
+        "Utilities"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "compatible",
+          "notes": "1.0.0+"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "example-hello",
+      "name": "Example Hello",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "Go",
+      "summary": "Example Hello is a Glyph plugin.",
+      "capabilities": [
+        "CAP_EMIT_FINDINGS"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "779e349dd31e35291496df536b5ae87721cf219fa8cefe74f57f8e891aa81969",
+      "links": {
+        "documentation": "../plugins/_catalog/example-hello/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/main.go",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/main.go.sig"
+      },
+      "categories": [
+        "Examples"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "compatible",
+          "notes": "1.0.0+"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "excavator",
+      "name": "Excavator",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "TypeScript",
+      "summary": "Excavator is the Playwright-powered crawler foundation for Glyph. It provides a reproducible baseline for scripted reconnaissance of target applications.",
+      "capabilities": [
+        "CAP_EMIT_FINDINGS",
+        "CAP_HTTP_PASSIVE",
+        "CAP_SPIDER"
+      ],
+      "last_updated": "2025-10-03T12:53:02-04:00",
+      "signature_sha256": "2bc2a623ba05c425735f1fc72530ed2db0f3b16602b57c6d0a0779dbf1555975",
+      "links": {
+        "documentation": "../plugins/_catalog/excavator/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/plugin.js",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/plugin.js.sig",
+        "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator#getting-started"
+      },
+      "categories": [
+        "Automation",
+        "Discovery"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "limited",
+          "notes": "Requires passive mode patch"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "galdr-proxy",
+      "name": "Galdr Proxy",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "TypeScript",
+      "summary": "Galdr Proxy is the interception layer for Glyph. It terminates client HTTP/HTTPS sessions, applies rules-based modifications, and records a tamper-proof history that other plugins can consume.",
+      "capabilities": [
+        "CAP_HTTP_ACTIVE",
+        "CAP_HTTP_PASSIVE",
+        "CAP_WS"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "50a8b2a25abd06346fc849bab40232de2d768cc60d6f9155bb42caf76b1dcb60",
+      "links": {
+        "documentation": "../plugins/_catalog/galdr-proxy/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/plugin.js",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/plugin.js.sig"
+      },
+      "categories": [
+        "Interception"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "unsupported"
+        },
+        "1.1": {
+          "status": "limited",
+          "notes": "HTTP-only support"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "grapher",
+      "name": "Grapher",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "Go",
+      "summary": "Grapher performs unauthenticated discovery of API schemas so downstream Glyph workflows can reason about surfaced endpoints without touching production credentials.",
+      "capabilities": [
+        "CAP_EMIT_FINDINGS",
+        "CAP_STORAGE"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "ca64abd3b27388206879f4134976387239fd50f4ac6fc3044d812703f8d2af20",
+      "links": {
+        "documentation": "../plugins/_catalog/grapher/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/main.go",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/main.go.sig"
+      },
+      "categories": [
+        "Visualization"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "compatible",
+          "notes": "1.0.0+"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "osint-well",
+      "name": "OSINT Well",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "TypeScript",
+      "summary": "OSINT Well wraps [OWASP Amass](https://github.com/owasp-amass/amass) to surface open-source intelligence such as subdomains and infrastructure relationships. The plugin intentionally defaults to passive reconnaissance so that it can be executed safely in shared or sensitive environments.",
+      "capabilities": [
+        "CAP_EMIT_FINDINGS",
+        "CAP_STORAGE"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "e7a804c5ede93f41fd2eb0871ab380f53d3342b0667f6a969c5c6fcb95b2c027",
+      "links": {
+        "documentation": "../plugins/_catalog/osint-well/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/plugin.js",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/plugin.js.sig",
+        "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well#installation"
+      },
+      "categories": [
+        "Intelligence"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "compatible",
+          "notes": "1.0.0+"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "raider",
+      "name": "Raider",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "TypeScript",
+      "summary": "Raider coordinates focused offensive testing campaigns once high-value targets are identified by discovery plugins.",
+      "capabilities": [
+        "CAP_EMIT_FINDINGS",
+        "CAP_HTTP_ACTIVE",
+        "CAP_HTTP_PASSIVE"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "ac97711a74c78f33d6dbb08d3a4a7e9f9534671db0be96afa84a4b8e451c69dd",
+      "links": {
+        "documentation": "../plugins/_catalog/raider/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/plugin.js",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/plugin.js.sig",
+        "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider#getting-started"
+      },
+      "categories": [
+        "Offense"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "unsupported"
+        },
+        "1.1": {
+          "status": "limited",
+          "notes": "Requires v1.1.5 hotfix"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "ranker",
+      "name": "Ranker",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "TypeScript",
+      "summary": "Ranker scores assets, findings, and leads so teams focus on the highest-impact work first.",
+      "capabilities": [
+        "CAP_EMIT_FINDINGS",
+        "CAP_STORAGE"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "a45acedbd3421c054d07db91f12938ac13f928d47170de6cec88770c5fde13f3",
+      "links": {
+        "documentation": "../plugins/_catalog/ranker/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/plugin.js",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/plugin.js.sig",
+        "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker#getting-started"
+      },
+      "categories": [
+        "Analytics"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "compatible",
+          "notes": "1.0.0+"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "scribe",
+      "name": "Scribe",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "TypeScript",
+      "summary": "Scribe renders investigation output into human-friendly reports, summarizing findings across the Glyph pipeline.",
+      "capabilities": [
+        "CAP_REPORT"
+      ],
+      "last_updated": "2025-09-30T10:30:42-04:00",
+      "signature_sha256": "61b004d72d616382997a2689a3f85d6a032cb29ffe2e53297440a4ee5bb1c0d0",
+      "links": {
+        "documentation": "../plugins/_catalog/scribe/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/plugin.js",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/plugin.js.sig",
+        "installation": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe#getting-started"
+      },
+      "categories": [
+        "Reporting"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "compatible",
+          "notes": "1.0.3+"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    },
+    {
+      "id": "seer",
+      "name": "Seer",
+      "version": "0.1.0",
+      "author": "Glyph Team",
+      "language": "Go",
+      "summary": "Seer inspects passive telemetry to spot anomalies and suspicious behaviors before they escalate into incidents. The v0.3 release focuses on low-noise secret and PII detection tailored for HTTP response bodies.",
+      "capabilities": [
+        "CAP_EMIT_FINDINGS",
+        "CAP_HTTP_PASSIVE"
+      ],
+      "last_updated": "2025-10-03T08:53:18-04:00",
+      "signature_sha256": "46e816b1b0cbd7f804430df0a730f8983004f3136739b6b62818a00b7b7b0fce",
+      "links": {
+        "documentation": "../plugins/_catalog/seer/",
+        "readme": "https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer#readme",
+        "manifest": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/manifest.json",
+        "artifact": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/main.go",
+        "signature": "https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/main.go.sig"
+      },
+      "categories": [
+        "Detection"
+      ],
+      "compatibility": {
+        "1.0": {
+          "status": "limited",
+          "notes": "Passive-only mode"
+        },
+        "1.1": {
+          "status": "compatible",
+          "notes": "1.1.0+"
+        },
+        "2.0": {
+          "status": "compatible",
+          "notes": "2.0.0+"
+        }
+      }
+    }
+  ]
+}

--- a/docs/en/plugins/_catalog/cartographer.md
+++ b/docs/en/plugins/_catalog/cartographer.md
@@ -29,16 +29,16 @@ Cartographer charts application surfaces discovered by crawlers and passive sens
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer#getting-started) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer#getting-started) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/plugin.js)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/plugin.js)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cartographer/plugin.js.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cartographer/plugin.js.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/cryptographer.md
+++ b/docs/en/plugins/_catalog/cryptographer.md
@@ -28,16 +28,16 @@ Cryptographer is a CyberChef-inspired utility surface for quickly transforming p
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer#getting-started) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer#getting-started) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/plugin.js)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/plugin.js)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/cryptographer/plugin.js.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/cryptographer/plugin.js.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/example-hello.md
+++ b/docs/en/plugins/_catalog/example-hello.md
@@ -28,16 +28,16 @@ Example Hello is a Glyph plugin.
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello#readme) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello#readme) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/main.go)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/main.go)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/example-hello/main.go.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/example-hello/main.go.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/excavator.md
+++ b/docs/en/plugins/_catalog/excavator.md
@@ -30,16 +30,16 @@ Excavator is the Playwright-powered crawler foundation for Glyph. It provides a 
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator#getting-started) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator#getting-started) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/plugin.js)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/plugin.js)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/excavator/plugin.js.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/excavator/plugin.js.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/galdr-proxy.md
+++ b/docs/en/plugins/_catalog/galdr-proxy.md
@@ -30,16 +30,16 @@ Galdr Proxy is the interception layer for Glyph. It terminates client HTTP/HTTPS
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy#readme) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy#readme) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/plugin.js)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/plugin.js)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/galdr-proxy/plugin.js.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/galdr-proxy/plugin.js.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/grapher.md
+++ b/docs/en/plugins/_catalog/grapher.md
@@ -29,16 +29,16 @@ Grapher performs unauthenticated discovery of API schemas so downstream Glyph wo
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher#readme) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher#readme) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/main.go)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/main.go)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/grapher/main.go.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/grapher/main.go.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/osint-well.md
+++ b/docs/en/plugins/_catalog/osint-well.md
@@ -29,16 +29,16 @@ OSINT Well wraps [OWASP Amass](https://github.com/owasp-amass/amass) to surface 
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well#installation) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well#installation) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/plugin.js)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/plugin.js)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/osint-well/plugin.js.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/osint-well/plugin.js.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/raider.md
+++ b/docs/en/plugins/_catalog/raider.md
@@ -30,16 +30,16 @@ Raider coordinates focused offensive testing campaigns once high-value targets a
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider#getting-started) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider#getting-started) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/plugin.js)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/plugin.js)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/raider/plugin.js.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/raider/plugin.js.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/ranker.md
+++ b/docs/en/plugins/_catalog/ranker.md
@@ -29,16 +29,16 @@ Ranker scores assets, findings, and leads so teams focus on the highest-impact w
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker#getting-started) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker#getting-started) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/plugin.js)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/plugin.js)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/ranker/plugin.js.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/ranker/plugin.js.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/scribe.md
+++ b/docs/en/plugins/_catalog/scribe.md
@@ -28,16 +28,16 @@ Scribe renders investigation output into human-friendly reports, summarizing fin
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe#getting-started) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe#getting-started) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/plugin.js)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/plugin.js)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/scribe/plugin.js.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/scribe/plugin.js.sig)
 
 
 ### Signature

--- a/docs/en/plugins/_catalog/seer.md
+++ b/docs/en/plugins/_catalog/seer.md
@@ -29,16 +29,16 @@ Seer inspects passive telemetry to spot anomalies and suspicious behaviors befor
 
 Download the signed artefact and verify its signature before running the plugin.
 
-Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer#readme) for detailed steps.
+Follow the [installation guide](https://github.com/RowanDark/Glyph/tree/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer#readme) for detailed steps.
 
 
 ### Downloads
 
-- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/manifest.json)
+- [Manifest](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/manifest.json)
 
-- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/main.go)
+- [Plugin artefact](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/main.go)
 
-- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/9245f2b8970021ae16fb399f76228c7c806dfaf8/plugins/seer/main.go.sig)
+- [Detached signature](https://raw.githubusercontent.com/RowanDark/Glyph/85464c5f43bc57662ffbc313c8008a6119bbc772/plugins/seer/main.go.sig)
 
 
 ### Signature

--- a/docs/en/plugins/catalog.md
+++ b/docs/en/plugins/catalog.md
@@ -27,6 +27,18 @@ straight into the author guides.
       <option value="">All categories</option>
     </select>
   </label>
+  <label class="plugin-catalog__filter">
+    <span>Glyph version</span>
+    <select id="plugin-glyph">
+      <option value="">All versions</option>
+    </select>
+  </label>
+  <label class="plugin-catalog__filter">
+    <span>Compatibility</span>
+    <select id="plugin-compatibility-status">
+      <option value="">All statuses</option>
+    </select>
+  </label>
 </div>
 
 <div id="plugin-catalog" class="plugin-catalog__grid" data-mdx-component="plugin-catalog"></div>
@@ -38,19 +50,38 @@ straight into the author guides.
 
 ## Marketplace metadata feeds
 
-The data that powers the marketplace is stored in
-[`docs/en/data/plugin-catalog.json`](../data/plugin-catalog.json). The file is
-generated from the manifests under `plugins/<id>/manifest.json` by running
-`python scripts/update_plugin_catalog.py`. The command captures the declared
-capabilities, summary, last Git commit date, and the SHA-256 hash of each
-detached signature. Repository owners can extend the schema with custom
-fields—new properties automatically appear in this catalogue without changes to
-the JavaScript renderer.
+The catalogue consumes the central registry feed stored at
+[`docs/en/data/plugin-registry.json`](../data/plugin-registry.json). The JSON
+payload combines the manifest metadata, SHA-256 signatures, categories, and
+compatibility declarations for every vetted plugin.
 
-If you are publishing a third-party plugin, open a pull request that updates the
-manifest and README under `plugins/<id>/`. Re-run the catalogue generator so the
-metadata and per-plugin reference page are refreshed; the docs build picks up
-the change and republishes the marketplace without additional configuration.
+Registry data is generated from the manifests under `plugins/<id>/manifest.json`
+and the compatibility matrix declared in
+[`plugins/compatibility.json`](../../plugins/compatibility.json). Regenerate the
+feed after editing either source by running the publish workflow:
+
+```bash
+glyphctl plugin registry publish --ref $(git rev-parse HEAD)
+```
+
+The command wraps `python scripts/update_plugin_catalog.py`, rebuilding:
+
+- [`docs/en/data/plugin-catalog.json`](../data/plugin-catalog.json) for the
+  marketplace cards.
+- [`docs/en/data/plugin-registry.json`](../data/plugin-registry.json) consumed by
+  the REST service and documentation UI.
+- Reference documentation under [`docs/en/plugins/_catalog/`](./_catalog/).
+
+Repository owners can extend the registry schema with additional properties—new
+fields automatically appear in this catalogue without changes to the JavaScript
+renderer.
+
+!!! info "Self-hosting the registry API"
+    Launch the lightweight registry server locally with
+    `go run ./cmd/glyph-registry --data docs/en/data/plugin-registry.json`. The
+    service exposes `/registry.json`, `/plugins`, and `/compatibility` endpoints
+    for dashboards or automation workflows that want to consume the curated
+    plugin feed directly.
 
 ## Discover more
 

--- a/docs/en/plugins/compatibility-matrix.md
+++ b/docs/en/plugins/compatibility-matrix.md
@@ -5,29 +5,38 @@ description: Understand which plugin versions work with each Glyph core release.
 
 # Plugin compatibility matrix
 
-The table below maps every supported plugin release to the Glyph core versions it
-supports. Compatibility testing runs as part of the release pipeline—plugins are
-only published after their integration suite has passed against the targeted
-core versions.
+The matrix below reflects every plugin listed in the registry feed. Filter by
+Glyph core version or compatibility status to plan safe upgrades—filters apply
+instantly, and search works across plugin names, authors, and categories.
 
-| Plugin | Latest version | Glyph v1.0 | Glyph v1.1 | Glyph v2.0 |
-| ------ | -------------- | ---------- | ---------- | ---------- |
-| Cartographer | `0.1.0` | ✅ 1.0.0+ | ✅ 1.1.0+ | ✅ 2.0.0+ |
-| Cryptographer | `0.1.0` | ✅ 1.0.2+ | ✅ 1.1.0+ | ✅ 2.0.0+ |
-| Excavator | `0.1.0` | ⚠️ Requires passive mode patch | ✅ 1.1.0+ | ✅ 2.0.0+ |
-| Galdr Proxy | `0.1.0` | ❌ | ⚠️ HTTP-only support | ✅ 2.0.0+ |
-| Grapher | `0.1.0` | ✅ 1.0.0+ | ✅ 1.1.0+ | ✅ 2.0.0+ |
-| OSINT Well | `0.1.0` | ✅ 1.0.0+ | ✅ 1.1.0+ | ✅ 2.0.0+ |
-| Raider | `0.1.0` | ❌ | ⚠️ Requires v1.1.5 hotfix | ✅ 2.0.0+ |
-| Ranker | `0.1.0` | ✅ 1.0.0+ | ✅ 1.1.0+ | ✅ 2.0.0+ |
-| Scribe | `0.1.0` | ✅ 1.0.3+ | ✅ 1.1.0+ | ✅ 2.0.0+ |
-| Seer | `0.1.0` | ⚠️ Passive-only mode | ✅ 1.1.0+ | ✅ 2.0.0+ |
+<div class="plugin-compatibility__toolbar">
+  <label class="plugin-compatibility__filter">
+    <span>Search</span>
+    <input type="search" id="compatibility-search" placeholder="Search by plugin or capability" />
+  </label>
+  <label class="plugin-compatibility__filter">
+    <span>Glyph version</span>
+    <select id="compatibility-glyph">
+      <option value="">All versions</option>
+    </select>
+  </label>
+  <label class="plugin-compatibility__filter">
+    <span>Status</span>
+    <select id="compatibility-status">
+      <option value="">All statuses</option>
+      <option value="compatible">Compatible</option>
+      <option value="limited">Limited</option>
+      <option value="unsupported">Unsupported</option>
+    </select>
+  </label>
+</div>
 
-## Legend
+<div id="plugin-compatibility" class="plugin-compatibility__table-wrapper" data-mdx-component="plugin-compatibility"></div>
 
-- ✅ — Fully compatible with the specified Glyph release.
-- ⚠️ — Supported with caveats documented in the plugin README.
-- ❌ — Not compatible with that Glyph release.
+!!! note "Compatibility legend"
+    - ✅ — Fully compatible with the specified Glyph release.
+    - ⚠️ — Supported with caveats documented in the plugin README.
+    - ❌ — Not compatible with that Glyph release.
 
 ## Version constraints
 

--- a/docs/javascripts/plugin-catalog.js
+++ b/docs/javascripts/plugin-catalog.js
@@ -1,7 +1,10 @@
 (function () {
   const docsRoot = resolveDocsRoot('plugin-catalog.js');
   let cachedPlugins = null;
+  let cachedRegistry = null;
   let catalogDataUrl = null;
+  let cachedGlyphVersions = [];
+  const compatibilityStatuses = ['compatible', 'limited', 'unsupported'];
 
   const slugify = (value) =>
     (value || '')
@@ -21,7 +24,9 @@
     const searchField = document.getElementById('plugin-search');
     const languageFilter = document.getElementById('plugin-language');
     const categoryFilter = document.getElementById('plugin-category');
-    if (!searchField || !languageFilter || !categoryFilter) {
+    const glyphFilter = document.getElementById('plugin-glyph');
+    const statusFilter = document.getElementById('plugin-compatibility-status');
+    if (!searchField || !languageFilter || !categoryFilter || !glyphFilter || !statusFilter) {
       return;
     }
 
@@ -37,28 +42,40 @@
     emptyState.setAttribute('aria-live', 'polite');
     emptyState.tabIndex = -1;
 
-    catalogDataUrl = new URL('data/plugin-catalog.json', docsRoot);
+    catalogDataUrl = new URL('data/plugin-registry.json', docsRoot);
     const dataUrl = catalogDataUrl;
 
-    const loadPlugins = cachedPlugins
-      ? Promise.resolve(cachedPlugins)
+    const loadRegistry = cachedRegistry
+      ? Promise.resolve(cachedRegistry)
       : fetch(dataUrl).then((response) => {
           if (!response.ok) {
             throw new Error(`Failed to load plugin catalogue: ${response.status}`);
           }
           return response.json();
+        })
+        .then((payload) => {
+          if (Array.isArray(payload)) {
+            return { plugins: payload, glyph_versions: [] };
+          }
+          return payload;
         });
 
-    loadPlugins
-      .then((plugins) => {
+    loadRegistry
+      .then((registry) => {
+        cachedRegistry = registry;
+        const plugins = Array.isArray(registry.plugins) ? registry.plugins : [];
+        const glyphVersions = Array.isArray(registry.glyph_versions) ? registry.glyph_versions : [];
         cachedPlugins = plugins;
-        renderFilters(plugins, languageFilter, categoryFilter);
-        renderCatalog(plugins, container, emptyState);
+        cachedGlyphVersions = glyphVersions;
+        renderFilters(plugins, languageFilter, categoryFilter, glyphFilter, statusFilter, glyphVersions);
+        renderCatalog(plugins, container, emptyState, glyphVersions);
 
         const handleFilterChange = () => {
           const query = (searchField.value || '').trim().toLowerCase();
           const language = languageFilter.value;
           const category = categoryFilter.value;
+          const glyphVersion = glyphFilter.value;
+          const status = statusFilter.value;
           const filtered = plugins.filter((plugin) => {
             if (language && plugin.language !== language) {
               return false;
@@ -67,8 +84,42 @@
             if (category && !pluginCategories.includes(category)) {
               return false;
             }
+            if (glyphVersion || status) {
+              const compatibility = plugin.compatibility || {};
+              if (glyphVersion) {
+                const glyphEntry = compatibility[glyphVersion];
+                if (!glyphEntry) {
+                  return false;
+                }
+                if (status && glyphEntry.status !== status) {
+                  return false;
+                }
+              } else if (status) {
+                const matchesStatus = Object.values(compatibility).some(
+                  (entry) => entry && entry.status === status,
+                );
+                if (!matchesStatus) {
+                  return false;
+                }
+              }
+            }
             if (!query) {
               return true;
+            }
+            const compatibilityValues = [];
+            if (plugin.compatibility) {
+              Object.entries(plugin.compatibility).forEach(([version, entry]) => {
+                if (!entry) {
+                  return;
+                }
+                compatibilityValues.push(`glyph v${version}`);
+                if (entry.status) {
+                  compatibilityValues.push(entry.status);
+                }
+                if (entry.notes) {
+                  compatibilityValues.push(entry.notes);
+                }
+              });
             }
             const haystack = [
               plugin.name,
@@ -77,17 +128,21 @@
               plugin.language,
               ...(plugin.capabilities || []),
               ...pluginCategories,
+              ...(glyphVersion ? [glyphVersion] : []),
+              ...compatibilityValues,
             ]
               .join(' ')
               .toLowerCase();
             return haystack.includes(query);
           });
-          renderCatalog(filtered, container, emptyState);
+          renderCatalog(filtered, container, emptyState, glyphVersions);
         };
 
         searchField.addEventListener('input', handleFilterChange);
         languageFilter.addEventListener('change', handleFilterChange);
         categoryFilter.addEventListener('change', handleFilterChange);
+        glyphFilter.addEventListener('change', handleFilterChange);
+        statusFilter.addEventListener('change', handleFilterChange);
       })
       .catch((error) => {
         console.error(error); // eslint-disable-line no-console
@@ -127,7 +182,14 @@
     return new URL('..', scriptUrl);
   }
 
-  function renderFilters(plugins, languageFilter, categoryFilter) {
+  function renderFilters(
+    plugins,
+    languageFilter,
+    categoryFilter,
+    glyphFilter,
+    statusFilter,
+    glyphVersions,
+  ) {
     const languages = new Set();
     const categories = new Set();
     plugins.forEach((plugin) => {
@@ -137,6 +199,7 @@
       (plugin.categories || []).forEach((category) => categories.add(category));
     });
 
+    resetSelectOptions(languageFilter);
     Array.from(languages)
       .sort((a, b) => a.localeCompare(b))
       .forEach((language) => {
@@ -146,6 +209,7 @@
         languageFilter.appendChild(option);
       });
 
+    resetSelectOptions(categoryFilter);
     Array.from(categories)
       .sort((a, b) => a.localeCompare(b))
       .forEach((category) => {
@@ -154,9 +218,63 @@
         option.textContent = category;
         categoryFilter.appendChild(option);
       });
+
+    resetSelectOptions(glyphFilter);
+    glyphVersions
+      .slice()
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+      .forEach((version) => {
+        const option = document.createElement('option');
+        option.value = version;
+        option.textContent = `Glyph v${version}`;
+        glyphFilter.appendChild(option);
+      });
+
+    resetSelectOptions(statusFilter);
+    compatibilityStatuses.forEach((status) => {
+      const option = document.createElement('option');
+      option.value = status;
+      option.textContent = statusLabel(status);
+      statusFilter.appendChild(option);
+    });
   }
 
-  function renderCatalog(plugins, container, emptyState) {
+  function resetSelectOptions(select) {
+    if (!select) {
+      return;
+    }
+    while (select.options.length > 1) {
+      select.remove(1);
+    }
+  }
+
+  function statusLabel(status) {
+    switch (status) {
+      case 'compatible':
+        return 'Compatible';
+      case 'limited':
+        return 'Limited';
+      case 'unsupported':
+        return 'Unsupported';
+      default:
+        return status || '';
+    }
+  }
+
+  function statusIcon(status) {
+    switch (status) {
+      case 'compatible':
+        return '✅';
+      case 'limited':
+        return '⚠️';
+      case 'unsupported':
+        return '❌';
+      default:
+        return '•';
+    }
+  }
+
+  function renderCatalog(plugins, container, emptyState, glyphVersions) {
     container.setAttribute('aria-busy', 'true');
     container.innerHTML = '';
     if (!plugins.length) {
@@ -169,12 +287,12 @@
     }
 
     plugins.forEach((plugin) => {
-      container.appendChild(renderPlugin(plugin));
+      container.appendChild(renderPlugin(plugin, glyphVersions));
     });
     container.setAttribute('aria-busy', 'false');
   }
 
-  function renderPlugin(plugin) {
+  function renderPlugin(plugin, glyphVersions) {
     const card = document.createElement('article');
     card.className = 'plugin-card';
     card.setAttribute('role', 'listitem');
@@ -312,8 +430,67 @@
       card.appendChild(catLabel);
       card.appendChild(categories);
     }
+
+    const compatibility = renderCompatibility(plugin, glyphVersions);
+    if (compatibility) {
+      const compatibilityLabel = document.createElement('p');
+      compatibilityLabel.className = 'plugin-card__label';
+      compatibilityLabel.textContent = 'Compatibility';
+      card.appendChild(compatibilityLabel);
+      card.appendChild(compatibility);
+    }
     card.appendChild(footer);
     return card;
+  }
+
+  function renderCompatibility(plugin, glyphVersions) {
+    const compat = plugin.compatibility || {};
+    const orderedVersions = [];
+    const seen = new Set();
+    glyphVersions.forEach((version) => {
+      if (compat[version]) {
+        orderedVersions.push(version);
+        seen.add(version);
+      }
+    });
+    Object.keys(compat)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+      .forEach((version) => {
+        if (!seen.has(version)) {
+          orderedVersions.push(version);
+          seen.add(version);
+        }
+      });
+    if (!orderedVersions.length) {
+      return null;
+    }
+    const container = document.createElement('div');
+    container.className = 'plugin-card__compatibility';
+    orderedVersions.forEach((version) => {
+      const entry = compat[version];
+      if (!entry || !entry.status) {
+        return;
+      }
+      const badge = document.createElement('span');
+      badge.className = `plugin-card__compatibility-badge plugin-card__compatibility-badge--${entry.status}`;
+      badge.setAttribute('data-version', version);
+      const icon = document.createElement('span');
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = statusIcon(entry.status);
+      const text = document.createElement('span');
+      text.textContent = `Glyph v${version}`;
+      badge.appendChild(icon);
+      badge.appendChild(text);
+      const description = statusLabel(entry.status);
+      const notes = entry.notes ? ` — ${entry.notes}` : '';
+      badge.setAttribute('title', `${description}${notes}`.trim());
+      badge.setAttribute('aria-label', `${description} on Glyph v${version}${entry.notes ? `: ${entry.notes}` : ''}`);
+      container.appendChild(badge);
+    });
+    if (!container.childElementCount) {
+      return null;
+    }
+    return container;
   }
 
   function formatDate(value) {

--- a/docs/javascripts/plugin-compatibility.js
+++ b/docs/javascripts/plugin-compatibility.js
@@ -1,0 +1,324 @@
+(function () {
+  const docsRoot = resolveDocsRoot('plugin-compatibility.js');
+  let cachedRegistry = null;
+
+  const init = () => window.requestAnimationFrame(initialise);
+  if (window.document$ && typeof window.document$.subscribe === 'function') {
+    window.document$.subscribe(init);
+  }
+
+  if (document.readyState !== 'loading') {
+    init();
+  } else {
+    document.addEventListener('DOMContentLoaded', init);
+  }
+
+  function initialise() {
+    const container = document.getElementById('plugin-compatibility');
+    if (!container || container.dataset.compatibilityInitialised) {
+      return;
+    }
+
+    const searchField = document.getElementById('compatibility-search');
+    const glyphFilter = document.getElementById('compatibility-glyph');
+    const statusFilter = document.getElementById('compatibility-status');
+    if (!searchField || !glyphFilter || !statusFilter) {
+      return;
+    }
+
+    container.dataset.compatibilityInitialised = 'true';
+    container.setAttribute('role', 'region');
+    container.setAttribute('aria-live', 'polite');
+    container.setAttribute('aria-busy', 'true');
+
+    const dataUrl = new URL('data/plugin-registry.json', docsRoot);
+    const loadRegistry = cachedRegistry
+      ? Promise.resolve(cachedRegistry)
+      : fetch(dataUrl)
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`Failed to load plugin registry: ${response.status}`);
+            }
+            return response.json();
+          })
+          .then((payload) => {
+            if (Array.isArray(payload)) {
+              return { plugins: payload, glyph_versions: [] };
+            }
+            return payload;
+          });
+
+    loadRegistry
+      .then((registry) => {
+        cachedRegistry = registry;
+        const plugins = Array.isArray(registry.plugins) ? registry.plugins : [];
+        const glyphVersions = Array.isArray(registry.glyph_versions) ? registry.glyph_versions : [];
+        populateFilters(glyphFilter, statusFilter, glyphVersions);
+        renderTable(container, plugins, glyphVersions, {
+          query: '',
+          glyph: '',
+          status: '',
+        });
+
+        const handleChange = () => {
+          const filters = {
+            query: (searchField.value || '').trim().toLowerCase(),
+            glyph: glyphFilter.value,
+            status: statusFilter.value,
+          };
+          renderTable(container, plugins, glyphVersions, filters);
+        };
+
+        searchField.addEventListener('input', handleChange);
+        glyphFilter.addEventListener('change', handleChange);
+        statusFilter.addEventListener('change', handleChange);
+      })
+      .catch((error) => {
+        console.error(error); // eslint-disable-line no-console
+        container.innerHTML = '';
+        const failure = document.createElement('p');
+        failure.className = 'plugin-compatibility__empty';
+        failure.textContent = 'Unable to load compatibility data. Please try reloading the page.';
+        failure.setAttribute('role', 'alert');
+        container.appendChild(failure);
+        container.setAttribute('aria-busy', 'false');
+      });
+  }
+
+  function populateFilters(glyphFilter, statusFilter, glyphVersions) {
+    resetSelectOptions(glyphFilter);
+    glyphVersions
+      .slice()
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+      .forEach((version) => {
+        const option = document.createElement('option');
+        option.value = version;
+        option.textContent = `Glyph v${version}`;
+        glyphFilter.appendChild(option);
+      });
+
+    resetSelectOptions(statusFilter);
+    ['compatible', 'limited', 'unsupported'].forEach((status) => {
+      const option = document.createElement('option');
+      option.value = status;
+      option.textContent = statusLabel(status);
+      statusFilter.appendChild(option);
+    });
+  }
+
+  function renderTable(container, plugins, glyphVersions, filters) {
+    container.setAttribute('aria-busy', 'true');
+    container.innerHTML = '';
+
+    const filtered = plugins
+      .filter((plugin) => filterPlugin(plugin, glyphVersions, filters))
+      .sort((a, b) => (a.name || a.id || '').localeCompare(b.name || b.id || ''));
+
+    if (!filtered.length) {
+      const empty = document.createElement('p');
+      empty.className = 'plugin-compatibility__empty';
+      empty.textContent = 'No plugins match the selected filters yet.';
+      empty.setAttribute('role', 'status');
+      container.appendChild(empty);
+      container.setAttribute('aria-busy', 'false');
+      return;
+    }
+
+    const table = document.createElement('table');
+    table.className = 'plugin-compatibility__table';
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    ['Plugin', 'Latest version', ...glyphVersions.map((version) => `Glyph v${version}`)].forEach((heading, index) => {
+      const cell = document.createElement('th');
+      cell.scope = 'col';
+      cell.textContent = heading;
+      if (index === 0) {
+        cell.style.minWidth = '12rem';
+      }
+      headRow.appendChild(cell);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    filtered.forEach((plugin) => {
+      const row = document.createElement('tr');
+
+      const nameCell = document.createElement('th');
+      nameCell.scope = 'row';
+      const link = resolvePluginLink(plugin);
+      if (link) {
+        const anchor = document.createElement('a');
+        anchor.href = link;
+        anchor.textContent = plugin.name || plugin.id;
+        anchor.rel = 'noopener noreferrer';
+        nameCell.appendChild(anchor);
+      } else {
+        nameCell.textContent = plugin.name || plugin.id;
+      }
+      row.appendChild(nameCell);
+
+      const versionCell = document.createElement('td');
+      versionCell.textContent = plugin.version ? `v${plugin.version}` : 'Unversioned';
+      row.appendChild(versionCell);
+
+      glyphVersions.forEach((version) => {
+        const cell = document.createElement('td');
+        const entry = plugin.compatibility ? plugin.compatibility[version] : null;
+        if (entry && entry.status) {
+          cell.appendChild(renderStatus(entry));
+        } else {
+          cell.textContent = '—';
+          cell.style.textAlign = 'center';
+        }
+        row.appendChild(cell);
+      });
+
+      tbody.appendChild(row);
+    });
+
+    table.appendChild(tbody);
+    container.appendChild(table);
+    container.setAttribute('aria-busy', 'false');
+  }
+
+  function renderStatus(entry) {
+    const wrapper = document.createElement('div');
+    wrapper.className = `plugin-compatibility__status plugin-compatibility__status--${entry.status}`;
+    const icon = document.createElement('span');
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = statusIcon(entry.status);
+    wrapper.appendChild(icon);
+
+    const label = document.createElement('span');
+    label.textContent = statusLabel(entry.status);
+    wrapper.appendChild(label);
+
+    if (entry.notes) {
+      const notes = document.createElement('div');
+      notes.className = 'plugin-compatibility__notes';
+      notes.textContent = entry.notes;
+      wrapper.appendChild(notes);
+    }
+
+    return wrapper;
+  }
+
+  function filterPlugin(plugin, glyphVersions, filters) {
+    const query = filters.query;
+    const glyph = filters.glyph;
+    const status = filters.status;
+
+    if (glyph) {
+      const entry = plugin.compatibility ? plugin.compatibility[glyph] : null;
+      if (!entry) {
+        return false;
+      }
+      if (status && entry.status !== status) {
+        return false;
+      }
+    } else if (status) {
+      const hasStatus = Object.values(plugin.compatibility || {}).some(
+        (entry) => entry && entry.status === status,
+      );
+      if (!hasStatus) {
+        return false;
+      }
+    }
+
+    if (!query) {
+      return true;
+    }
+
+    const haystack = [
+      plugin.name,
+      plugin.id,
+      plugin.summary,
+      plugin.author,
+      plugin.language,
+      ...(plugin.capabilities || []),
+      ...((plugin.categories || [])),
+    ];
+
+    if (plugin.compatibility) {
+      Object.entries(plugin.compatibility).forEach(([version, entry]) => {
+        if (!entry) {
+          return;
+        }
+        haystack.push(`glyph v${version}`);
+        if (entry.status) {
+          haystack.push(entry.status);
+        }
+        if (entry.notes) {
+          haystack.push(entry.notes);
+        }
+      });
+    }
+
+    return haystack
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+      .includes(query);
+  }
+
+  function resolvePluginLink(plugin) {
+    const base = docsRoot;
+    const href = plugin.links?.documentation || plugin.links?.readme;
+    if (!href) {
+      return null;
+    }
+    try {
+      return new URL(href, base).href;
+    } catch (error) {
+      console.warn('Unable to resolve plugin link', error); // eslint-disable-line no-console
+      return href;
+    }
+  }
+
+  function resetSelectOptions(select) {
+    while (select.options.length > 1) {
+      select.remove(1);
+    }
+  }
+
+  function statusLabel(status) {
+    switch (status) {
+      case 'compatible':
+        return 'Compatible';
+      case 'limited':
+        return 'Limited';
+      case 'unsupported':
+        return 'Unsupported';
+      default:
+        return status || '';
+    }
+  }
+
+  function statusIcon(status) {
+    switch (status) {
+      case 'compatible':
+        return '✅';
+      case 'limited':
+        return '⚠️';
+      case 'unsupported':
+        return '❌';
+      default:
+        return '•';
+    }
+  }
+
+  function resolveDocsRoot(scriptName) {
+    let script = document.currentScript;
+    if (!script || !(script.src || '').includes(scriptName)) {
+      script = Array.from(document.getElementsByTagName('script')).find((element) =>
+        (element.src || '').includes(scriptName),
+      );
+    }
+    if (!script) {
+      return new URL('.', window.location.href);
+    }
+    const scriptUrl = new URL(script.src, window.location.href);
+    return new URL('..', scriptUrl);
+  }
+})();

--- a/docs/stylesheets/marketplace.css
+++ b/docs/stylesheets/marketplace.css
@@ -130,6 +130,41 @@
   gap: 0.5rem;
 }
 
+.plugin-card__compatibility {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.25rem 0 0;
+}
+
+.plugin-card__compatibility-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.4rem;
+  border: 1px solid transparent;
+}
+
+.plugin-card__compatibility-badge--compatible {
+  background: rgba(16, 185, 129, 0.12);
+  color: rgb(16, 122, 87);
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+.plugin-card__compatibility-badge--limited {
+  background: rgba(251, 191, 36, 0.15);
+  color: rgb(181, 105, 0);
+  border-color: rgba(251, 191, 36, 0.35);
+}
+
+.plugin-card__compatibility-badge--unsupported {
+  background: rgba(248, 113, 113, 0.18);
+  color: rgb(153, 27, 27);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
 .plugin-card__link {
   font-weight: 600;
   display: inline-flex;
@@ -142,6 +177,85 @@
 
 .plugin-catalog__empty {
   grid-column: 1 / -1;
+  margin: 0;
+  padding: 1rem;
+  border: 1px dashed var(--md-default-fg-color--lightest);
+  border-radius: 0.5rem;
+  text-align: center;
+}
+
+.plugin-compatibility__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  align-items: flex-end;
+}
+
+.plugin-compatibility__filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.plugin-compatibility__filter input,
+.plugin-compatibility__filter select {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.25rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  min-width: 12rem;
+}
+
+.plugin-compatibility__table-wrapper {
+  overflow-x: auto;
+}
+
+.plugin-compatibility__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.plugin-compatibility__table th,
+.plugin-compatibility__table td {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.plugin-compatibility__table thead {
+  background: var(--md-default-fg-color--lightest);
+  color: var(--md-default-bg-color);
+}
+
+.plugin-compatibility__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.plugin-compatibility__status--compatible {
+  color: rgb(16, 122, 87);
+}
+
+.plugin-compatibility__status--limited {
+  color: rgb(181, 105, 0);
+}
+
+.plugin-compatibility__status--unsupported {
+  color: rgb(153, 27, 27);
+}
+
+.plugin-compatibility__notes {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.8rem;
+}
+
+.plugin-compatibility__empty {
   margin: 0;
   padding: 1rem;
   border: 1px dashed var(--md-default-fg-color--lightest);

--- a/internal/registry/dataset.go
+++ b/internal/registry/dataset.go
@@ -1,0 +1,296 @@
+package registry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+)
+
+var allowedStatuses = map[string]struct{}{
+	"compatible":  {},
+	"limited":     {},
+	"unsupported": {},
+}
+
+// Dataset represents the plugin registry payload persisted to disk or served
+// via the registry API.
+type Dataset struct {
+	GeneratedAt   time.Time `json:"generated_at"`
+	GlyphVersions []string  `json:"glyph_versions"`
+	Plugins       []Plugin  `json:"plugins"`
+}
+
+// Plugin contains the metadata tracked for each registry entry.
+type Plugin struct {
+	ID              string                   `json:"id"`
+	Name            string                   `json:"name"`
+	Version         string                   `json:"version"`
+	Author          string                   `json:"author"`
+	Language        string                   `json:"language"`
+	Summary         string                   `json:"summary"`
+	Capabilities    []string                 `json:"capabilities"`
+	Categories      []string                 `json:"categories,omitempty"`
+	LastUpdated     string                   `json:"last_updated,omitempty"`
+	SignatureSHA256 string                   `json:"signature_sha256"`
+	Links           map[string]string        `json:"links"`
+	Compatibility   map[string]Compatibility `json:"compatibility,omitempty"`
+}
+
+// Compatibility describes Glyph core support for a plugin release.
+type Compatibility struct {
+	Status string `json:"status"`
+	Notes  string `json:"notes,omitempty"`
+}
+
+// Filter expresses the constraints used when searching the registry.
+type Filter struct {
+	Query      string
+	Language   string
+	Category   string
+	Capability string
+	Glyph      string
+	Status     string
+}
+
+// Load reads a registry dataset from disk, validates its structure, and
+// normalises the content for efficient querying.
+func Load(path string) (Dataset, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Dataset{}, fmt.Errorf("read registry dataset: %w", err)
+	}
+
+	var dataset Dataset
+	if err := json.Unmarshal(raw, &dataset); err != nil {
+		return Dataset{}, fmt.Errorf("decode registry dataset: %w", err)
+	}
+	if err := dataset.Validate(); err != nil {
+		return Dataset{}, err
+	}
+	dataset.normalise()
+
+	return dataset, nil
+}
+
+// Validate checks that the dataset is well-formed.
+func (d *Dataset) Validate() error {
+	if d == nil {
+		return errors.New("registry dataset is nil")
+	}
+
+	glyphSet := make(map[string]struct{}, len(d.GlyphVersions))
+	trimmedGlyphs := d.GlyphVersions[:0]
+	for _, version := range d.GlyphVersions {
+		v := strings.TrimSpace(version)
+		if v == "" {
+			continue
+		}
+		if _, exists := glyphSet[v]; exists {
+			continue
+		}
+		glyphSet[v] = struct{}{}
+		trimmedGlyphs = append(trimmedGlyphs, v)
+	}
+	d.GlyphVersions = trimmedGlyphs
+
+	for idx := range d.Plugins {
+		plugin := &d.Plugins[idx]
+		plugin.ID = strings.TrimSpace(plugin.ID)
+		if plugin.ID == "" {
+			return fmt.Errorf("registry plugin at index %d missing id", idx)
+		}
+		plugin.Name = strings.TrimSpace(plugin.Name)
+		plugin.Author = strings.TrimSpace(plugin.Author)
+		plugin.Language = strings.TrimSpace(plugin.Language)
+		plugin.Summary = strings.TrimSpace(plugin.Summary)
+		plugin.SignatureSHA256 = strings.TrimSpace(plugin.SignatureSHA256)
+
+		plugin.Capabilities = unique(plugin.Capabilities)
+		plugin.Categories = unique(plugin.Categories)
+
+		if plugin.Compatibility != nil {
+			for glyph, entry := range plugin.Compatibility {
+				trimmedGlyph := strings.TrimSpace(glyph)
+				if trimmedGlyph == "" {
+					return fmt.Errorf("plugin %s has empty glyph version in compatibility", plugin.ID)
+				}
+				entry.Status = strings.TrimSpace(entry.Status)
+				entry.Notes = strings.TrimSpace(entry.Notes)
+				if entry.Status == "" {
+					return fmt.Errorf("plugin %s compatibility for %s missing status", plugin.ID, trimmedGlyph)
+				}
+				if _, ok := allowedStatuses[entry.Status]; !ok {
+					return fmt.Errorf(
+						"plugin %s compatibility for %s has unknown status %q",
+						plugin.ID,
+						trimmedGlyph,
+						entry.Status,
+					)
+				}
+				plugin.Compatibility[trimmedGlyph] = entry
+				if trimmedGlyph != glyph {
+					delete(plugin.Compatibility, glyph)
+				}
+				if _, exists := glyphSet[trimmedGlyph]; !exists {
+					glyphSet[trimmedGlyph] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if len(d.GlyphVersions) == 0 && len(glyphSet) > 0 {
+		d.GlyphVersions = make([]string, 0, len(glyphSet))
+		for version := range glyphSet {
+			d.GlyphVersions = append(d.GlyphVersions, version)
+		}
+	}
+
+	return nil
+}
+
+// FilterPlugins returns the set of plugins that match the provided constraints.
+func (d Dataset) FilterPlugins(filter Filter) []Plugin {
+	query := strings.ToLower(strings.TrimSpace(filter.Query))
+	language := strings.TrimSpace(filter.Language)
+	category := strings.TrimSpace(filter.Category)
+	capability := strings.TrimSpace(filter.Capability)
+	glyph := strings.TrimSpace(filter.Glyph)
+	status := strings.TrimSpace(filter.Status)
+
+	var results []Plugin
+	for _, plugin := range d.Plugins {
+		if language != "" && plugin.Language != language {
+			continue
+		}
+		if category != "" && !contains(plugin.Categories, category) {
+			continue
+		}
+		if capability != "" && !contains(plugin.Capabilities, capability) {
+			continue
+		}
+		if glyph != "" {
+			entry, ok := plugin.Compatibility[glyph]
+			if !ok {
+				continue
+			}
+			if status != "" && entry.Status != status {
+				continue
+			}
+		} else if status != "" {
+			found := false
+			for _, entry := range plugin.Compatibility {
+				if entry.Status == status {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		if query != "" && !matchesQuery(plugin, query) {
+			continue
+		}
+		results = append(results, plugin)
+	}
+	return results
+}
+
+// Plugin returns the registry entry for the provided ID, performing a
+// case-insensitive lookup.
+func (d Dataset) Plugin(id string) (Plugin, bool) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return Plugin{}, false
+	}
+	for _, plugin := range d.Plugins {
+		if plugin.ID == trimmed || strings.EqualFold(plugin.ID, trimmed) {
+			return plugin, true
+		}
+	}
+	return Plugin{}, false
+}
+
+func (d *Dataset) normalise() {
+	d.GlyphVersions = unique(d.GlyphVersions)
+	slices.Sort(d.GlyphVersions)
+
+	slices.SortStableFunc(d.Plugins, func(a, b Plugin) int {
+		left := strings.ToLower(strings.TrimSpace(a.Name))
+		if left == "" {
+			left = strings.ToLower(strings.TrimSpace(a.ID))
+		}
+		right := strings.ToLower(strings.TrimSpace(b.Name))
+		if right == "" {
+			right = strings.ToLower(strings.TrimSpace(b.ID))
+		}
+		return strings.Compare(left, right)
+	})
+
+	for idx := range d.Plugins {
+		plugin := &d.Plugins[idx]
+		plugin.Capabilities = unique(plugin.Capabilities)
+		plugin.Categories = unique(plugin.Categories)
+		slices.Sort(plugin.Capabilities)
+		slices.Sort(plugin.Categories)
+		if plugin.Compatibility != nil {
+			for glyph, entry := range plugin.Compatibility {
+				entry.Status = strings.TrimSpace(entry.Status)
+				entry.Notes = strings.TrimSpace(entry.Notes)
+				plugin.Compatibility[glyph] = entry
+			}
+		}
+	}
+}
+
+func unique(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesQuery(plugin Plugin, query string) bool {
+	haystack := []string{
+		plugin.Name,
+		plugin.ID,
+		plugin.Summary,
+		plugin.Author,
+		plugin.Language,
+		strings.Join(plugin.Capabilities, " "),
+		strings.Join(plugin.Categories, " "),
+	}
+
+	for version, entry := range plugin.Compatibility {
+		haystack = append(haystack, "glyph v"+version, entry.Status, entry.Notes)
+	}
+
+	joined := strings.ToLower(strings.Join(haystack, " "))
+	return strings.Contains(joined, query)
+}

--- a/internal/registry/dataset_test.go
+++ b/internal/registry/dataset_test.go
@@ -1,0 +1,42 @@
+package registry
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDataset(t *testing.T) {
+	path := filepath.Join("testdata", "registry.json")
+	dataset, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(dataset.Plugins) != 2 {
+		t.Fatalf("expected 2 plugins, got %d", len(dataset.Plugins))
+	}
+	if dataset.GlyphVersions[0] != "1.0" || dataset.GlyphVersions[1] != "2.0" {
+		t.Fatalf("unexpected glyph versions: %v", dataset.GlyphVersions)
+	}
+
+	alpha, ok := dataset.Plugin("alpha")
+	if !ok {
+		t.Fatalf("expected to find plugin alpha")
+	}
+	if alpha.Compatibility["2.0"].Status != "compatible" {
+		t.Fatalf("unexpected status for alpha@2.0: %s", alpha.Compatibility["2.0"].Status)
+	}
+
+	filtered := dataset.FilterPlugins(Filter{Glyph: "2.0", Status: "compatible"})
+	if len(filtered) != 1 || filtered[0].ID != "alpha" {
+		t.Fatalf("expected only alpha to match, got %#v", filtered)
+	}
+
+	byQuery := dataset.FilterPlugins(Filter{Query: "crawler"})
+	if len(byQuery) != 1 || byQuery[0].ID != "bravo" {
+		t.Fatalf("expected bravo to match query, got %#v", byQuery)
+	}
+
+	if _, ok := dataset.Plugin("BRAVO"); !ok {
+		t.Fatalf("case-insensitive lookup failed")
+	}
+}

--- a/internal/registry/testdata/registry.json
+++ b/internal/registry/testdata/registry.json
@@ -1,0 +1,41 @@
+{
+  "generated_at": "2025-01-01T00:00:00Z",
+  "glyph_versions": ["1.0", "2.0"],
+  "plugins": [
+    {
+      "id": "alpha",
+      "name": "Alpha",
+      "version": "1.2.3",
+      "author": "Core Team",
+      "language": "Go",
+      "summary": "Alpha plugin for reporting",
+      "capabilities": ["CAP_REPORT", "CAP_EMIT_FINDINGS"],
+      "categories": ["Reporting"],
+      "signature_sha256": "abc123",
+      "links": {
+        "documentation": "https://example.com/alpha"
+      },
+      "compatibility": {
+        "1.0": {"status": "limited", "notes": "Legacy support"},
+        "2.0": {"status": "compatible"}
+      }
+    },
+    {
+      "id": "bravo",
+      "name": "Bravo",
+      "version": "0.9.0",
+      "author": "Core Team",
+      "language": "TypeScript",
+      "summary": "Bravo crawler",
+      "capabilities": ["CAP_SPIDER"],
+      "categories": ["Discovery"],
+      "signature_sha256": "def456",
+      "links": {
+        "documentation": "https://example.com/bravo"
+      },
+      "compatibility": {
+        "2.0": {"status": "unsupported", "notes": "Requires rewrite"}
+      }
+    }
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,8 @@ extra_javascript:
     defer: true
   - path: javascripts/plugin-catalog.js
     defer: true
+  - path: javascripts/plugin-compatibility.js
+    defer: true
   - path: javascripts/lazy-media.js
     defer: true
   - path: javascripts/quickstart-demo.js

--- a/plugins/compatibility.json
+++ b/plugins/compatibility.json
@@ -1,0 +1,104 @@
+{
+  "glyph_versions": ["1.0", "1.1", "2.0"],
+  "plugins": [
+    {
+      "id": "cartographer",
+      "categories": ["Discovery", "Recon"],
+      "compatibility": {
+        "1.0": {"status": "compatible", "notes": "1.0.0+"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "cryptographer",
+      "categories": ["Utilities"],
+      "compatibility": {
+        "1.0": {"status": "compatible", "notes": "1.0.0+"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "example-hello",
+      "categories": ["Examples"],
+      "compatibility": {
+        "1.0": {"status": "compatible", "notes": "1.0.0+"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "excavator",
+      "categories": ["Discovery", "Automation"],
+      "compatibility": {
+        "1.0": {"status": "limited", "notes": "Requires passive mode patch"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "galdr-proxy",
+      "categories": ["Interception"],
+      "compatibility": {
+        "1.0": {"status": "unsupported"},
+        "1.1": {"status": "limited", "notes": "HTTP-only support"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "grapher",
+      "categories": ["Visualization"],
+      "compatibility": {
+        "1.0": {"status": "compatible", "notes": "1.0.0+"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "osint-well",
+      "categories": ["Intelligence"],
+      "compatibility": {
+        "1.0": {"status": "compatible", "notes": "1.0.0+"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "raider",
+      "categories": ["Offense"],
+      "compatibility": {
+        "1.0": {"status": "unsupported"},
+        "1.1": {"status": "limited", "notes": "Requires v1.1.5 hotfix"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "ranker",
+      "categories": ["Analytics"],
+      "compatibility": {
+        "1.0": {"status": "compatible", "notes": "1.0.0+"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "scribe",
+      "categories": ["Reporting"],
+      "compatibility": {
+        "1.0": {"status": "compatible", "notes": "1.0.3+"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    },
+    {
+      "id": "seer",
+      "categories": ["Detection"],
+      "compatibility": {
+        "1.0": {"status": "limited", "notes": "Passive-only mode"},
+        "1.1": {"status": "compatible", "notes": "1.1.0+"},
+        "2.0": {"status": "compatible", "notes": "2.0.0+"}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- generate a centralized plugin registry feed with compatibility metadata and expose it via a new Go server
- extend glyphctl with a `plugin registry publish` workflow and share registry loading utilities
- refresh the docs marketplace UI with compatibility filters, a dynamic matrix view, and registry publishing guidance

## Testing
- go test ./... *(fails: existing tracing exporter import error and glyphd build issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e59c08a1cc832aa11288f842497013