### PR TITLE
Add glyphctl UI explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ the generated findings, and emits an interactive HTML report under `out/demo/`.
 point. See the [Quickstart walkthrough](https://rowandark.github.io/Glyph/quickstart/)
 for a full tour and troubleshooting notes.
 
+To inspect the generated Cases, launch the embedded UI server and open the
+provided address in your browser:
+
+```bash
+glyphctl serve ui --input out/demo/findings.jsonl
+```
+
+The UI lists correlated Cases, risk metadata, and evidence, and offers SARIF and
+JSON exports for downstream tooling.
+
 As the pipeline completes, the CLI streams status updates for each stage and
 prints a Case preview summarising the top finding, including its proof of
 concept command and embedded thumbnail metadata.

--- a/cmd/glyphctl/main.go
+++ b/cmd/glyphctl/main.go
@@ -76,18 +76,30 @@ func main() {
 			fmt.Fprintln(os.Stderr, "repeater subcommand required")
 			os.Exit(2)
 		}
-		switch args[1] {
-		case "send":
-			os.Exit(runRepeaterSend(args[2:]))
-		default:
-			fmt.Fprintf(os.Stderr, "unknown repeater subcommand: %s\n", args[1])
-			os.Exit(2)
-		}
-	case "replay":
-		os.Exit(runReplay(args[1:]))
-	case "version":
-		os.Exit(runVersion(args[1:]))
-	default:
+                switch args[1] {
+                case "send":
+                        os.Exit(runRepeaterSend(args[2:]))
+                default:
+                        fmt.Fprintf(os.Stderr, "unknown repeater subcommand: %s\n", args[1])
+                        os.Exit(2)
+                }
+        case "serve":
+                if len(args) < 2 {
+                        fmt.Fprintln(os.Stderr, "serve subcommand required")
+                        os.Exit(2)
+                }
+                switch args[1] {
+                case "ui":
+                        os.Exit(runServeUI(args[2:]))
+                default:
+                        fmt.Fprintf(os.Stderr, "unknown serve subcommand: %s\n", args[1])
+                        os.Exit(2)
+                }
+        case "replay":
+                os.Exit(runReplay(args[1:]))
+        case "version":
+                os.Exit(runVersion(args[1:]))
+        default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
 		flag.Usage()
 		os.Exit(2)

--- a/cmd/glyphctl/serve_ui.go
+++ b/cmd/glyphctl/serve_ui.go
@@ -1,0 +1,353 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	stdfs "io/fs"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/exporter"
+	"github.com/RowanDark/Glyph/internal/reporter"
+)
+
+// uiAssets contains the static files that power the Glyph UI server.
+var (
+	//go:embed ui_assets/*
+	uiAssets embed.FS
+)
+
+type uiDataset struct {
+	Cases         []cases.Case       `json:"cases"`
+	Telemetry     exporter.Telemetry `json:"telemetry"`
+	FindingsCount int                `json:"findings_count"`
+	RefreshedAt   string             `json:"refreshed_at"`
+}
+
+type uiServerState struct {
+	dataset   uiDataset
+	casesJSON []byte
+	sarif     []byte
+	caseIndex map[string]cases.Case
+}
+
+func runServeUI(args []string) int {
+	fs := flag.NewFlagSet("serve ui", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	addr := fs.String("addr", "127.0.0.1:5150", "address to bind the UI server")
+	input := fs.String("input", reporter.DefaultFindingsPath, "path to findings JSONL input")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(os.Stderr, "unexpected argument: %s\n", fs.Arg(0))
+		return 2
+	}
+
+	dataset, err := loadUIDataset(strings.TrimSpace(*input))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load dataset: %v\n", err)
+		return 1
+	}
+
+	state, err := newUIServerState(dataset)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "prepare UI server: %v\n", err)
+		return 1
+	}
+
+	listener, err := net.Listen("tcp", strings.TrimSpace(*addr))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen: %v\n", err)
+		return 1
+	}
+	defer func() { _ = listener.Close() }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", serveIndex)
+	mux.HandleFunc("/api/data", state.handleAPIDataset)
+	mux.HandleFunc("/download/cases.json", state.handleDownloadCasesJSON)
+	mux.HandleFunc("/download/cases.sarif", state.handleDownloadSARIF)
+	mux.HandleFunc("/download/case/", state.handleDownloadCaseAsset)
+	assetFS, err := stdfs.Sub(uiAssets, "ui_assets")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load assets: %v\n", err)
+		return 1
+	}
+	fileServer := http.FileServer(http.FS(assetFS))
+	mux.Handle("/static/", http.StripPrefix("/static/", fileServer))
+
+	server := &http.Server{Handler: mux}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	fmt.Fprintf(os.Stdout, "Glyph UI available at http://%s\n", listener.Addr())
+	err = server.Serve(listener)
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		fmt.Fprintf(os.Stderr, "serve UI: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func serveIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	data, err := uiAssets.ReadFile("ui_assets/index.html")
+	if err != nil {
+		http.Error(w, "missing UI assets", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func loadUIDataset(inputPath string) (uiDataset, error) {
+	if inputPath == "" {
+		inputPath = reporter.DefaultFindingsPath
+	}
+	findingsList, err := reporter.ReadJSONL(inputPath)
+	if err != nil {
+		return uiDataset{}, err
+	}
+
+	builder := cases.NewBuilder()
+	casesList, err := builder.Build(context.Background(), findingsList)
+	if err != nil {
+		return uiDataset{}, err
+	}
+	if casesList == nil {
+		casesList = []cases.Case{}
+	}
+
+	telemetry := exporter.BuildTelemetry(casesList, len(findingsList))
+	dataset := uiDataset{
+		Cases:         casesList,
+		Telemetry:     telemetry,
+		FindingsCount: len(findingsList),
+		RefreshedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+	return dataset, nil
+}
+
+func newUIServerState(dataset uiDataset) (uiServerState, error) {
+	state := uiServerState{dataset: dataset, caseIndex: make(map[string]cases.Case, len(dataset.Cases))}
+	for _, c := range dataset.Cases {
+		state.caseIndex[c.ID] = c
+	}
+
+	envelope := struct {
+		GeneratedAt string             `json:"generated_at"`
+		Telemetry   exporter.Telemetry `json:"telemetry"`
+		Cases       []cases.Case       `json:"cases"`
+	}{
+		GeneratedAt: dataset.RefreshedAt,
+		Telemetry:   dataset.Telemetry,
+		Cases:       dataset.Cases,
+	}
+	data, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return uiServerState{}, fmt.Errorf("encode cases json: %w", err)
+	}
+	data = append(data, '\n')
+	state.casesJSON = data
+
+	sarif, err := exporter.EncodeSARIF(dataset.Cases)
+	if err != nil {
+		return uiServerState{}, fmt.Errorf("encode sarif: %w", err)
+	}
+	state.sarif = sarif
+
+	return state, nil
+}
+
+func (s uiServerState) handleAPIDataset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(s.dataset)
+}
+
+func (s uiServerState) handleDownloadCasesJSON(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", "attachment; filename=cases.json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(s.casesJSON)
+}
+
+func (s uiServerState) handleDownloadSARIF(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/sarif+json")
+	w.Header().Set("Content-Disposition", "attachment; filename=cases.sarif")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(s.sarif)
+}
+
+func (s uiServerState) handleDownloadCaseAsset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	trimmed := strings.TrimPrefix(r.URL.Path, "/download/case/")
+	if trimmed == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch {
+	case strings.HasSuffix(trimmed, ".json"):
+		id, err := url.PathUnescape(strings.TrimSuffix(trimmed, ".json"))
+		if err != nil {
+			http.Error(w, "invalid case id", http.StatusBadRequest)
+			return
+		}
+		s.serveCaseJSON(w, r, id)
+	case strings.HasSuffix(trimmed, ".md"):
+		id, err := url.PathUnescape(strings.TrimSuffix(trimmed, ".md"))
+		if err != nil {
+			http.Error(w, "invalid case id", http.StatusBadRequest)
+			return
+		}
+		s.serveCaseMarkdown(w, r, id)
+	case strings.HasSuffix(trimmed, "/poc.txt"):
+		id, err := url.PathUnescape(strings.TrimSuffix(trimmed, "/poc.txt"))
+		if err != nil {
+			http.Error(w, "invalid case id", http.StatusBadRequest)
+			return
+		}
+		s.serveCasePOC(w, r, id)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s uiServerState) serveCaseJSON(w http.ResponseWriter, r *http.Request, id string) {
+	c, ok := s.caseIndex[id]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	data, err := cases.ExportJSON(c)
+	if err != nil {
+		http.Error(w, "encode case", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.json", sanitizeFilename(c.ID)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (s uiServerState) serveCaseMarkdown(w http.ResponseWriter, r *http.Request, id string) {
+	c, ok := s.caseIndex[id]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	payload := cases.ExportMarkdown(c)
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.md", sanitizeFilename(c.ID)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(payload))
+}
+
+func (s uiServerState) serveCasePOC(w http.ResponseWriter, r *http.Request, id string) {
+	c, ok := s.caseIndex[id]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	payload := formatPOC(c)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s-poc.txt", sanitizeFilename(c.ID)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(payload))
+}
+
+func formatPOC(c cases.Case) string {
+	var b strings.Builder
+	summary := strings.TrimSpace(c.Proof.Summary)
+	if summary != "" {
+		b.WriteString(summary)
+		b.WriteString("\n\n")
+	}
+	if len(c.Proof.Steps) == 0 {
+		b.WriteString("No proof of concept steps were provided.\n")
+		return b.String()
+	}
+	stepIndex := 1
+	for _, step := range c.Proof.Steps {
+		trimmed := strings.TrimSpace(step)
+		if trimmed == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "%d. %s\n", stepIndex, trimmed)
+		stepIndex++
+	}
+	if stepIndex == 1 {
+		b.WriteString("No proof of concept steps were provided.\n")
+	}
+	return b.String()
+}
+
+func sanitizeFilename(name string) string {
+	sanitized := make([]rune, 0, len(name))
+	lastHyphen := false
+	trimmed := strings.TrimSpace(name)
+	for _, r := range trimmed {
+		replace := r
+		switch r {
+		case '/', '\\', ':', '*', '?', '"', '<', '>', '|', '.':
+			replace = '-'
+		}
+		if replace == '-' {
+			if lastHyphen {
+				continue
+			}
+			sanitized = append(sanitized, replace)
+			lastHyphen = true
+			continue
+		}
+		sanitized = append(sanitized, replace)
+		lastHyphen = false
+	}
+	cleaned := strings.Trim(string(sanitized), "-")
+	if cleaned == "" {
+		return "case"
+	}
+	return cleaned
+}

--- a/cmd/glyphctl/serve_ui_test.go
+++ b/cmd/glyphctl/serve_ui_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RowanDark/Glyph/internal/cases"
+	"github.com/RowanDark/Glyph/internal/exporter"
+	"github.com/RowanDark/Glyph/internal/findings"
+)
+
+func TestLoadUIDataset(t *testing.T) {
+	path := filepath.Join("testdata", "findings.jsonl")
+	dataset, err := loadUIDataset(path)
+	if err != nil {
+		t.Fatalf("loadUIDataset: %v", err)
+	}
+	if dataset.FindingsCount == 0 {
+		t.Fatalf("expected findings to be loaded")
+	}
+	if len(dataset.Cases) == 0 {
+		t.Fatalf("expected cases to be built")
+	}
+	if dataset.RefreshedAt == "" {
+		t.Fatalf("expected refreshed timestamp to be populated")
+	}
+}
+
+func TestNewUIServerState(t *testing.T) {
+	dataset := uiDataset{
+		Cases: []cases.Case{{
+			ID:          "case-1",
+			Version:     cases.CaseSchemaVersion,
+			Asset:       cases.Asset{Kind: "service", Identifier: "api"},
+			Vector:      cases.AttackVector{Kind: "http"},
+			Summary:     "Example case",
+			Risk:        cases.Risk{Severity: findings.SeverityHigh, Score: 7.5},
+			GeneratedAt: findings.NewTimestamp(time.Date(2024, time.January, 1, 12, 0, 0, 0, time.UTC)),
+		}},
+		Telemetry:     exporter.Telemetry{CaseCount: 1, FindingCount: 1},
+		FindingsCount: 1,
+		RefreshedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+
+	state, err := newUIServerState(dataset)
+	if err != nil {
+		t.Fatalf("newUIServerState: %v", err)
+	}
+	if got, want := len(state.caseIndex), len(dataset.Cases); got != want {
+		t.Fatalf("unexpected index length: got %d want %d", got, want)
+	}
+	if len(state.casesJSON) == 0 {
+		t.Fatalf("expected cases JSON to be populated")
+	}
+	if len(state.sarif) == 0 {
+		t.Fatalf("expected sarif payload to be populated")
+	}
+}
+
+func TestFormatPOC(t *testing.T) {
+	c := cases.Case{Proof: cases.ProofOfConcept{Summary: "Steps", Steps: []string{" step one ", "", "step two"}}}
+	payload := formatPOC(c)
+	if !strings.Contains(payload, "Steps") {
+		t.Fatalf("expected summary to be included: %q", payload)
+	}
+	if strings.Count(payload, "step") < 2 {
+		t.Fatalf("expected steps to be numbered: %q", payload)
+	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	if got, want := sanitizeFilename("../case::01"), "case-01"; got != want {
+		t.Fatalf("sanitizeFilename: got %q want %q", got, want)
+	}
+	if got := sanitizeFilename("   "); got != "case" {
+		t.Fatalf("sanitizeFilename empty: got %q", got)
+	}
+}

--- a/cmd/glyphctl/ui_assets/app.js
+++ b/cmd/glyphctl/ui_assets/app.js
@@ -1,0 +1,762 @@
+const severityOrder = [
+  { id: "crit", label: "Critical" },
+  { id: "high", label: "High" },
+  { id: "med", label: "Medium" },
+  { id: "low", label: "Low" },
+  { id: "info", label: "Informational" },
+];
+
+const severityRank = severityOrder.reduce((acc, item, index) => {
+  acc[item.id] = index;
+  return acc;
+}, {});
+
+const state = {
+  allCases: [],
+  filteredCases: [],
+  telemetry: null,
+  findingsCount: 0,
+  refreshedAt: "",
+  searchQuery: "",
+  severities: new Set(severityOrder.map((item) => item.id)),
+};
+
+async function init() {
+  buildSeverityFilters();
+  bindControls();
+  try {
+    const data = await fetchDataset();
+    state.allCases = Array.isArray(data.cases) ? data.cases : [];
+    state.telemetry = data.telemetry || null;
+    state.findingsCount = typeof data.findings_count === "number" ? data.findings_count : 0;
+    state.refreshedAt = typeof data.refreshed_at === "string" ? data.refreshed_at : "";
+    hideError();
+  } catch (error) {
+    console.error("Failed to load dataset", error);
+    showError();
+    return;
+  }
+
+  applyFilters();
+}
+
+document.addEventListener("DOMContentLoaded", init);
+
+function bindControls() {
+  const searchInput = document.getElementById("searchInput");
+  if (searchInput) {
+    searchInput.addEventListener("input", (event) => {
+      state.searchQuery = event.target.value || "";
+      applyFilters();
+    });
+  }
+
+  const resetButton = document.getElementById("resetFilters");
+  if (resetButton) {
+    resetButton.addEventListener("click", () => {
+      state.searchQuery = "";
+      state.severities = new Set(severityOrder.map((item) => item.id));
+      updateSeverityChipState();
+      if (searchInput) {
+        searchInput.value = "";
+      }
+      applyFilters();
+    });
+  }
+}
+
+function buildSeverityFilters() {
+  const container = document.getElementById("severityFilters");
+  if (!container) {
+    return;
+  }
+  container.innerHTML = "";
+  severityOrder.forEach((item) => {
+    const label = document.createElement("label");
+    label.className = `severity-chip severity-${item.id}`;
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.value = item.id;
+    checkbox.checked = true;
+    checkbox.addEventListener("change", (event) => {
+      if (event.target.checked) {
+        state.severities.add(item.id);
+      } else {
+        state.severities.delete(item.id);
+      }
+      label.classList.toggle("inactive", !event.target.checked);
+      applyFilters();
+    });
+
+    const text = document.createElement("span");
+    text.textContent = item.label;
+
+    label.append(checkbox, text);
+    container.appendChild(label);
+  });
+}
+
+function updateSeverityChipState() {
+  const container = document.getElementById("severityFilters");
+  if (!container) {
+    return;
+  }
+  const chips = Array.from(container.querySelectorAll("label.severity-chip"));
+  chips.forEach((chip) => {
+    const checkbox = chip.querySelector("input[type='checkbox']");
+    if (!checkbox) {
+      return;
+    }
+    const value = checkbox.value;
+    const checked = state.severities.has(value);
+    checkbox.checked = checked;
+    chip.classList.toggle("inactive", !checked);
+  });
+}
+
+async function fetchDataset() {
+  const response = await fetch("/api/data", { headers: { "Accept": "application/json" } });
+  if (!response.ok) {
+    throw new Error(`unexpected status ${response.status}`);
+  }
+  return response.json();
+}
+
+function applyFilters() {
+  const query = state.searchQuery.trim().toLowerCase();
+  const severities = state.severities;
+
+  const filtered = state.allCases.filter((caze) => {
+    const severity = normaliseSeverity(caze?.risk?.severity);
+    if (!severities.has(severity)) {
+      return false;
+    }
+    if (!query) {
+      return true;
+    }
+    return buildSearchText(caze).includes(query);
+  });
+
+  filtered.sort(compareCases);
+  state.filteredCases = filtered;
+
+  renderStats();
+  renderCases();
+}
+
+function compareCases(a, b) {
+  const severityA = severityRank[normaliseSeverity(a?.risk?.severity)] ?? Number.MAX_SAFE_INTEGER;
+  const severityB = severityRank[normaliseSeverity(b?.risk?.severity)] ?? Number.MAX_SAFE_INTEGER;
+  if (severityA !== severityB) {
+    return severityA - severityB;
+  }
+  const timeA = parseTime(b?.generated_at) - parseTime(a?.generated_at);
+  if (timeA !== 0) {
+    return timeA;
+  }
+  return (a?.id || "").localeCompare(b?.id || "");
+}
+
+function parseTime(value) {
+  if (!value) {
+    return 0;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 0;
+  }
+  return parsed.getTime();
+}
+
+function renderStats() {
+  const caseCount = document.getElementById("caseCount");
+  const findingCount = document.getElementById("findingCount");
+  const updatedAt = document.getElementById("updatedAt");
+  const severityBreakdown = document.getElementById("severityBreakdown");
+
+  if (caseCount) {
+    const total = state.allCases.length;
+    const visible = state.filteredCases.length;
+    caseCount.textContent = total > 0 ? `${visible} / ${total}` : "0";
+  }
+  if (findingCount) {
+    findingCount.textContent = state.findingsCount.toString();
+  }
+  if (updatedAt) {
+    updatedAt.textContent = formatDate(state.refreshedAt);
+  }
+  if (severityBreakdown) {
+    severityBreakdown.innerHTML = "";
+    const counts = (state.telemetry && state.telemetry.severity_counts) || {};
+    severityOrder.forEach((item) => {
+      const pill = document.createElement("span");
+      pill.className = `severity-pill severity-${item.id}`;
+      const total = counts[item.id] ?? 0;
+      const visible = state.filteredCases.filter(
+        (caze) => normaliseSeverity(caze?.risk?.severity) === item.id,
+      ).length;
+      pill.textContent = `${item.label}: ${total}${visible !== total ? ` (showing ${visible})` : ""}`;
+      severityBreakdown.appendChild(pill);
+    });
+  }
+}
+
+function renderCases() {
+  const container = document.getElementById("caseList");
+  const emptyState = document.getElementById("emptyState");
+  if (!container) {
+    return;
+  }
+  container.innerHTML = "";
+  if (state.filteredCases.length === 0) {
+    if (emptyState) {
+      const heading = emptyState.querySelector("h2");
+      const description = emptyState.querySelector("p");
+      if (heading) {
+        heading.textContent = state.allCases.length === 0 ? "No cases available" : "No cases match your filters";
+      }
+      if (description) {
+        description.textContent =
+          state.allCases.length === 0
+            ? "Run a scan or export findings to generate Case data, then refresh this view."
+            : "Adjust the severity filters or search query to see more results.";
+      }
+      emptyState.classList.remove("hidden");
+    }
+    return;
+  }
+  if (emptyState) {
+    emptyState.classList.add("hidden");
+  }
+  state.filteredCases.forEach((caze) => {
+    const card = document.createElement("details");
+    card.className = "case-card";
+
+    const summary = document.createElement("summary");
+    summary.className = "case-summary";
+
+    const header = document.createElement("div");
+    header.className = "case-header";
+
+    const severityCode = normaliseSeverity(caze?.risk?.severity);
+    const badge = createSeverityBadge(severityCode);
+    header.appendChild(badge);
+
+    const title = document.createElement("span");
+    title.className = "case-title";
+    title.textContent = normaliseText(caze.summary) || "Untitled case";
+    header.appendChild(title);
+
+    summary.appendChild(header);
+
+    const meta = document.createElement("span");
+    meta.className = "case-meta";
+    const parts = [formatAssetShort(caze.asset), formatVector(caze.vector), caze.id];
+    meta.textContent = parts.filter(Boolean).join(" • ");
+    summary.appendChild(meta);
+
+    card.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "case-body";
+
+    const overview = buildOverviewSection(caze);
+    body.appendChild(overview);
+
+    const summarySection = buildSummarySection(caze.summary);
+    if (summarySection) {
+      body.appendChild(summarySection);
+    }
+
+    const proofSection = buildProofSection(caze.proof);
+    if (proofSection) {
+      body.appendChild(proofSection);
+    }
+
+    const evidenceSection = buildEvidenceSection(caze.evidence);
+    if (evidenceSection) {
+      body.appendChild(evidenceSection);
+    }
+
+    const sourcesSection = buildSourcesSection(caze.sources);
+    if (sourcesSection) {
+      body.appendChild(sourcesSection);
+    }
+
+    const graphSection = buildGraphSection(caze.graph);
+    if (graphSection) {
+      body.appendChild(graphSection);
+    }
+
+    const downloads = buildDownloadsSection(caze.id);
+    body.appendChild(downloads);
+
+    card.appendChild(body);
+    container.appendChild(card);
+  });
+}
+
+function buildOverviewSection(caze) {
+  const section = createSection("Overview");
+  const list = document.createElement("dl");
+  list.className = "case-details";
+
+  addDefinition(list, "Case ID", caze.id || "–");
+  addDefinition(list, "Asset", formatAsset(caze.asset));
+  addDefinition(list, "Attack vector", formatVector(caze.vector) || "–");
+
+  const riskScore = typeof caze?.risk?.score === "number" ? caze.risk.score.toFixed(1) : "–";
+  addDefinition(list, "Risk score", riskScore);
+
+  const confidence = typeof caze?.confidence === "number" ? caze.confidence.toFixed(2) : "–";
+  addDefinition(list, "Confidence", confidence);
+
+  addDefinition(list, "Generated", formatDate(caze?.generated_at));
+
+  if (caze?.confidence_log) {
+    addDefinition(list, "Confidence log", caze.confidence_log);
+  }
+
+  const labels = normaliseLabels(caze.labels);
+  if (labels.length > 0) {
+    const container = document.createElement("div");
+    container.className = "metadata-list";
+    labels.forEach((label) => {
+      const item = document.createElement("span");
+      item.className = "metadata-item";
+      item.textContent = label;
+      container.appendChild(item);
+    });
+    addDefinition(list, "Labels", container);
+  }
+
+  section.appendChild(list);
+  return section;
+}
+
+function buildSummarySection(summaryText) {
+  const normalised = normaliseText(summaryText);
+  if (!normalised) {
+    return null;
+  }
+  const section = createSection("Summary");
+  section.appendChild(buildParagraphs(normalised));
+  return section;
+}
+
+function buildProofSection(proof) {
+  if (!proof || (!normaliseText(proof.summary) && !Array.isArray(proof.steps))) {
+    return null;
+  }
+  const section = createSection("Proof of concept");
+  if (normaliseText(proof.summary)) {
+    section.appendChild(buildParagraphs(proof.summary));
+  }
+  if (Array.isArray(proof.steps) && proof.steps.length > 0) {
+    const list = document.createElement("ol");
+    list.className = "proof-steps";
+    proof.steps
+      .map((step) => normaliseText(step))
+      .filter(Boolean)
+      .forEach((step) => {
+        const item = document.createElement("li");
+        item.textContent = step;
+        list.appendChild(item);
+      });
+    if (list.childNodes.length > 0) {
+      section.appendChild(list);
+    }
+  }
+  if (section.childNodes.length === 0) {
+    const para = document.createElement("p");
+    para.textContent = "No proof of concept steps were provided.";
+    section.appendChild(para);
+  }
+  return section;
+}
+
+function buildEvidenceSection(evidence) {
+  if (!Array.isArray(evidence) || evidence.length === 0) {
+    return null;
+  }
+  const section = createSection("Evidence");
+  const grid = document.createElement("div");
+  grid.className = "evidence-grid";
+
+  evidence.forEach((item, index) => {
+    const card = document.createElement("article");
+    card.className = "evidence-card";
+
+    const header = document.createElement("header");
+    const title = document.createElement("strong");
+    const plugin = normaliseText(item?.plugin) || "Unknown plugin";
+    const type = normaliseText(item?.type) || "evidence";
+    title.textContent = `${plugin} • ${type}`;
+    header.appendChild(title);
+
+    const counter = document.createElement("span");
+    counter.className = "case-meta";
+    counter.textContent = `#${index + 1}`;
+    header.appendChild(counter);
+
+    card.appendChild(header);
+
+    if (normaliseText(item?.message)) {
+      const message = document.createElement("p");
+      message.textContent = item.message.trim();
+      card.appendChild(message);
+    }
+
+    if (normaliseText(item?.evidence)) {
+      const blob = document.createElement("pre");
+      blob.className = "graph-code";
+      blob.textContent = item.evidence.trim();
+      card.appendChild(blob);
+    }
+
+    const metadataEntries = normaliseMetadata(item?.metadata);
+    if (metadataEntries.length > 0) {
+      const metaContainer = document.createElement("div");
+      metaContainer.className = "metadata-list";
+      metadataEntries.forEach((entry) => {
+        const pill = document.createElement("span");
+        pill.className = "metadata-item";
+        pill.textContent = `${entry.key}: ${entry.value}`;
+        metaContainer.appendChild(pill);
+      });
+      card.appendChild(metaContainer);
+    }
+
+    grid.appendChild(card);
+  });
+
+  section.appendChild(grid);
+  return section;
+}
+
+function buildSourcesSection(sources) {
+  if (!Array.isArray(sources) || sources.length === 0) {
+    return null;
+  }
+  const section = createSection("Source findings");
+  const list = document.createElement("ul");
+  list.className = "sources-list";
+
+  sources.forEach((source) => {
+    const item = document.createElement("li");
+    const line = [];
+    if (source?.plugin) {
+      line.push(source.plugin);
+    }
+    if (source?.type) {
+      line.push(source.type);
+    }
+    if (source?.target) {
+      line.push(source.target);
+    }
+    if (source?.id) {
+      line.push(`ID: ${source.id}`);
+    }
+    const text = line.filter(Boolean).join(" • ");
+    item.textContent = text || "Source";
+
+    const severityCode = normaliseSeverity(source?.severity);
+    const badge = createSeverityBadge(severityCode);
+    item.prepend(badge);
+
+    list.appendChild(item);
+  });
+
+  section.appendChild(list);
+  return section;
+}
+
+function buildGraphSection(graph) {
+  if (!graph) {
+    return null;
+  }
+  const section = createSection("Attack path");
+  if (normaliseText(graph.summary)) {
+    section.appendChild(buildParagraphs(graph.summary));
+  }
+
+  if (Array.isArray(graph.attack_path) && graph.attack_path.length > 0) {
+    const chain = document.createElement("ol");
+    chain.className = "chain-list";
+    graph.attack_path.forEach((step) => {
+      const item = document.createElement("li");
+      item.className = "chain-step";
+
+      const stage = document.createElement("div");
+      stage.className = "stage";
+      const stageLabel = typeof step?.stage === "number" ? `Stage ${step.stage}` : "Stage";
+      stage.textContent = stageLabel;
+      item.appendChild(stage);
+
+      if (normaliseText(step?.description)) {
+        const description = document.createElement("div");
+        description.textContent = step.description.trim();
+        item.appendChild(description);
+      }
+
+      const flow = document.createElement("div");
+      flow.className = "flow";
+      const from = normaliseText(step?.from) || "origin";
+      const to = normaliseText(step?.to) || "target";
+      flow.textContent = `${from} → ${to}`;
+      item.appendChild(flow);
+
+      const meta = document.createElement("div");
+      meta.className = "case-meta";
+      const parts = [];
+      if (step?.plugin) {
+        parts.push(step.plugin);
+      }
+      if (step?.type) {
+        parts.push(step.type);
+      }
+      if (step?.finding_id) {
+        parts.push(`Finding ${step.finding_id}`);
+      }
+      meta.textContent = parts.join(" • ");
+      const badge = createSeverityBadge(normaliseSeverity(step?.severity));
+      meta.appendChild(badge);
+      item.appendChild(meta);
+
+      if (step?.weak_link) {
+        const weak = document.createElement("div");
+        weak.className = "case-meta";
+        weak.textContent = "Weak link";
+        item.appendChild(weak);
+      }
+
+      chain.appendChild(item);
+    });
+    section.appendChild(chain);
+  }
+
+  if (normaliseText(graph.mermaid)) {
+    const raw = document.createElement("details");
+    const summary = document.createElement("summary");
+    summary.textContent = "View Mermaid definition";
+    raw.appendChild(summary);
+    const pre = document.createElement("pre");
+    pre.className = "graph-code";
+    pre.textContent = graph.mermaid.trim();
+    raw.appendChild(pre);
+    section.appendChild(raw);
+  }
+
+  return section.childNodes.length === 0 ? null : section;
+}
+
+function buildDownloadsSection(caseID) {
+  const section = createSection("Downloads");
+  const container = document.createElement("div");
+  container.className = "case-downloads";
+
+  const jsonLink = createDownloadLink(`/download/case/${encodeURIComponent(caseID)}.json`, "Case JSON");
+  const markdownLink = createDownloadLink(`/download/case/${encodeURIComponent(caseID)}.md`, "Case Markdown");
+  const pocLink = createDownloadLink(`/download/case/${encodeURIComponent(caseID)}/poc.txt`, "POC steps");
+
+  container.append(jsonLink, markdownLink, pocLink);
+  section.appendChild(container);
+  return section;
+}
+
+function createDownloadLink(href, label) {
+  const link = document.createElement("a");
+  link.href = href;
+  link.textContent = label;
+  link.setAttribute("download", "");
+  return link;
+}
+
+function createSection(title) {
+  const section = document.createElement("section");
+  section.className = "case-section";
+  const heading = document.createElement("h3");
+  heading.textContent = title;
+  section.appendChild(heading);
+  return section;
+}
+
+function addDefinition(list, label, value) {
+  const dt = document.createElement("dt");
+  dt.textContent = label;
+  const dd = document.createElement("dd");
+  if (value instanceof Node) {
+    dd.appendChild(value);
+  } else {
+    dd.textContent = value || "–";
+  }
+  list.append(dt, dd);
+}
+
+function buildParagraphs(text) {
+  const fragment = document.createDocumentFragment();
+  text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      const p = document.createElement("p");
+      p.textContent = line;
+      fragment.appendChild(p);
+    });
+  if (!fragment.childNodes.length) {
+    const p = document.createElement("p");
+    p.textContent = text;
+    fragment.appendChild(p);
+  }
+  return fragment;
+}
+
+function normaliseMetadata(metadata) {
+  if (!metadata || typeof metadata !== "object") {
+    return [];
+  }
+  return Object.keys(metadata)
+    .filter((key) => normaliseText(metadata[key]))
+    .sort()
+    .map((key) => ({ key, value: metadata[key] }));
+}
+
+function normaliseLabels(labels) {
+  if (!labels || typeof labels !== "object") {
+    return [];
+  }
+  return Object.keys(labels)
+    .sort()
+    .map((key) => `${key}: ${labels[key]}`);
+}
+
+function normaliseText(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim();
+}
+
+function normaliseSeverity(value) {
+  if (typeof value !== "string") {
+    return "info";
+  }
+  const lower = value.toLowerCase();
+  return severityOrder.some((item) => item.id === lower) ? lower : "info";
+}
+
+function createSeverityBadge(code) {
+  const badge = document.createElement("span");
+  badge.className = `severity-badge severity-${code}`;
+  badge.textContent = severityOrder.find((item) => item.id === code)?.label || code;
+  return badge;
+}
+
+function formatAsset(asset) {
+  if (!asset) {
+    return "Unknown";
+  }
+  const identifier = normaliseText(asset.identifier);
+  const kind = normaliseText(asset.kind);
+  if (identifier && kind) {
+    return `${identifier} (${kind})`;
+  }
+  return identifier || kind || "Unknown";
+}
+
+function formatAssetShort(asset) {
+  if (!asset) {
+    return "";
+  }
+  const identifier = normaliseText(asset.identifier);
+  if (identifier) {
+    return identifier;
+  }
+  return normaliseText(asset.kind);
+}
+
+function formatVector(vector) {
+  if (!vector) {
+    return "";
+  }
+  const kind = normaliseText(vector.kind);
+  const value = normaliseText(vector.value);
+  if (kind && value) {
+    return `${kind} (${value})`;
+  }
+  return kind || value || "";
+}
+
+function formatDate(value) {
+  if (!value) {
+    return "–";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function buildSearchText(caze) {
+  const bits = [];
+  bits.push(caze?.id);
+  bits.push(caze?.summary);
+  bits.push(caze?.proof?.summary);
+  bits.push(caze?.graph?.summary);
+  bits.push(caze?.asset?.identifier);
+  bits.push(caze?.asset?.kind);
+  bits.push(caze?.vector?.kind);
+  bits.push(caze?.vector?.value);
+  if (Array.isArray(caze?.evidence)) {
+    caze.evidence.forEach((item) => {
+      bits.push(item?.plugin);
+      bits.push(item?.type);
+      bits.push(item?.message);
+      bits.push(item?.evidence);
+    });
+  }
+  if (Array.isArray(caze?.sources)) {
+    caze.sources.forEach((source) => {
+      bits.push(source?.plugin);
+      bits.push(source?.type);
+      bits.push(source?.target);
+      bits.push(source?.id);
+    });
+  }
+  return bits
+    .filter((value) => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+}
+
+function showError() {
+  const banner = document.getElementById("errorBanner");
+  const stats = document.getElementById("statsPanel");
+  const caseList = document.getElementById("caseList");
+  if (banner) {
+    banner.classList.remove("hidden");
+  }
+  if (stats) {
+    stats.classList.add("hidden");
+  }
+  if (caseList) {
+    caseList.innerHTML = "";
+  }
+}
+
+function hideError() {
+  const banner = document.getElementById("errorBanner");
+  const stats = document.getElementById("statsPanel");
+  if (banner) {
+    banner.classList.add("hidden");
+  }
+  if (stats) {
+    stats.classList.remove("hidden");
+  }
+}

--- a/cmd/glyphctl/ui_assets/index.html
+++ b/cmd/glyphctl/ui_assets/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Glyph Case Explorer</title>
+  <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+  <header class="top-bar">
+    <div>
+      <h1>Glyph Case Explorer</h1>
+      <p class="subtitle">Browse correlated findings, review evidence, and download artefacts directly from glyphctl.</p>
+    </div>
+    <nav class="downloads" aria-label="Global downloads">
+      <a class="download-button" href="/download/cases.json">All cases (JSON)</a>
+      <a class="download-button" href="/download/cases.sarif">All cases (SARIF)</a>
+    </nav>
+  </header>
+  <main>
+    <section class="controls" aria-label="Filters">
+      <div class="control-group search-group">
+        <label for="searchInput">Search</label>
+        <input type="search" id="searchInput" placeholder="Search cases, assets, vectors, evidence…" autocomplete="off" />
+      </div>
+      <div class="control-group">
+        <span class="control-label">Severity</span>
+        <div id="severityFilters" class="severity-filter" role="group" aria-label="Filter by risk severity"></div>
+      </div>
+      <div class="control-group compact">
+        <button type="button" id="resetFilters" class="ghost-button">Reset filters</button>
+      </div>
+    </section>
+
+    <section id="errorBanner" class="banner banner-error hidden" role="alert">
+      <h2>Unable to load scan data</h2>
+      <p>Check that the findings file exists and try launching <code>glyphctl serve ui</code> again.</p>
+    </section>
+
+    <section class="stats" id="statsPanel" aria-label="Summary">
+      <article class="stat">
+        <span class="label">Cases</span>
+        <span class="value" id="caseCount">0</span>
+      </article>
+      <article class="stat">
+        <span class="label">Findings</span>
+        <span class="value" id="findingCount">0</span>
+      </article>
+      <article class="stat">
+        <span class="label">Last updated</span>
+        <span class="value" id="updatedAt">–</span>
+      </article>
+      <article class="stat full-width">
+        <span class="label">Severity breakdown</span>
+        <div class="severity-breakdown" id="severityBreakdown" aria-live="polite"></div>
+      </article>
+    </section>
+
+    <section id="caseList" class="case-list" aria-live="polite"></section>
+
+    <section id="emptyState" class="empty-state hidden" aria-live="polite">
+      <h2>No cases match your filters</h2>
+      <p>Adjust the severity filters or search query to see more results.</p>
+    </section>
+  </main>
+  <footer class="footer">
+    <p>Glyph UI preview &mdash; synchronised with glyphctl findings.</p>
+  </footer>
+  <script type="module" src="/static/app.js"></script>
+</body>
+</html>

--- a/cmd/glyphctl/ui_assets/style.css
+++ b/cmd/glyphctl/ui_assets/style.css
@@ -1,0 +1,560 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.5;
+  --bg: #0f172a;
+  --panel: rgba(15, 23, 42, 0.65);
+  --panel-border: rgba(148, 163, 184, 0.25);
+  --panel-light: rgba(248, 250, 252, 0.85);
+  --text: #0f172a;
+  --text-muted: #475569;
+  --accent: #38bdf8;
+  --border-radius: 16px;
+  --shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #020617;
+    --panel: rgba(15, 23, 42, 0.85);
+    --panel-light: rgba(15, 23, 42, 0.95);
+    --text: #e2e8f0;
+    --text-muted: #94a3b8;
+    --panel-border: rgba(148, 163, 184, 0.2);
+    --shadow: 0 24px 48px rgba(2, 6, 23, 0.45);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.18), transparent 55%),
+    radial-gradient(circle at 20% 80%, rgba(244, 114, 182, 0.15), transparent 50%),
+    var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  width: min(1150px, 100%);
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+  flex: 1;
+}
+
+.top-bar {
+  width: min(1150px, 100%);
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.top-bar h1 {
+  margin: 0;
+  font-size: clamp(2rem, 2.5vw + 1.2rem, 2.8rem);
+  font-weight: 700;
+}
+
+.subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  max-width: 40rem;
+}
+
+.downloads {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.download-button {
+  background: rgba(56, 189, 248, 0.15);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: var(--text);
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  backdrop-filter: blur(10px);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.download-button:hover,
+.download-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(56, 189, 248, 0.25);
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
+  background: var(--panel);
+  backdrop-filter: blur(12px);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--shadow);
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--text-muted);
+}
+
+.search-group input[type="search"] {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text);
+}
+
+.search-group input[type="search"]:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.55);
+  outline-offset: 2px;
+}
+
+.control-label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ghost-button {
+  align-self: flex-start;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.banner {
+  margin-bottom: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(248, 113, 113, 0.12);
+  color: var(--text);
+  box-shadow: var(--shadow);
+}
+
+.banner h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.banner p {
+  margin: 0.45rem 0 0;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 1.75rem;
+}
+
+.stat {
+  background: var(--panel-light);
+  border-radius: var(--border-radius);
+  padding: 1.25rem;
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.stat.full-width {
+  grid-column: 1 / -1;
+}
+
+.stat .label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.stat .value {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.severity-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.severity-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text);
+}
+
+.case-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.case-card {
+  background: var(--panel-light);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--panel-border);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.case-card[open] {
+  border-color: rgba(56, 189, 248, 0.35);
+}
+
+.case-card summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 1.2rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.case-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.case-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.case-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.case-meta {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.case-body {
+  padding: 0 1.4rem 1.4rem;
+  display: grid;
+  gap: 1.4rem;
+}
+
+.case-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.case-section h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.case-details {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.case-details dt {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.case-details dd {
+  margin: 0.2rem 0 0;
+  word-break: break-word;
+}
+
+.case-downloads {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.case-downloads a {
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  text-decoration: none;
+  color: var(--text);
+  font-size: 0.9rem;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.case-downloads a:hover,
+.case-downloads a:focus-visible {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.evidence-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.evidence-card {
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.evidence-card header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.evidence-card strong {
+  font-size: 0.95rem;
+}
+
+.evidence-card p {
+  margin: 0.4rem 0 0;
+}
+
+.metadata-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.6rem 0 0;
+}
+
+.metadata-item {
+  background: rgba(56, 189, 248, 0.15);
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.8rem;
+}
+
+.chain-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.chain-step {
+  border-left: 3px solid rgba(56, 189, 248, 0.4);
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.chain-step .stage {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.chain-step .flow {
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.graph-code {
+  margin: 0;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  overflow-x: auto;
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
+  font-size: 0.85rem;
+}
+
+.sources-list,
+.proof-steps {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.sources-list li,
+.proof-steps li {
+  margin: 0.35rem 0;
+}
+
+.severity-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.severity-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.severity-chip input {
+  accent-color: currentColor;
+}
+
+.severity-chip input {
+  pointer-events: none;
+}
+
+.severity-chip.inactive {
+  opacity: 0.45;
+}
+
+.severity-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.empty-state {
+  margin-top: 2rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.footer {
+  width: min(1150px, 100%);
+  margin: auto;
+  padding: 1.5rem;
+  color: var(--text-muted);
+}
+
+.severity-crit {
+  background: rgba(239, 68, 68, 0.18);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: #dc2626;
+}
+
+.severity-high {
+  background: rgba(249, 115, 22, 0.18);
+  border-color: rgba(249, 115, 22, 0.35);
+  color: #ea580c;
+}
+
+.severity-med {
+  background: rgba(234, 179, 8, 0.18);
+  border-color: rgba(234, 179, 8, 0.35);
+  color: #ca8a04;
+}
+
+.severity-low {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: #16a34a;
+}
+
+.severity-info {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.35);
+  color: #2563eb;
+}
+
+.severity-pill.severity-crit,
+.severity-chip.severity-crit,
+.severity-badge.severity-crit {
+  background: rgba(239, 68, 68, 0.18);
+  color: #dc2626;
+}
+
+.severity-pill.severity-high,
+.severity-chip.severity-high,
+.severity-badge.severity-high {
+  background: rgba(249, 115, 22, 0.18);
+  color: #ea580c;
+}
+
+.severity-pill.severity-med,
+.severity-chip.severity-med,
+.severity-badge.severity-med {
+  background: rgba(234, 179, 8, 0.18);
+  color: #ca8a04;
+}
+
+.severity-pill.severity-low,
+.severity-chip.severity-low,
+.severity-badge.severity-low {
+  background: rgba(34, 197, 94, 0.18);
+  color: #16a34a;
+}
+
+.severity-pill.severity-info,
+.severity-chip.severity-info,
+.severity-badge.severity-info {
+  background: rgba(59, 130, 246, 0.18);
+  color: #2563eb;
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .downloads {
+    justify-content: flex-start;
+  }
+
+  .case-body {
+    padding: 0 1rem 1.2rem;
+  }
+
+  .controls {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a `glyphctl serve ui` subcommand that hosts an embedded case explorer with JSON, SARIF, and per-case downloads
- build a lightweight browser UI with filtering, search, chain visualisation, and evidence detail panels
- cover dataset loading helpers with unit tests and document how to launch the UI from the quickstart

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e64071fff8832a992e32e70cc4259f