### PR TITLE
Handle localStorage write failures in theme provider

### DIFF
--- a/apps/desktop-shell/src/providers/theme-provider.tsx
+++ b/apps/desktop-shell/src/providers/theme-provider.tsx
@@ -170,7 +170,11 @@ export function ThemeProvider({ children, projectId: projectIdProp }: ThemeProvi
     if (!storage) {
       return;
     }
-    storage.setItem(contrastStorageKey(projectId), highContrast ? '1' : '0');
+    try {
+      storage.setItem(contrastStorageKey(projectId), highContrast ? '1' : '0');
+    } catch (error) {
+      // Swallow persistence errors to avoid crashing the shell when storage is unavailable.
+    }
   }, [highContrast, storage, projectId]);
 
   useEffect(() => {
@@ -178,7 +182,11 @@ export function ThemeProvider({ children, projectId: projectIdProp }: ThemeProvi
       return;
     }
     if (userHasLockedTheme) {
-      storage.setItem(themeStorageKey(projectId), theme);
+      try {
+        storage.setItem(themeStorageKey(projectId), theme);
+      } catch (error) {
+        // Swallow persistence errors to avoid crashing the shell when storage is unavailable.
+      }
     }
   }, [theme, storage, projectId, userHasLockedTheme]);
 


### PR DESCRIPTION
## Summary
- guard theme and contrast persistence writes so storage failures do not crash the shell

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6749550b4832a9bfcfa1b2f24ed50